### PR TITLE
Implement Alternating Timed Automata

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,8 @@ jobs:
               cmake \
               doxygen \
               gcc-c++ \
-              make
+              make \
+              range-v3-devel
       - checkout
       - run:
           name: Build the project

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
       - checkout
       - run:
           name: Build the project
-          command: mkdir -p build && cd build && cmake .. && make -j$(NPROC)
+          command: mkdir -p build && cd build && cmake .. && make -j$(nproc)
       - run:
           name: Run tests
           working_directory: build

--- a/src/libta/CMakeLists.txt
+++ b/src/libta/CMakeLists.txt
@@ -1,2 +1,2 @@
-add_library(libta SHARED ta.cpp automata.cpp)
+add_library(libta SHARED ta.cpp automata.cpp ata_formula.cpp)
 target_include_directories(libta PUBLIC include)

--- a/src/libta/CMakeLists.txt
+++ b/src/libta/CMakeLists.txt
@@ -1,4 +1,4 @@
 find_package(range-v3 REQUIRED)
-add_library(libta SHARED ta.cpp automata.cpp ata_formula.cpp)
+add_library(libta SHARED ta.cpp automata.cpp ata_formula.cpp ata.cpp)
 target_link_libraries(libta PRIVATE range-v3::range-v3)
 target_include_directories(libta PUBLIC include)

--- a/src/libta/CMakeLists.txt
+++ b/src/libta/CMakeLists.txt
@@ -1,2 +1,4 @@
+find_package(range-v3 REQUIRED)
 add_library(libta SHARED ta.cpp automata.cpp ata_formula.cpp)
+target_link_libraries(libta PRIVATE range-v3::range-v3)
 target_include_directories(libta PUBLIC include)

--- a/src/libta/ata.cpp
+++ b/src/libta/ata.cpp
@@ -1,0 +1,157 @@
+/***************************************************************************
+ *  ata.cpp - Alternating Timed Automata
+ *
+ *  Created: Fri 05 Jun 2020 11:54:51 CEST 11:54
+ *  Copyright  2020  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ ****************************************************************************/
+
+/*  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Library General Public License for more details.
+ *
+ *  Read the full text in the LICENSE.GPL file in the doc directory.
+ */
+
+#include <libta/ata.h>
+
+#include <cassert>
+#include <iterator>
+#include <range/v3/algorithm/for_each.hpp>
+#include <range/v3/view/cartesian_product.hpp>
+#include <variant>
+
+namespace automata::ata {
+
+Transition::Transition(const Location &         source,
+                       const Symbol &           symbol,
+                       std::unique_ptr<Formula> formula)
+: source_(source), symbol_(symbol), formula_(std::move(formula))
+{
+}
+
+AlternatingTimedAutomaton::AlternatingTimedAutomaton(const std::set<Symbol> &  alphabet,
+                                                     const Location &          initial_location,
+                                                     const std::set<Location> &final_locations,
+                                                     std::set<Transition>      transitions)
+: alphabet_(alphabet),
+  initial_location_(initial_location),
+  final_locations_(final_locations),
+  transitions_(std::move(transitions))
+{
+}
+std::vector<Run>
+AlternatingTimedAutomaton::make_symbol_transition(const std::vector<Run> &runs,
+                                                  const Symbol &          symbol) const
+{
+	std::vector<Run> res;
+	for (const auto &run : runs) {
+		if (!run.empty() && std::holds_alternative<Symbol>(run.back().first)) {
+			throw WrongTransitionTypeException(
+			  "Cannot do two subsequent symbol transitions, transitions must be "
+			  "alternating between symbol and time");
+		}
+		std::set<State> start_states;
+		if (run.empty()) {
+			start_states = {State(initial_location_, 0)};
+		} else {
+			start_states = run.back().second;
+		}
+		// A vector of a set of target configurations that are reached when following a transition
+		// One entry for each start state
+		std::vector<std::set<Configuration>> models;
+		for (const auto &state : start_states) {
+			auto t = std::find_if(transitions_.cbegin(), transitions_.cend(), [&](const auto &t) {
+				return t.source_ == state.first && t.symbol_ == symbol;
+			});
+			if (t == transitions_.end()) {
+				continue;
+			}
+			const auto new_states = get_minimal_models(t->formula_.get(), state.second);
+			models.push_back(new_states);
+		}
+		assert(!models.empty());
+		if (models.empty()) {
+			return {};
+		}
+		// The resulting configurations after computing the cartesian product of all target
+		// configurations of each state
+		std::set<Configuration> configurations;
+		// Populate the configurations by splitting the first configuration in all minimal models
+		// { { m1, m2, m3 } } -> { { m1 }, { m2 }, { m3 } }
+		ranges::for_each(models[0],
+		                 [&](const auto &state_model) { configurations.insert({state_model}); });
+		// Add models from the other configurations
+		std::for_each(std::next(models.begin()), models.end(), [&](const auto &state_models) {
+			std::set<Configuration> expanded_configurations;
+			ranges::for_each(state_models, [&](const auto &state_model) {
+				ranges::for_each(configurations, [&](const auto &configuration) {
+					auto expanded_configuration = configuration;
+					expanded_configuration.insert(state_model.begin(), state_model.end());
+					expanded_configurations.insert(expanded_configuration);
+				});
+			});
+			configurations = expanded_configurations;
+		});
+		ranges::for_each(configurations, [&](const auto &c) {
+			auto expanded_run = run;
+			expanded_run.push_back(std::make_pair(std::variant<Symbol, Time>(symbol), c));
+			res.push_back(expanded_run);
+		});
+	}
+	return res;
+}
+
+std::vector<Run>
+AlternatingTimedAutomaton::make_time_transition(const std::vector<Run> &runs,
+                                                const Time &            time) const
+{
+	if (time < 0) {
+		throw NegativeTimeDeltaException(time);
+	}
+	std::vector<Run> res;
+	for (auto run : runs) {
+		if (run.empty()) {
+			throw WrongTransitionTypeException(
+			  "Cannot do a time transition on empty run, a run must start with a symbol transition");
+		}
+		if (std::holds_alternative<Time>(run.back().first)) {
+			throw WrongTransitionTypeException(
+			  "Cannot do two subsequent time transitions, transitions must be "
+			  "alternating between symbol and time");
+		}
+		std::set<State> res_states;
+		std::transform(run.back().second.cbegin(),
+		               run.back().second.cend(),
+		               std::inserter(res_states, res_states.begin()),
+		               [&time](const auto &s) { return State(s.first, s.second + time); });
+		run.push_back(std::make_pair(time, res_states));
+		res.push_back(run);
+	}
+	return res;
+}
+
+std::set<std::set<State>>
+AlternatingTimedAutomaton::get_minimal_models(Formula *formula, ClockValuation v) const
+{
+	return formula->get_minimal_models(v);
+}
+
+bool
+operator<(const Transition &first, const Transition &second)
+{
+	if (first.source_ != second.source_) {
+		return first.source_ < second.source_;
+	} else if (first.symbol_ != second.symbol_) {
+		return first.symbol_ < second.symbol_;
+	} else {
+		return first.formula_ < second.formula_;
+	}
+}
+
+} // namespace automata::ata

--- a/src/libta/ata_formula.cpp
+++ b/src/libta/ata_formula.cpp
@@ -57,30 +57,29 @@ ClockConstraintFormula::is_satisfied(const std::set<State> &, const ClockValuati
 	return automata::is_satisfied(constraint_, v);
 }
 
-ConjunctionFormula::ConjunctionFormula(std::vector<std::unique_ptr<Formula>> conjuncts)
-: conjuncts_(std::move(conjuncts))
+ConjunctionFormula::ConjunctionFormula(std::unique_ptr<Formula> conjunct1,
+                                       std::unique_ptr<Formula> conjunct2)
+: conjunct1_(std::move(conjunct1)), conjunct2_(std::move(conjunct2))
 {
 }
 
 bool
 ConjunctionFormula::is_satisfied(const std::set<State> &states, const ClockValuation &v) const
 {
-	return std::all_of(std::begin(conjuncts_), std::end(conjuncts_), [&](const auto &c) {
-		return c->is_satisfied(states, v);
-	});
+	return conjunct1_->is_satisfied(states, v) && conjunct2_->is_satisfied(states, v);
+
 }
 
-DisjunctionFormula::DisjunctionFormula(std::vector<std::unique_ptr<Formula>> disjuncts)
-: disjuncts_(std::move(disjuncts))
+DisjunctionFormula::DisjunctionFormula(std::unique_ptr<Formula> disjunct1,
+                                       std::unique_ptr<Formula> disjunct2)
+: disjunct1_(std::move(disjunct1)), disjunct2_(std::move(disjunct2))
 {
 }
 
 bool
 DisjunctionFormula::is_satisfied(const std::set<State> &states, const ClockValuation &v) const
 {
-	return std::any_of(std::begin(disjuncts_), std::end(disjuncts_), [&](const auto &c) {
-		return c->is_satisfied(states, v);
-	});
+	return disjunct1_->is_satisfied(states, v) || disjunct2_->is_satisfied(states, v);
 }
 
 ResetClockFormula::ResetClockFormula(std::unique_ptr<Formula> sub_formula)

--- a/src/libta/ata_formula.cpp
+++ b/src/libta/ata_formula.cpp
@@ -21,6 +21,9 @@
 #include <libta/ata_formula.h>
 #include <libta/automata.h>
 
+#include <range/v3/algorithm.hpp>
+#include <range/v3/view.hpp>
+
 namespace automata {
 namespace ata {
 
@@ -30,10 +33,22 @@ TrueFormula::is_satisfied(const std::set<State> &, const ClockValuation &) const
 	return true;
 }
 
+std::set<std::set<State>>
+TrueFormula::get_minimal_models(const ClockValuation &) const
+{
+	return {{}};
+}
+
 bool
 FalseFormula::is_satisfied(const std::set<State> &, const ClockValuation &) const
 {
 	return false;
+}
+
+std::set<std::set<State>>
+FalseFormula::get_minimal_models(const ClockValuation &) const
+{
+	return {};
 }
 
 LocationFormula::LocationFormula(const Location &location) : location_(location)
@@ -44,6 +59,12 @@ bool
 LocationFormula::is_satisfied(const std::set<State> &states, const ClockValuation &v) const
 {
 	return states.count(std::make_pair(location_, v));
+}
+
+std::set<std::set<State>>
+LocationFormula::get_minimal_models(const ClockValuation &v) const
+{
+	return {{State(location_, v)}};
 }
 
 ClockConstraintFormula::ClockConstraintFormula(const ClockConstraint &constraint)
@@ -57,6 +78,16 @@ ClockConstraintFormula::is_satisfied(const std::set<State> &, const ClockValuati
 	return automata::is_satisfied(constraint_, v);
 }
 
+std::set<std::set<State>>
+ClockConstraintFormula::get_minimal_models(const ClockValuation &v) const
+{
+	if (automata::is_satisfied(constraint_, v)) {
+		return {{}};
+	} else {
+		return {};
+	}
+}
+
 ConjunctionFormula::ConjunctionFormula(std::unique_ptr<Formula> conjunct1,
                                        std::unique_ptr<Formula> conjunct2)
 : conjunct1_(std::move(conjunct1)), conjunct2_(std::move(conjunct2))
@@ -67,7 +98,21 @@ bool
 ConjunctionFormula::is_satisfied(const std::set<State> &states, const ClockValuation &v) const
 {
 	return conjunct1_->is_satisfied(states, v) && conjunct2_->is_satisfied(states, v);
+}
 
+std::set<std::set<State>>
+ConjunctionFormula::get_minimal_models(const ClockValuation &v) const
+{
+	auto                      s1        = conjunct1_->get_minimal_models(v);
+	auto                      s2        = conjunct2_->get_minimal_models(v);
+	auto                      cartesian = ranges::views::cartesian_product(s1, s2);
+	std::set<std::set<State>> res;
+	ranges::for_each(cartesian, [&](const auto &prod) {
+		std::set<State> u = std::get<0>(prod);
+		u.insert(std::get<1>(prod).begin(), std::get<1>(prod).end());
+		res.insert(u);
+	});
+	return res;
 }
 
 DisjunctionFormula::DisjunctionFormula(std::unique_ptr<Formula> disjunct1,
@@ -82,6 +127,15 @@ DisjunctionFormula::is_satisfied(const std::set<State> &states, const ClockValua
 	return disjunct1_->is_satisfied(states, v) || disjunct2_->is_satisfied(states, v);
 }
 
+std::set<std::set<State>>
+DisjunctionFormula::get_minimal_models(const ClockValuation &v) const
+{
+	auto disjunct1_models = disjunct1_->get_minimal_models(v);
+	auto disjunct2_models = disjunct2_->get_minimal_models(v);
+	disjunct1_models.insert(disjunct2_models.begin(), disjunct2_models.end());
+	return disjunct1_models;
+}
+
 ResetClockFormula::ResetClockFormula(std::unique_ptr<Formula> sub_formula)
 : sub_formula_(std::move(sub_formula))
 {
@@ -91,6 +145,12 @@ bool
 ResetClockFormula::is_satisfied(const std::set<State> &states, const ClockValuation &) const
 {
 	return sub_formula_->is_satisfied(states, 0);
+}
+
+std::set<std::set<State>>
+ResetClockFormula::get_minimal_models(const ClockValuation &) const
+{
+	return sub_formula_->get_minimal_models(0);
 }
 
 } // namespace ata

--- a/src/libta/ata_formula.cpp
+++ b/src/libta/ata_formula.cpp
@@ -1,0 +1,98 @@
+/***************************************************************************
+ *  ata_formula.cpp - Alternating Timed Automata Formulas
+ *
+ *  Created: Thu 28 May 2020 14:41:01 CEST 14:41
+ *  Copyright  2020  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ ****************************************************************************/
+
+/*  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Library General Public License for more details.
+ *
+ *  Read the full text in the LICENSE.GPL file in the doc directory.
+ */
+
+#include <libta/ata_formula.h>
+#include <libta/automata.h>
+
+namespace automata {
+namespace ata {
+
+bool
+TrueFormula::is_satisfied(const std::set<State> &, const ClockValuation &) const
+{
+	return true;
+}
+
+bool
+FalseFormula::is_satisfied(const std::set<State> &, const ClockValuation &) const
+{
+	return false;
+}
+
+LocationFormula::LocationFormula(const Location &location) : location_(location)
+{
+}
+
+bool
+LocationFormula::is_satisfied(const std::set<State> &states, const ClockValuation &v) const
+{
+	return states.count(std::make_pair(location_, v));
+}
+
+ClockConstraintFormula::ClockConstraintFormula(const ClockConstraint &constraint)
+: constraint_(constraint)
+{
+}
+
+bool
+ClockConstraintFormula::is_satisfied(const std::set<State> &, const ClockValuation &v) const
+{
+	return automata::is_satisfied(constraint_, v);
+}
+
+ConjunctionFormula::ConjunctionFormula(std::vector<std::unique_ptr<Formula>> conjuncts)
+: conjuncts_(std::move(conjuncts))
+{
+}
+
+bool
+ConjunctionFormula::is_satisfied(const std::set<State> &states, const ClockValuation &v) const
+{
+	return std::all_of(std::begin(conjuncts_), std::end(conjuncts_), [&](const auto &c) {
+		return c->is_satisfied(states, v);
+	});
+}
+
+DisjunctionFormula::DisjunctionFormula(std::vector<std::unique_ptr<Formula>> disjuncts)
+: disjuncts_(std::move(disjuncts))
+{
+}
+
+bool
+DisjunctionFormula::is_satisfied(const std::set<State> &states, const ClockValuation &v) const
+{
+	return std::any_of(std::begin(disjuncts_), std::end(disjuncts_), [&](const auto &c) {
+		return c->is_satisfied(states, v);
+	});
+}
+
+ResetClockFormula::ResetClockFormula(std::unique_ptr<Formula> sub_formula)
+: sub_formula_(std::move(sub_formula))
+{
+}
+
+bool
+ResetClockFormula::is_satisfied(const std::set<State> &states, const ClockValuation &) const
+{
+	return sub_formula_->is_satisfied(states, 0);
+}
+
+} // namespace ata
+} // namespace automata

--- a/src/libta/ata_formula.cpp
+++ b/src/libta/ata_formula.cpp
@@ -155,3 +155,11 @@ ResetClockFormula::get_minimal_models(const ClockValuation &) const
 
 } // namespace ata
 } // namespace automata
+
+std::ostream &
+operator<<(std::ostream &os, const automata::ata::State &state)
+{
+	os << std::string("(") << state.first << std::string(",") << std::to_string(state.second)
+	   << std::string(")");
+	return os;
+}

--- a/src/libta/include/libta/ata.h
+++ b/src/libta/include/libta/ata.h
@@ -1,0 +1,121 @@
+/***************************************************************************
+ *  ata.h - Alternating Timed Automata
+ *
+ *  Created: Fri 05 Jun 2020 10:58:27 CEST 10:58
+ *  Copyright  2020  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ ****************************************************************************/
+
+/*  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Library General Public License for more details.
+ *
+ *  Read the full text in the LICENSE.GPL file in the doc directory.
+ */
+
+#pragma once
+
+#include <libta/ata_formula.h>
+
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace automata::ata {
+
+/// Thrown if the wrong ATA transition type is attempted
+class WrongTransitionTypeException : public std::logic_error
+{
+public:
+	/** Constructor.
+	 * @param what The error message
+	 */
+	WrongTransitionTypeException(const std::string &what) : std::logic_error(what)
+	{
+	}
+};
+
+/// Thrown if a transition with a negative time delta is attempted
+class NegativeTimeDeltaException : public std::logic_error
+{
+public:
+	/** Constructor.
+	 * @param time_delta The negative time difference to warn about
+	 */
+	NegativeTimeDeltaException(Time time_delta)
+	: std::logic_error(
+	  "Cannot do a time transition with negative time delta (=" + std::to_string(time_delta) + ")")
+	{
+	}
+};
+
+/// A transition of an alternating timed automaton
+class Transition
+{
+public:
+	friend class AlternatingTimedAutomaton;
+	friend bool operator<(const Transition &first, const Transition &second);
+	Transition(const Transition &) = delete;
+	/** Move constructor */
+	Transition(Transition &&) = default;
+	/** Constructor.
+	 * @param source The source location of the transition
+	 * @param symbol The symbol to read with this transition
+	 * @param formula The formula that is used to determine the configuration after this transition
+	 */
+	Transition(const Location &source, const Symbol &symbol, std::unique_ptr<Formula> formula);
+
+private:
+	const Location           source_;
+	const Symbol             symbol_;
+	std::unique_ptr<Formula> formula_;
+};
+
+using Configuration = std::set<State>;
+using Run           = std::vector<std::pair<std::variant<Symbol, Time>, Configuration>>;
+/// An alternating timed automaton.
+class AlternatingTimedAutomaton
+{
+public:
+	AlternatingTimedAutomaton() = delete;
+	/** Constructor.
+	 * @param alphabet The set of symbols used by the automaton
+	 * @param initial_location The initial location that determines the initial state
+	 * @param final_locations The locations where the automaton is accepting
+	 * @param transitions The set of transitions used by the automaton
+	 */
+	AlternatingTimedAutomaton(const std::set<Symbol> &  alphabet,
+	                          const Location &          initial_location,
+	                          const std::set<Location> &final_locations,
+	                          std::set<Transition>      transitions);
+	/** Compute the resulting run after reading a symbol.
+	 * @param run The run until now (i.e., the prefix)
+	 * @param symbol The symbol to read
+	 * @return The run appended with the resulting configuration
+	 */
+	std::vector<Run> make_symbol_transition(const std::vector<Run> &run, const Symbol &symbol) const;
+	/** Compute the resulting run after progressing the time.
+	 * @param run The run until now (i.e., the prefix)
+	 * @param time The time difference to add to the automaton's clock
+	 */
+	std::vector<Run> make_time_transition(const std::vector<Run> &run, const Time &time) const;
+
+private:
+	std::set<std::set<State>>  get_minimal_models(Formula *formula, ClockValuation v) const;
+	const std::set<Symbol>     alphabet_;
+	const Location             initial_location_;
+	const std::set<Location>   final_locations_;
+	const std::set<Transition> transitions_;
+};
+
+/** Compare two transitions.
+ * @param first The first transition
+ * @param second The second transition
+ */
+bool operator<(const Transition &first, const Transition &second);
+} // namespace automata::ata

--- a/src/libta/include/libta/ata.h
+++ b/src/libta/include/libta/ata.h
@@ -21,6 +21,7 @@
 #pragma once
 
 #include <libta/ata_formula.h>
+#include <libta/automata.h>
 
 #include <stdexcept>
 #include <string>
@@ -104,6 +105,11 @@ public:
 	 * @param time The time difference to add to the automaton's clock
 	 */
 	std::vector<Run> make_time_transition(const std::vector<Run> &run, const Time &time) const;
+	/** Check if the ATA accepts a timed word.
+	 * @param word The timed word to check
+	 * @return true if the given word is accepted
+	 */
+	[[nodiscard]] bool accepts_word(const TimedWord &word) const;
 
 private:
 	std::set<std::set<State>>  get_minimal_models(Formula *formula, ClockValuation v) const;

--- a/src/libta/include/libta/ata_formula.h
+++ b/src/libta/include/libta/ata_formula.h
@@ -46,6 +46,11 @@ public:
 	 */
 	[[nodiscard]] virtual bool is_satisfied(const std::set<State> &states,
 	                                        const ClockValuation & v) const = 0;
+	/** Compute the minimal model of the formula.
+	 * @param v The clock valuation to evaluate teh formula against
+	 * @return a set of minimal models, where each minimal model consists of a set of states
+	 */
+	virtual std::set<std::set<State>> get_minimal_models(const ClockValuation &v) const = 0;
 };
 
 /// A formula that is always true
@@ -53,6 +58,7 @@ class TrueFormula : public Formula
 {
 public:
 	bool is_satisfied(const std::set<State> &states, const ClockValuation &v) const override;
+	std::set<std::set<State>> get_minimal_models(const ClockValuation &v) const override;
 };
 
 /// A formula that is always false
@@ -60,6 +66,7 @@ class FalseFormula : public Formula
 {
 public:
 	bool is_satisfied(const std::set<State> &states, const ClockValuation &v) const override;
+	std::set<std::set<State>> get_minimal_models(const ClockValuation &v) const override;
 };
 
 /// A formula requiring a specific location
@@ -71,6 +78,7 @@ public:
 	 */
 	explicit LocationFormula(const Location &location);
 	bool is_satisfied(const std::set<State> &states, const ClockValuation &v) const override;
+	std::set<std::set<State>> get_minimal_models(const ClockValuation &v) const override;
 
 private:
 	const Location location_;
@@ -85,6 +93,7 @@ public:
 	 */
 	explicit ClockConstraintFormula(const ClockConstraint &constraint);
 	bool is_satisfied(const std::set<State> &states, const ClockValuation &v) const override;
+	std::set<std::set<State>> get_minimal_models(const ClockValuation &v) const override;
 
 private:
 	ClockConstraint constraint_;
@@ -102,6 +111,8 @@ public:
 	                            std::unique_ptr<Formula> conjunct2);
 	bool is_satisfied(const std::set<State> &states, const ClockValuation &v) const override;
 
+	std::set<std::set<State>> get_minimal_models(const ClockValuation &v) const override;
+
 private:
 	std::unique_ptr<Formula> conjunct1_;
 	std::unique_ptr<Formula> conjunct2_;
@@ -118,6 +129,7 @@ public:
 	explicit DisjunctionFormula(std::unique_ptr<Formula> disjunct1,
 	                            std::unique_ptr<Formula> disjunct2);
 	bool is_satisfied(const std::set<State> &states, const ClockValuation &v) const override;
+	std::set<std::set<State>> get_minimal_models(const ClockValuation &v) const override;
 
 private:
 	std::unique_ptr<Formula> disjunct1_;
@@ -133,6 +145,7 @@ public:
 	 */
 	ResetClockFormula(std::unique_ptr<Formula> sub_formula);
 	bool is_satisfied(const std::set<State> &states, const ClockValuation &v) const override;
+	std::set<std::set<State>> get_minimal_models(const ClockValuation &v) const override;
 
 private:
 	std::unique_ptr<Formula> sub_formula_;

--- a/src/libta/include/libta/ata_formula.h
+++ b/src/libta/include/libta/ata_formula.h
@@ -1,0 +1,137 @@
+/***************************************************************************
+ *  ata_formula.h - Alternating Timed Automata Formulas
+ *
+ *  Created: Thu 28 May 2020 13:39:06 CEST 13:39
+ *  Copyright  2020  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ ****************************************************************************/
+
+/*  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Library General Public License for more details.
+ *
+ *  Read the full text in the LICENSE.GPL file in the doc directory.
+ */
+
+#pragma once
+
+#include "automata.h"
+
+#include <algorithm>
+#include <memory>
+#include <utility>
+
+namespace automata {
+namespace ata {
+
+using State = std::pair<Location, ClockValuation>;
+
+/// An abstract ATA formula.
+class Formula
+{
+public:
+	/// Constructor
+	explicit Formula(){};
+	Formula(const Formula &) = delete;
+	Formula &operator=(const Formula &) = delete;
+	/** Check if the formula is satisfied by a configuration and a clock valuation.
+	 * @param states The configuration to check
+	 * @param v The clock valuation to check
+	 * @return true if the formula is satisfied
+	 */
+	[[nodiscard]] virtual bool is_satisfied(const std::set<State> &states,
+	                                        const ClockValuation & v) const = 0;
+};
+
+/// A formula that is always true
+class TrueFormula : public Formula
+{
+public:
+	bool is_satisfied(const std::set<State> &states, const ClockValuation &v) const override;
+};
+
+/// A formula that is always false
+class FalseFormula : public Formula
+{
+public:
+	bool is_satisfied(const std::set<State> &states, const ClockValuation &v) const override;
+};
+
+/// A formula requiring a specific location
+class LocationFormula : public Formula
+{
+public:
+	/** Constructor.
+	 * @param location The location that must be in the configuration to satisfy this formula
+	 */
+	explicit LocationFormula(const Location &location);
+	bool is_satisfied(const std::set<State> &states, const ClockValuation &v) const override;
+
+private:
+	const Location location_;
+};
+
+/// A formula requiring that a clock constraint must be satisfied
+class ClockConstraintFormula : public Formula
+{
+public:
+	/** Constructor.
+	 * @param constraint The clock constraint that must be satisfied to satisfy this formula
+	 */
+	explicit ClockConstraintFormula(const ClockConstraint &constraint);
+	bool is_satisfied(const std::set<State> &states, const ClockValuation &v) const override;
+
+private:
+	ClockConstraint constraint_;
+};
+
+/// A conjunction of formulas
+class ConjunctionFormula : public Formula
+{
+public:
+	/** Constructor.
+	 * @param conjuncts A vector of sub-formulas that must all be satisfied
+	 */
+	explicit ConjunctionFormula(std::vector<std::unique_ptr<Formula>> conjuncts);
+	bool is_satisfied(const std::set<State> &states, const ClockValuation &v) const override;
+
+private:
+	std::vector<std::unique_ptr<Formula>> conjuncts_;
+};
+
+/// A disjunction of formulas
+class DisjunctionFormula : public Formula
+{
+public:
+	/** Constructor.
+	 * @param disjuncts A vector of sub-formulas, one of them must be satisfied to satisfy this
+	 * formula
+	 */
+	explicit DisjunctionFormula(std::vector<std::unique_ptr<Formula>> disjuncts);
+	bool is_satisfied(const std::set<State> &states, const ClockValuation &v) const override;
+
+private:
+	std::vector<std::unique_ptr<Formula>> disjuncts_;
+};
+
+/// A formula that sets the clock valuation to 0 for it sub-formula
+class ResetClockFormula : public Formula
+{
+public:
+	/** Constructor.
+	 * @param sub_formula The sub-formula to evaluate with a reset clock
+	 */
+	ResetClockFormula(std::unique_ptr<Formula> sub_formula);
+	bool is_satisfied(const std::set<State> &states, const ClockValuation &v) const override;
+
+private:
+	std::unique_ptr<Formula> sub_formula_;
+};
+
+} // namespace ata
+} // namespace automata

--- a/src/libta/include/libta/ata_formula.h
+++ b/src/libta/include/libta/ata_formula.h
@@ -90,18 +90,21 @@ private:
 	ClockConstraint constraint_;
 };
 
-/// A conjunction of formulas
+/// A conjunction of two formulas
 class ConjunctionFormula : public Formula
 {
 public:
 	/** Constructor.
-	 * @param conjuncts A vector of sub-formulas that must all be satisfied
+	 * @param conjunct1 The first conjunct
+	 * @param conjunct2 The second conjunct
 	 */
-	explicit ConjunctionFormula(std::vector<std::unique_ptr<Formula>> conjuncts);
+	explicit ConjunctionFormula(std::unique_ptr<Formula> conjunct1,
+	                            std::unique_ptr<Formula> conjunct2);
 	bool is_satisfied(const std::set<State> &states, const ClockValuation &v) const override;
 
 private:
-	std::vector<std::unique_ptr<Formula>> conjuncts_;
+	std::unique_ptr<Formula> conjunct1_;
+	std::unique_ptr<Formula> conjunct2_;
 };
 
 /// A disjunction of formulas
@@ -109,14 +112,16 @@ class DisjunctionFormula : public Formula
 {
 public:
 	/** Constructor.
-	 * @param disjuncts A vector of sub-formulas, one of them must be satisfied to satisfy this
-	 * formula
+	 * @param disjunct1 The first disjunct
+	 * @param disjunct2 The second disjunct
 	 */
-	explicit DisjunctionFormula(std::vector<std::unique_ptr<Formula>> disjuncts);
+	explicit DisjunctionFormula(std::unique_ptr<Formula> disjunct1,
+	                            std::unique_ptr<Formula> disjunct2);
 	bool is_satisfied(const std::set<State> &states, const ClockValuation &v) const override;
 
 private:
-	std::vector<std::unique_ptr<Formula>> disjuncts_;
+	std::unique_ptr<Formula> disjunct1_;
+	std::unique_ptr<Formula> disjunct2_;
 };
 
 /// A formula that sets the clock valuation to 0 for it sub-formula

--- a/src/libta/include/libta/ata_formula.h
+++ b/src/libta/include/libta/ata_formula.h
@@ -153,3 +153,10 @@ private:
 
 } // namespace ata
 } // namespace automata
+
+/** Print a State to an ostream
+ * @param os The ostream to print to
+ * @param state The state to print
+ * @return A reference to the ostream
+ */
+std::ostream &operator<<(std::ostream &os, const automata::ata::State &state);

--- a/src/libta/include/libta/automata.h
+++ b/src/libta/include/libta/automata.h
@@ -20,6 +20,7 @@
 
 #pragma once
 
+#include <functional>
 #include <set>
 #include <stdexcept>
 #include <string>
@@ -139,9 +140,10 @@ private:
 using ClockConstraint = std::variant<AtomicClockConstraintT<std::less<Time>>,
                                      AtomicClockConstraintT<std::less_equal<Time>>,
                                      AtomicClockConstraintT<std::equal_to<Time>>,
+                                     AtomicClockConstraintT<std::not_equal_to<Time>>,
                                      AtomicClockConstraintT<std::greater_equal<Time>>,
                                      AtomicClockConstraintT<std::greater<Time>>>;
 
-bool is_satisfied(const ClockConstraint &constraint, const Time &valuation);
+bool is_satisfied(const ClockConstraint &constraint, const ClockValuation &valuation);
 
 } // namespace automata

--- a/src/libta/include/libta/automata.h
+++ b/src/libta/include/libta/automata.h
@@ -29,11 +29,12 @@
 
 namespace automata {
 
-using Location  = std::string;
-using Symbol    = std::string;
-using Time      = double;
-using Endpoint  = unsigned int;
-using TimedWord = std::vector<std::pair<Symbol, Time>>;
+using Location       = std::string;
+using Symbol         = std::string;
+using Time           = double;
+using ClockValuation = Time;
+using Endpoint       = unsigned int;
+using TimedWord      = std::vector<std::pair<Symbol, Time>>;
 
 /// A clock of a timed automaton.
 class Clock

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -5,3 +5,7 @@ include(Catch)
 add_executable(testta test_ta.cpp catch2_main.cpp)
 target_link_libraries(testta PRIVATE libta PRIVATE Catch2::Catch2)
 catch_discover_tests(testta)
+
+add_executable(testata catch2_main.cpp test_ata_formula.cpp)
+target_link_libraries(testata PRIVATE libta PRIVATE Catch2::Catch2)
+catch_discover_tests(testata)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -6,6 +6,6 @@ add_executable(testta test_ta.cpp catch2_main.cpp)
 target_link_libraries(testta PRIVATE libta PRIVATE Catch2::Catch2)
 catch_discover_tests(testta)
 
-add_executable(testata catch2_main.cpp test_ata_formula.cpp)
+add_executable(testata catch2_main.cpp test_ata_formula.cpp test_ata.cpp)
 target_link_libraries(testata PRIVATE libta PRIVATE Catch2::Catch2)
 catch_discover_tests(testata)

--- a/test/test_ata.cpp
+++ b/test/test_ata.cpp
@@ -137,6 +137,15 @@ TEST_CASE("ATA accepting no events with a time difference of exactly 1"
 	runs = ata.make_time_transition(runs, 1);
 	runs = ata.make_symbol_transition(runs, "a");
 	CHECK(runs.size() == 0);
+
+	SECTION("accepting the correct words")
+	{
+		CHECK(!ata.accepts_word({}));
+		CHECK(ata.accepts_word({{"a", 0}, {"a", 0.5}}));
+		CHECK(!ata.accepts_word({{"a", 0}, {"a", 1}}));
+		CHECK(ata.accepts_word({{"a", 0}, {"a", 1.1}, {"a", 2}}));
+		CHECK(!ata.accepts_word({{"a", 0}, {"a", 1.1}, {"a", 2}, {"a", 3}}));
+	}
 }
 
 TEST_CASE("Time-bounded response two-state ATA (example by Ouaknine & Worrel, 2005)", "[libta]")
@@ -228,4 +237,20 @@ TEST_CASE("Time-bounded response two-state ATA (example by Ouaknine & Worrel, 20
 	CHECK(run[5].second == Configuration{{"s0", 2.5}, {"s1", 1}, {"s1", 2.5}});
 	CHECK(run[6].first == std::variant<Symbol, Time>("b"));
 	CHECK(run[6].second == Configuration{{"s0", 2.5}, {"s1", 2.5}});
+
+	SECTION("accepting the correct words")
+	{
+		CHECK(!ata.accepts_word({}));
+		CHECK(ata.accepts_word({{"a", 1}, {"b", 2}}));
+		CHECK(!ata.accepts_word({{"a", 1}, {"b", 1.5}}));
+		CHECK(!ata.accepts_word({{"a", 1}, {"b", 1.9}}));
+		CHECK(!ata.accepts_word({{"a", 1}, {"b", 1.9}}));
+		CHECK(!ata.accepts_word({{"a", 1}, {"a", 2}}));
+		CHECK(!ata.accepts_word({{"a", 1}, {"b", 2.5}}));
+		CHECK(!ata.accepts_word({{"a", 0}, {"a", 0.5}, {"b", 1}}));
+		CHECK(ata.accepts_word({{"a", 0}, {"a", 0.5}, {"b", 1}, {"b", 1.5}}));
+		CHECK(!ata.accepts_word({{"a", 0}, {"a", 0.5}, {"b", 1}, {"a", 1}, {"b", 1.5}}));
+		CHECK(!ata.accepts_word({{"a", 0}, {"a", 0.5}, {"b", 1}, {"b", 1.5}, {"a", 2.5}}));
+		CHECK(ata.accepts_word({{"a", 0}, {"a", 0.5}, {"b", 1}, {"b", 1.5}, {"b", 2.0}}));
+	}
 }

--- a/test/test_ata.cpp
+++ b/test/test_ata.cpp
@@ -1,0 +1,231 @@
+/***************************************************************************
+ *  test_ata.cpp - Tests for Alternating Timed Automata
+ *
+ *  Created: Tue 09 Jun 2020 09:05:03 CEST 09:05
+ *  Copyright  2020  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ ****************************************************************************/
+
+/*  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Library General Public License for more details.
+ *
+ *  Read the full text in the LICENSE.GPL file in the doc directory.
+ */
+
+#include <libta/ata.h>
+#include <libta/ata_formula.h>
+#include <libta/automata.h>
+
+#include <catch2/catch.hpp>
+#include <functional>
+#include <memory>
+
+using namespace automata;
+using namespace automata::ata;
+
+TEST_CASE("Transitions in a single-state ATA", "[libta]")
+{
+	std::set<Transition> transitions;
+	transitions.insert(Transition("s0", "a", std::make_unique<LocationFormula>("s0")));
+	AlternatingTimedAutomaton ata({"a"}, "s0", {"s0"}, std::move(transitions));
+	SECTION("reading a single 'a'")
+	{
+		auto runs = ata.make_symbol_transition({{}}, "a");
+		REQUIRE(runs.size() == 1);
+		REQUIRE(runs[0]
+		        == Run{{std::make_pair(std::variant<Symbol, Time>("a"), Configuration{{"s0", 0}})}});
+	}
+	SECTION("reading 'a', '0', 'a'")
+	{
+		auto runs =
+		  ata.make_symbol_transition(ata.make_time_transition(ata.make_symbol_transition({{}}, "a"), 1),
+		                             "a");
+		REQUIRE(runs.size() == 1);
+		auto run = runs[0];
+		REQUIRE(run.size() == 3);
+		CHECK(run[0] == std::make_pair(std::variant<Symbol, Time>("a"), Configuration{{"s0", 0}}));
+		CHECK(run[1] == std::make_pair(std::variant<Symbol, Time>(1.), Configuration{{"s0", 1}}));
+		CHECK(run[2] == std::make_pair(std::variant<Symbol, Time>("a"), Configuration{{"s0", 1}}));
+	}
+}
+
+TEST_CASE("ATA transition exceptions", "[libta]")
+{
+	std::set<Transition> transitions;
+	transitions.insert(Transition("s0", "a", std::make_unique<LocationFormula>("s0")));
+	AlternatingTimedAutomaton ata({"a"}, "s0", {"s0"}, std::move(transitions));
+	SECTION("throwing if a time transition occurs before any symbol transition")
+	{
+		REQUIRE_THROWS(ata.make_time_transition({{}}, 0));
+	}
+	SECTION("throwing if two subsequent symbol transitions occur")
+	{
+		REQUIRE_THROWS(ata.make_symbol_transition(ata.make_symbol_transition({{}}, "a"), "a"));
+	}
+	SECTION("throwing if the time delta is negative")
+	{
+		auto runs = ata.make_symbol_transition({{}}, "a");
+		REQUIRE_NOTHROW(ata.make_time_transition(runs, 0.));
+		REQUIRE_NOTHROW(ata.make_time_transition(runs, 0.5));
+		REQUIRE_THROWS_AS(ata.make_time_transition(runs, -0.5), NegativeTimeDeltaException);
+	}
+}
+
+TEST_CASE("Simple ATA with a disjcuntion", "[libta]")
+{
+	std::set<Transition> transitions;
+	transitions.insert(
+	  Transition("s0",
+	             "a",
+	             std::make_unique<DisjunctionFormula>(std::make_unique<LocationFormula>("s0"),
+	                                                  std::make_unique<LocationFormula>("s1"))));
+	AlternatingTimedAutomaton ata({"a"}, "s0", {"s0"}, std::move(transitions));
+	auto                      runs = ata.make_symbol_transition({{}}, "a");
+	REQUIRE(runs.size() == 2);
+	auto run = runs[0];
+	REQUIRE(run.size() == 1);
+	CHECK(run[0].first == std::variant<Symbol, Time>("a"));
+	CHECK(run[0].second == Configuration{{"s0", 0}});
+	run = runs[1];
+	REQUIRE(run.size() == 1);
+	CHECK(run[0].first == std::variant<Symbol, Time>("a"));
+	CHECK(run[0].second == Configuration{{"s1", 0}});
+}
+
+TEST_CASE("ATA accepting no events with a time difference of exactly 1"
+          " (example by Ouaknine & Worrel, 2005)")
+{
+	std::set<Transition> transitions;
+	transitions.insert(
+	  Transition("s0",
+	             "a",
+	             std::make_unique<ConjunctionFormula>(std::make_unique<LocationFormula>("s0"),
+	                                                  std::make_unique<ResetClockFormula>(
+	                                                    std::make_unique<LocationFormula>("s1")))));
+	transitions.insert(Transition(
+	  "s1",
+	  "a",
+	  std::make_unique<ConjunctionFormula>(std::make_unique<LocationFormula>("s1"),
+	                                       std::make_unique<ClockConstraintFormula>(
+	                                         AtomicClockConstraintT<std::not_equal_to<Time>>(1.)))));
+	AlternatingTimedAutomaton ata({"a"}, "s0", {"s0", "s1"}, std::move(transitions));
+
+	auto runs = ata.make_symbol_transition({{}}, "a");
+	REQUIRE(runs.size() == 1);
+	auto run = runs[0];
+	CHECK(run[0].first == std::variant<Symbol, Time>("a"));
+	CHECK(run[0].second == Configuration{{"s0", 0}, {"s1", 0}});
+	runs = ata.make_symbol_transition(ata.make_time_transition(runs, 0.5), "a");
+	REQUIRE(runs.size() == 1);
+	run = runs[0];
+	REQUIRE(run.size() == 3);
+	CHECK(run[0].first == std::variant<Symbol, Time>("a"));
+	CHECK(run[0].second == Configuration{{"s0", 0}, {"s1", 0}});
+	CHECK(run[1].first == std::variant<Symbol, Time>(0.5));
+	CHECK(run[1].second == Configuration{{"s0", 0.5}, {"s1", 0.5}});
+	CHECK(run[2].first == std::variant<Symbol, Time>("a"));
+	CHECK(run[2].second == Configuration{{"s0", 0.5}, {"s1", 0}, {"s1", 0.5}});
+
+	// (a,0), (a,1) should not be accepted
+	runs = ata.make_symbol_transition({{}}, "a");
+	runs = ata.make_time_transition(runs, 1);
+	runs = ata.make_symbol_transition(runs, "a");
+	CHECK(runs.size() == 0);
+}
+
+TEST_CASE("Time-bounded response two-state ATA (example by Ouaknine & Worrel, 2005)", "[libta]")
+{
+	std::set<Transition> transitions;
+	transitions.insert(
+	  Transition("s0",
+	             "a",
+	             std::make_unique<ConjunctionFormula>(std::make_unique<LocationFormula>("s0"),
+	                                                  std::make_unique<ResetClockFormula>(
+	                                                    std::make_unique<LocationFormula>("s1")))));
+	transitions.insert(Transition("s0", "b", std::make_unique<LocationFormula>("s0")));
+	transitions.insert(Transition("s1", "a", std::make_unique<LocationFormula>("s1")));
+	transitions.insert(Transition(
+	  "s1",
+	  "b",
+	  std::make_unique<DisjunctionFormula>(std::make_unique<ClockConstraintFormula>(
+	                                         AtomicClockConstraintT<std::equal_to<Time>>(1.)),
+	                                       std::make_unique<LocationFormula>("s1"))));
+	AlternatingTimedAutomaton ata({"a", "b"}, "s0", {"s0"}, std::move(transitions));
+
+	auto runs = ata.make_symbol_transition({{}}, "a");
+	runs      = ata.make_time_transition(runs, 1);
+	runs      = ata.make_symbol_transition(runs, "b");
+	REQUIRE(runs.size() == 2);
+	auto run = runs[0];
+	REQUIRE(run.size() == 3);
+	CHECK(run[0].first == std::variant<Symbol, Time>("a"));
+	CHECK(run[0].second == Configuration{{"s0", 0}, {"s1", 0}});
+	CHECK(run[1].first == std::variant<Symbol, Time>(1.0));
+	CHECK(run[1].second == Configuration{{"s0", 1.0}, {"s1", 1.0}});
+	CHECK(run[2].first == std::variant<Symbol, Time>("b"));
+	CHECK(run[2].second == Configuration{{"s0", 1}});
+	run = runs[1];
+	REQUIRE(run.size() == 3);
+	CHECK(run[0].first == std::variant<Symbol, Time>("a"));
+	CHECK(run[0].second == Configuration{{"s0", 0}, {"s1", 0}});
+	CHECK(run[1].first == std::variant<Symbol, Time>(1.0));
+	CHECK(run[1].second == Configuration{{"s0", 1.0}, {"s1", 1.0}});
+	CHECK(run[2].first == std::variant<Symbol, Time>("b"));
+	CHECK(run[2].second == Configuration{{"s0", 1}, {"s1", 1}});
+
+	runs = ata.make_time_transition(runs, 0.5);
+	runs = ata.make_symbol_transition(runs, "a");
+	runs = ata.make_time_transition(runs, 1);
+	runs = ata.make_symbol_transition(runs, "b");
+
+	REQUIRE(runs.size() == 4);
+	// 1. option: disjunct `x=1` on both b's
+	run = runs[0];
+	CHECK(run[3].first == std::variant<Symbol, Time>(0.5));
+	CHECK(run[3].second == Configuration{{"s0", 1.5}});
+	CHECK(run[4].first == std::variant<Symbol, Time>("a"));
+	CHECK(run[4].second == Configuration{{"s0", 1.5}, {"s1", 0}});
+	CHECK(run[5].first == std::variant<Symbol, Time>(1.));
+	CHECK(run[5].second == Configuration{{"s0", 2.5}, {"s1", 1}});
+	CHECK(run[6].first == std::variant<Symbol, Time>("b"));
+	CHECK(run[6].second == Configuration{{"s0", 2.5}});
+
+	// 2. option: disjunct `x=1` on first b, disjunct `s1` on second b
+	run = runs[1];
+	CHECK(run[3].first == std::variant<Symbol, Time>(0.5));
+	CHECK(run[3].second == Configuration{{"s0", 1.5}});
+	CHECK(run[4].first == std::variant<Symbol, Time>("a"));
+	CHECK(run[4].second == Configuration{{"s0", 1.5}, {"s1", 0}});
+	CHECK(run[5].first == std::variant<Symbol, Time>(1.));
+	CHECK(run[5].second == Configuration{{"s0", 2.5}, {"s1", 1}});
+	CHECK(run[6].first == std::variant<Symbol, Time>("b"));
+	CHECK(run[6].second == Configuration{{"s0", 2.5}, {"s1", 1}});
+
+	// 3. option: disjunct `s1` on first b, disjunct `x=1` on second b
+	run = runs[2];
+	CHECK(run[3].first == std::variant<Symbol, Time>(0.5));
+	CHECK(run[3].second == Configuration{{"s0", 1.5}, {"s1", 1.5}});
+	CHECK(run[4].first == std::variant<Symbol, Time>("a"));
+	CHECK(run[4].second == Configuration{{"s0", 1.5}, {"s1", 0}, {"s1", 1.5}});
+	CHECK(run[5].first == std::variant<Symbol, Time>(1.));
+	CHECK(run[5].second == Configuration{{"s0", 2.5}, {"s1", 1}, {"s1", 2.5}});
+	CHECK(run[6].first == std::variant<Symbol, Time>("b"));
+	CHECK(run[6].second == Configuration{{"s0", 2.5}, {"s1", 1}, {"s1", 2.5}});
+
+	// 4. option: disjunct `s1` on both b's
+	run = runs[3];
+	CHECK(run[3].first == std::variant<Symbol, Time>(0.5));
+	CHECK(run[3].second == Configuration{{"s0", 1.5}, {"s1", 1.5}});
+	CHECK(run[4].first == std::variant<Symbol, Time>("a"));
+	CHECK(run[4].second == Configuration{{"s0", 1.5}, {"s1", 0}, {"s1", 1.5}});
+	CHECK(run[5].first == std::variant<Symbol, Time>(1.));
+	CHECK(run[5].second == Configuration{{"s0", 2.5}, {"s1", 1}, {"s1", 2.5}});
+	CHECK(run[6].first == std::variant<Symbol, Time>("b"));
+	CHECK(run[6].second == Configuration{{"s0", 2.5}, {"s1", 2.5}});
+}

--- a/test/test_ata_formula.cpp
+++ b/test/test_ata_formula.cpp
@@ -18,9 +18,8 @@
  *  Read the full text in the LICENSE.GPL file in the doc directory.
  */
 
-#include "libta/automata.h"
-
 #include <libta/ata_formula.h>
+#include <libta/automata.h>
 
 #include <catch2/catch.hpp>
 #include <functional>
@@ -56,72 +55,60 @@ TEST_CASE("Simple ATA formulas", "[libta]")
 
 TEST_CASE("ATA conjunction formulas", "[libta]")
 {
-	REQUIRE(ConjunctionFormula({}).is_satisfied({}, 0));
-	std::vector<std::unique_ptr<Formula>> subs;
-	SECTION("satisfying a conjunction with a single conjunct")
-	{
-		subs.emplace_back(std::make_unique<LocationFormula>("s0"));
-		REQUIRE(ConjunctionFormula(std::move(subs)).is_satisfied({{"s0", 0}}, 0));
-	}
-	SECTION("satisfying two true conjuncts")
-	{
-		subs.emplace_back(std::make_unique<TrueFormula>());
-		subs.emplace_back(std::make_unique<TrueFormula>());
-		REQUIRE(ConjunctionFormula(std::move(subs)).is_satisfied({{"s0", 0}}, 0));
-	}
-	SECTION("not satisfying a true and a false conjunct")
-	{
-		subs.emplace_back(std::make_unique<TrueFormula>());
-		subs.emplace_back(std::make_unique<FalseFormula>());
-		REQUIRE(!ConjunctionFormula(std::move(subs)).is_satisfied({{"s0", 0}}, 0));
-	}
-	SECTION("satisfying two location conjuncts")
-	{
-		subs.emplace_back(std::make_unique<LocationFormula>("s1"));
-		subs.emplace_back(std::make_unique<LocationFormula>("s2"));
-		REQUIRE(DisjunctionFormula(std::move(subs)).is_satisfied({{"s1", 0}, {"s2", 1}}, 0));
-	}
-	SECTION("not satisfying a conjunction of one true and one false location formula")
-	{
-		subs.emplace_back(std::make_unique<LocationFormula>("s1"));
-		subs.emplace_back(std::make_unique<LocationFormula>("s2"));
-		REQUIRE(!ConjunctionFormula(std::move(subs)).is_satisfied({{"s1", 0}}, 0));
-	}
+	REQUIRE(ConjunctionFormula(std::make_unique<TrueFormula>(), std::make_unique<TrueFormula>())
+	          .is_satisfied({{"s0", 0}}, 0));
+	REQUIRE(!ConjunctionFormula(std::make_unique<TrueFormula>(), std::make_unique<FalseFormula>())
+	           .is_satisfied({{"s0", 0}}, 0));
+	REQUIRE(!ConjunctionFormula(std::make_unique<FalseFormula>(), std::make_unique<TrueFormula>())
+	           .is_satisfied({{"s0", 0}}, 0));
+
+	REQUIRE(ConjunctionFormula(std::make_unique<LocationFormula>("s0"),
+	                           std::make_unique<LocationFormula>("s0"))
+	          .is_satisfied({{"s0", 0}}, 0));
+	REQUIRE(ConjunctionFormula(std::make_unique<LocationFormula>("s1"),
+	                           std::make_unique<LocationFormula>("s2"))
+	          .is_satisfied({{"s1", 0}, {"s2", 0}}, 0));
+	REQUIRE(!ConjunctionFormula(std::make_unique<LocationFormula>("s1"),
+	                            std::make_unique<LocationFormula>("s2"))
+	           .is_satisfied({{"s1", 0}}, 0));
+	REQUIRE(ConjunctionFormula(
+	          std::make_unique<ConjunctionFormula>(std::make_unique<LocationFormula>("s0"),
+	                                               std::make_unique<LocationFormula>("s1")),
+	          std::make_unique<ConjunctionFormula>(std::make_unique<LocationFormula>("s2"),
+	                                               std::make_unique<LocationFormula>("s3")))
+	          .is_satisfied({{"s0", 0}, {"s1", 0}, {"s2", 0}, {"s3", 0}}, 0));
 }
 
 TEST_CASE("ATA disjunction formulas", "[libta]")
 {
-	REQUIRE(!DisjunctionFormula({}).is_satisfied({}, 0));
-	std::vector<std::unique_ptr<Formula>> subs;
-	SECTION("satisfying a disjunction with a single disjunct")
-	{
-		subs.emplace_back(std::make_unique<LocationFormula>("s0"));
-		REQUIRE(DisjunctionFormula(std::move(subs)).is_satisfied({{"s0", 0}}, 0));
-	}
-	SECTION("satisfying two true disjuncts")
-	{
-		subs.emplace_back(std::make_unique<TrueFormula>());
-		subs.emplace_back(std::make_unique<TrueFormula>());
-		REQUIRE(DisjunctionFormula(std::move(subs)).is_satisfied({{"s0", 0}}, 0));
-	}
-	SECTION("satisfying a true and a false disjuncts")
-	{
-		subs.emplace_back(std::make_unique<TrueFormula>());
-		subs.emplace_back(std::make_unique<FalseFormula>());
-		REQUIRE(DisjunctionFormula(std::move(subs)).is_satisfied({{"s0", 0}}, 0));
-	}
-	SECTION("satisfying two true location disjuncts")
-	{
-		subs.emplace_back(std::make_unique<LocationFormula>("s1"));
-		subs.emplace_back(std::make_unique<LocationFormula>("s2"));
-		REQUIRE(DisjunctionFormula(std::move(subs)).is_satisfied({{"s1", 0}, {"s2", 1}}, 0));
-	}
-	SECTION("satisfying a disjunction of one true and one false location formula")
-	{
-		subs.emplace_back(std::make_unique<LocationFormula>("s1"));
-		subs.emplace_back(std::make_unique<LocationFormula>("s2"));
-		REQUIRE(DisjunctionFormula(std::move(subs)).is_satisfied({{"s1", 0}}, 0));
-	}
+	REQUIRE(DisjunctionFormula(std::make_unique<TrueFormula>(), std::make_unique<TrueFormula>())
+	          .is_satisfied({{"s0", 0}}, 0));
+	REQUIRE(DisjunctionFormula(std::make_unique<TrueFormula>(), std::make_unique<FalseFormula>())
+	          .is_satisfied({{"s0", 0}}, 0));
+	REQUIRE(DisjunctionFormula(std::make_unique<FalseFormula>(), std::make_unique<TrueFormula>())
+	          .is_satisfied({{"s0", 0}}, 0));
+
+	REQUIRE(DisjunctionFormula(std::make_unique<LocationFormula>("s0"),
+	                           std::make_unique<LocationFormula>("s0"))
+	          .is_satisfied({{"s0", 0}}, 0));
+	REQUIRE(DisjunctionFormula(std::make_unique<LocationFormula>("s1"),
+	                           std::make_unique<LocationFormula>("s2"))
+	          .is_satisfied({{"s1", 0}, {"s2", 0}}, 0));
+	REQUIRE(DisjunctionFormula(std::make_unique<LocationFormula>("s1"),
+	                           std::make_unique<LocationFormula>("s2"))
+	          .is_satisfied({{"s1", 0}}, 0));
+	REQUIRE(DisjunctionFormula(
+	          std::make_unique<DisjunctionFormula>(std::make_unique<LocationFormula>("s0"),
+	                                               std::make_unique<LocationFormula>("s1")),
+	          std::make_unique<DisjunctionFormula>(std::make_unique<LocationFormula>("s2"),
+	                                               std::make_unique<LocationFormula>("s3")))
+	          .is_satisfied({{"s0", 0}, {"s1", 0}, {"s2", 0}, {"s3", 0}}, 0));
+	REQUIRE(DisjunctionFormula(
+	          std::make_unique<DisjunctionFormula>(std::make_unique<LocationFormula>("s0"),
+	                                               std::make_unique<LocationFormula>("s1")),
+	          std::make_unique<DisjunctionFormula>(std::make_unique<LocationFormula>("s2"),
+	                                               std::make_unique<LocationFormula>("s3")))
+	          .is_satisfied({{"s3", 0}}, 0));
 }
 
 TEST_CASE("ATA reset clock formulas", "[libta]")

--- a/test/test_ata_formula.cpp
+++ b/test/test_ata_formula.cpp
@@ -1,0 +1,134 @@
+/***************************************************************************
+ *  test_ata_formula.cpp - Test ATA formulas
+ *
+ *  Created: Thu 28 May 2020 16:33:29 CEST 16:33
+ *  Copyright  2020  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ ****************************************************************************/
+
+/*  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Library General Public License for more details.
+ *
+ *  Read the full text in the LICENSE.GPL file in the doc directory.
+ */
+
+#include "libta/automata.h"
+
+#include <libta/ata_formula.h>
+
+#include <catch2/catch.hpp>
+#include <functional>
+#include <memory>
+
+using namespace automata;
+using namespace automata::ata;
+
+TEST_CASE("Simple ATA formulas", "[libta]")
+{
+	REQUIRE(TrueFormula().is_satisfied({}, 0));
+	REQUIRE(!FalseFormula().is_satisfied({}, 0));
+	REQUIRE(LocationFormula("s1").is_satisfied({{"s0", 0}, {"s1", 0}}, 0));
+	REQUIRE(!LocationFormula("s1").is_satisfied({{"s0", 0}, {"s2", 0}}, 0));
+	REQUIRE(!LocationFormula("s1").is_satisfied({}, 0));
+	REQUIRE(!LocationFormula("s0").is_satisfied({{"s0", 0}}, 1));
+
+	{
+		ClockConstraint c = AtomicClockConstraintT<std::greater<Time>>(1);
+		REQUIRE(ClockConstraintFormula(c).is_satisfied({{"s0", 0}}, 2));
+		REQUIRE(ClockConstraintFormula(c).is_satisfied({{"s0", 2}}, 2));
+		REQUIRE(!ClockConstraintFormula(c).is_satisfied({{"s0", 2}}, 0));
+		REQUIRE(!ClockConstraintFormula(c).is_satisfied({{"s0", 0}}, 0));
+	}
+	{
+		ClockConstraint c = AtomicClockConstraintT<std::less<Time>>(1);
+		REQUIRE(!ClockConstraintFormula(c).is_satisfied({{"s0", 0}}, 2));
+		REQUIRE(!ClockConstraintFormula(c).is_satisfied({{"s0", 2}}, 2));
+		REQUIRE(ClockConstraintFormula(c).is_satisfied({{"s0", 2}}, 0));
+		REQUIRE(ClockConstraintFormula(c).is_satisfied({{"s0", 0}}, 0));
+	}
+}
+
+TEST_CASE("ATA conjunction formulas", "[libta]")
+{
+	REQUIRE(ConjunctionFormula({}).is_satisfied({}, 0));
+	std::vector<std::unique_ptr<Formula>> subs;
+	SECTION("satisfying a conjunction with a single conjunct")
+	{
+		subs.emplace_back(std::make_unique<LocationFormula>("s0"));
+		REQUIRE(ConjunctionFormula(std::move(subs)).is_satisfied({{"s0", 0}}, 0));
+	}
+	SECTION("satisfying two true conjuncts")
+	{
+		subs.emplace_back(std::make_unique<TrueFormula>());
+		subs.emplace_back(std::make_unique<TrueFormula>());
+		REQUIRE(ConjunctionFormula(std::move(subs)).is_satisfied({{"s0", 0}}, 0));
+	}
+	SECTION("not satisfying a true and a false conjunct")
+	{
+		subs.emplace_back(std::make_unique<TrueFormula>());
+		subs.emplace_back(std::make_unique<FalseFormula>());
+		REQUIRE(!ConjunctionFormula(std::move(subs)).is_satisfied({{"s0", 0}}, 0));
+	}
+	SECTION("satisfying two location conjuncts")
+	{
+		subs.emplace_back(std::make_unique<LocationFormula>("s1"));
+		subs.emplace_back(std::make_unique<LocationFormula>("s2"));
+		REQUIRE(DisjunctionFormula(std::move(subs)).is_satisfied({{"s1", 0}, {"s2", 1}}, 0));
+	}
+	SECTION("not satisfying a conjunction of one true and one false location formula")
+	{
+		subs.emplace_back(std::make_unique<LocationFormula>("s1"));
+		subs.emplace_back(std::make_unique<LocationFormula>("s2"));
+		REQUIRE(!ConjunctionFormula(std::move(subs)).is_satisfied({{"s1", 0}}, 0));
+	}
+}
+
+TEST_CASE("ATA disjunction formulas", "[libta]")
+{
+	REQUIRE(!DisjunctionFormula({}).is_satisfied({}, 0));
+	std::vector<std::unique_ptr<Formula>> subs;
+	SECTION("satisfying a disjunction with a single disjunct")
+	{
+		subs.emplace_back(std::make_unique<LocationFormula>("s0"));
+		REQUIRE(DisjunctionFormula(std::move(subs)).is_satisfied({{"s0", 0}}, 0));
+	}
+	SECTION("satisfying two true disjuncts")
+	{
+		subs.emplace_back(std::make_unique<TrueFormula>());
+		subs.emplace_back(std::make_unique<TrueFormula>());
+		REQUIRE(DisjunctionFormula(std::move(subs)).is_satisfied({{"s0", 0}}, 0));
+	}
+	SECTION("satisfying a true and a false disjuncts")
+	{
+		subs.emplace_back(std::make_unique<TrueFormula>());
+		subs.emplace_back(std::make_unique<FalseFormula>());
+		REQUIRE(DisjunctionFormula(std::move(subs)).is_satisfied({{"s0", 0}}, 0));
+	}
+	SECTION("satisfying two true location disjuncts")
+	{
+		subs.emplace_back(std::make_unique<LocationFormula>("s1"));
+		subs.emplace_back(std::make_unique<LocationFormula>("s2"));
+		REQUIRE(DisjunctionFormula(std::move(subs)).is_satisfied({{"s1", 0}, {"s2", 1}}, 0));
+	}
+	SECTION("satisfying a disjunction of one true and one false location formula")
+	{
+		subs.emplace_back(std::make_unique<LocationFormula>("s1"));
+		subs.emplace_back(std::make_unique<LocationFormula>("s2"));
+		REQUIRE(DisjunctionFormula(std::move(subs)).is_satisfied({{"s1", 0}}, 0));
+	}
+}
+
+TEST_CASE("ATA reset clock formulas", "[libta]")
+{
+	ResetClockFormula l{std::make_unique<LocationFormula>("s0")};
+	REQUIRE(l.is_satisfied({{"s0", 0}}, 1));
+	ResetClockFormula f{
+	  std::make_unique<ClockConstraintFormula>(AtomicClockConstraintT<std::less<Time>>(1))};
+	REQUIRE(f.is_satisfied({{"s1", 0}}, 2));
+}


### PR DESCRIPTION
Add ATAs to libta. This adds a new class `AlternatingTimedAutomaton` closely following the definitions by [Ouaknine & Worrell, 2005](https://doi.org/10.1109/LICS.2005.33). In particular:
* Add ATA formulas, which are used to define the transitions in an ATA. ATA formulas are defined as a polymorphic type, where each formula type implements the abstract `Formula`.
* Satisfaction and minimal models for ATA formulas. Satisfaction is straightforward, following the definitions in the paper. The minimal models are actually not defined in detail in the paper, but it seemed rather straightforward to compute them. As we do not have negation in ATA formulas, we can compute the minimal models by recursively computing the minimal models of all subformulas and combining those models. As an example for a conjunction `phi AND psi`, we need to take the union of a minimal model of `phi` and a minimal model of `psi`. As each formula can have multiple minimal models, this is done by computing the cartesian product of the minimal models of each subformula, and then recombining those pairs into one set.
* Based on ATA formulas, define transitions for ATAs. There are two types of (alternating) transitions (hence the name):
    * Symbol transitions read a symbol and compute the resulting configuration using the minimal models of the transition's formula.
    * Time transitions simply progress the (single) clock of the ATA.
* Using the transitions, we can define word acceptance for a timed word by iteratively applying transitions by reading the symbol and time difference from the timed word.

For testing, this uses two examples from the paper, which define non-trivial languages. There are also tests for formula satisfaction and minimal models, as well as for checking the resulting configurations of following individual transitions. While these could be considered implementation details, I'd like to keep the tests, as they allow to understand the implemenation in more detail. Also, we will likely use single transition steps later on (rather than just checking whether an ATA accepts a word).
