### PR TITLE
Switch to codecov for code coverage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,9 +18,6 @@ jobs:
               make \
               python3-pip \
               range-v3-devel
-      - run:
-          name: install cpp-coveralls
-          command: pip3 install cpp-coveralls
       - checkout
       - run:
           name: Build the project
@@ -38,7 +35,7 @@ jobs:
           command: |
             cmake -B build_coverage -DCMAKE_BUILD_TYPE=Debug -DCOVERAGE=ON && \
             cmake --build build_coverage -j1 --target coverage && \
-            coveralls -n -l build_coverage/coverage.info
+            bash <(curl -s https://codecov.io/bash)
 
 workflows:
   build:

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,2 @@
+ignore:
+  - "test/**"

--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 [![CircleCI](https://circleci.com/gh/morxa/mtlsyn.svg?style=shield)](https://circleci.com/gh/morxa/mtlsyn)
-[![Coverage Status](https://coveralls.io/repos/github/morxa/mtlsyn/badge.svg?branch=master)](https://coveralls.io/github/morxa/mtlsyn?branch=master)
+[![codecov](https://codecov.io/gh/morxa/mtlsyn/branch/master/graph/badge.svg?token=6TOV7K7YS7)](https://codecov.io/gh/morxa/mtlsyn)
 [![Codacy Badge](https://app.codacy.com/project/badge/Grade/6372f01df5ac4d8790b5ef885f72ed39)](https://www.codacy.com/gh/morxa/mtlsyn/dashboard?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=morxa/mtlsyn&amp;utm_campaign=Badge_Grade)


### PR DESCRIPTION
coveralls is weird and buggy, let's use codecov instead, which also seems easier to configure.