### PR TITLE
Add basic circleci config for CI builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ jobs:
       - checkout
       - run:
           name: Build the project
-          command: mkdir -p build && cd build && cmake .. && make
+          command: mkdir -p build && cd build && cmake .. && make -j$(NPROC)
       - run:
           name: Run tests
           working_directory: build


### PR DESCRIPTION
Build the project with CircleCI on Fedora 32. Also run tests and build docs to make sure everything is documented.