### PR TITLE
Add tests to cover untested code and fix some related bugs

### DIFF
--- a/src/mtl/include/mtl/MTLFormula.h
+++ b/src/mtl/include/mtl/MTLFormula.h
@@ -356,13 +356,6 @@ public:
 		return *this;
 	}
 
-	/// function to test whether a formula consists solely of an atomic proposition
-	bool
-	is_AP() const
-	{
-		assert(is_consistent());
-		return ap_.has_value() && operator_ == LOP::AP;
-	}
 	/// collects all used atomic propositions of the formula
 	std::set<AtomicProposition<APType>>
 	get_alphabet() const

--- a/src/mtl/include/mtl/MTLFormula.h
+++ b/src/mtl/include/mtl/MTLFormula.h
@@ -115,7 +115,7 @@ public:
 	bool
 	satisfies_at(const MTLFormula<APType> &phi, std::size_t i) const
 	{
-		if (i > this->word_.size())
+		if (i >= this->word_.size())
 			return false;
 
 		switch (phi.operator_) {

--- a/src/mtl/include/mtl/MTLFormula.h
+++ b/src/mtl/include/mtl/MTLFormula.h
@@ -313,32 +313,7 @@ public:
 	bool
 	operator==(const MTLFormula &rhs) const
 	{
-		// compare operation
-		if (this->get_operator() != rhs.get_operator()) {
-			return false;
-		}
-
-		// base case: compare atomic propositions
-		if (this->get_operator() == LOP::AP) {
-			assert(rhs.get_operator() == LOP::AP);
-			return this->get_atomicProposition() == rhs.get_atomicProposition();
-		}
-
-		// compare subformulas
-		// Note: since the operators are the same, the size of operands needs to be the same
-		if (this->get_operands().size() != rhs.get_operands().size()) {
-			return false;
-		}
-
-		auto itPair = std::mismatch(this->get_operands().begin(),
-		                            this->get_operands().end(),
-		                            rhs.get_operands().begin());
-
-		if (itPair.first != this->get_operands().end() && itPair.second != rhs.get_operands().end()) {
-			return false;
-		}
-
-		return true;
+		return !(*this < rhs) && !(rhs < *this);
 	}
 	/// not-equal operator
 	bool

--- a/src/mtl_ata_translation/translator.cpp
+++ b/src/mtl_ata_translation/translator.cpp
@@ -148,10 +148,10 @@ init(const MTLFormula<ActionType> &formula, const AtomicProposition<ActionType> 
 		// We know that this is an atomic proposition because the input formula is in positive normal
 		// form.
 		if (formula.get_operands().front() == ap) {
-			// init(b, a) = TRUE if b == a
+			// init(not b, a) = FALSE if b == a
 			return std::make_unique<FalseFormula>();
 		} else {
-			// init(b, a) = FALSE if b != a
+			// init(not b, a) = TRUE if b != a
 			return std::make_unique<TrueFormula>();
 		}
 	}
@@ -194,10 +194,10 @@ translate(const MTLFormula<ActionType> &input_formula)
 			transitions.insert(Transition(until, symbol, std::move(transition_formula)));
 		}
 		for (const auto &dual_until : dual_untils) {
-			auto transition_formula = std::make_unique<DisjunctionFormula>(
-			  std::make_unique<ConjunctionFormula>(init(dual_until.get_operands().back(), symbol),
+			auto transition_formula = std::make_unique<ConjunctionFormula>(
+			  std::make_unique<DisjunctionFormula>(init(dual_until.get_operands().back(), symbol),
 			                                       create_negated_contains(dual_until.get_interval())),
-			  std::make_unique<ConjunctionFormula>(init(dual_until.get_operands().front(), symbol),
+			  std::make_unique<DisjunctionFormula>(init(dual_until.get_operands().front(), symbol),
 			                                       std::make_unique<LocationFormula>(dual_until)));
 			transitions.insert(Transition(dual_until, symbol, std::move(transition_formula)));
 		}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -22,7 +22,7 @@ add_executable(testnumberutilities test_number_utilities.cpp catch2_main.cpp)
 target_link_libraries(testnumberutilities PRIVATE utilities PRIVATE Catch2::Catch2)
 catch_discover_tests(testnumberutilities)
 
-add_executable(testmtlformulae test_mtlFormula.cpp catch2_main.cpp)
+add_executable(testmtlformulae test_mtlFormula.cpp test_print_mtl_formula.cpp catch2_main.cpp)
 target_link_libraries(testmtlformulae PRIVATE mtl PRIVATE Catch2::Catch2)
 catch_discover_tests(testmtlformulae)
 

--- a/test/test_mtlFormula.cpp
+++ b/test/test_mtlFormula.cpp
@@ -114,6 +114,9 @@ TEST_CASE("Dual until", "[libmtl]")
 	REQUIRE(word4.satisfies(dual_until));
 	REQUIRE(word5.satisfies(dual_until));
 	REQUIRE(!word6.satisfies(dual_until));
+	REQUIRE(
+	  logic::MTLWord<std::string>{{{b}, 1}, {{b}, 2}, {{b}, 3}, {{b}, 4}, {{a, b}, 5}}.satisfies(
+	    dual_until));
 	REQUIRE(word1.satisfies(double_neg_until) == word1.satisfies(dual_until));
 	REQUIRE(word2.satisfies(double_neg_until) == word2.satisfies(dual_until));
 	REQUIRE(word3.satisfies(double_neg_until) == word3.satisfies(dual_until));

--- a/test/test_mtlFormula.cpp
+++ b/test/test_mtlFormula.cpp
@@ -74,6 +74,17 @@ TEST_CASE("Construction & simple satisfaction", "[libmtl]")
 	REQUIRE(!word2.satisfies(phi1.until(phi2, {1, 1})));
 }
 
+TEST_CASE("MTL literals", "[libmtl]")
+{
+	CHECK(logic::MTLWord<std::string>({{{}, 0}}).satisfies_at(
+	  logic::MTLFormula(logic::AtomicProposition<std::string>("true")), 0));
+	// Word too short, does not matter that the formula is "true".
+	CHECK(!logic::MTLWord<std::string>({{{}, 0}}).satisfies_at(
+	  logic::MTLFormula(logic::AtomicProposition<std::string>("true")), 1));
+	CHECK(!logic::MTLWord<std::string>({{{}, 0}}).satisfies_at(
+	  logic::MTLFormula(logic::AtomicProposition<std::string>("false")), 0));
+}
+
 TEST_CASE("Dual until", "[libmtl]")
 {
 	logic::AtomicProposition<std::string> a{"a"};

--- a/test/test_mtlFormula.cpp
+++ b/test/test_mtlFormula.cpp
@@ -25,6 +25,20 @@
 
 namespace {
 
+TEST_CASE("Word boundaries", "[libmtl]")
+{
+	logic::AtomicProposition<std::string> a{"a"};
+	{
+		logic::MTLWord<std::string> word{};
+		CHECK(!word.satisfies_at(a, 0));
+	}
+	{
+		logic::MTLWord<std::string> word{{{{a}, 0}}};
+		CHECK(word.satisfies_at(a, 0));
+		CHECK(!word.satisfies_at(a, 1));
+	}
+}
+
 TEST_CASE("Construction & simple satisfaction", "[libmtl]")
 {
 	logic::AtomicProposition<std::string> a{"a"};

--- a/test/test_mtlFormula.cpp
+++ b/test/test_mtlFormula.cpp
@@ -141,6 +141,7 @@ TEST_CASE("To positive normal form", "[libmtl]")
 	REQUIRE(land.to_positive_normal_form() == land);
 	REQUIRE(lor.to_positive_normal_form() == lor);
 	REQUIRE(nland.to_positive_normal_form() == (na || nb));
+	REQUIRE((!nland).to_positive_normal_form() == (a && b));
 	REQUIRE(nlor.to_positive_normal_form() == (na && nb));
 	REQUIRE(((!until).to_positive_normal_form()) == na.dual_until(nb));
 	REQUIRE(((!dual_until).to_positive_normal_form()) == na.until(nb));

--- a/test/test_mtlFormula.cpp
+++ b/test/test_mtlFormula.cpp
@@ -153,16 +153,22 @@ TEST_CASE("Comparison operators", "[libmtl]")
 	logic::MTLFormula phi2{b};
 	logic::MTLFormula phi3 = phi1 && phi2;
 	logic::MTLFormula phi4 = phi1.until(phi2, {1, 4});
+	logic::MTLFormula phi5{c};
 
-	REQUIRE(a == a);
-	REQUIRE(a != b);
-	REQUIRE(a < b);
+	CHECK(a == a);
+	CHECK(a != b);
+	CHECK(a < b);
 
-	REQUIRE(phi1 == phi1);
-	REQUIRE(phi1 != phi2);
-	REQUIRE(phi1 < phi2);
-	REQUIRE(phi4 != phi1);
-	REQUIRE(phi1 > phi4);
+	CHECK(phi1 == phi1);
+	CHECK(phi1 != phi2);
+	CHECK(phi1 < phi2);
+	CHECK(phi1 <= phi2);
+	CHECK(!(phi2 <= phi1));
+	CHECK(!(phi1 >= phi2));
+	CHECK(phi2 >= phi1);
+	CHECK(phi4 != phi1);
+	CHECK(phi1 > phi4);
+	CHECK(phi3 < (phi1 && phi5));
 }
 
 TEST_CASE("Get subformulas of type", "[libmtl]")

--- a/test/test_mtl_ata_translation.cpp
+++ b/test/test_mtl_ata_translation.cpp
@@ -48,6 +48,11 @@ TEST_CASE("ATA satisfiability of simple MTL formulas", "[translator]")
 		INFO("ATA:\n" << ata);
 		CHECK(ata.accepts_word({{"a", 0}, {"a", 1}, {"b", 2.5}}));
 		CHECK(ata.accepts_word({{"a", 0}, {"a", 1}, {"b", 1.5}}));
+		CHECK(!ata.accepts_word({{"c", 0}, {"b", 1.5}}));
+		CHECK(ata.accepts_word({{"a", 0}, {"b", 1.5}}));
+		CHECK(!ata.accepts_word({{"b", 0}}));
+		CHECK(ata.accepts_word({{"b", 0}, {"b", 0}}));
+		CHECK(ata.accepts_word({{"b", 0}, {"b", 1}}));
 	}
 
 	SECTION("An until formula with time bounds")

--- a/test/test_mtl_ata_translation.cpp
+++ b/test/test_mtl_ata_translation.cpp
@@ -20,23 +20,191 @@
 
 #include "mtl/MTLFormula.h"
 #include "mtl_ata_translation/translator.h"
+#include "utilities/Interval.h"
 
 #include <catch2/catch.hpp>
+#include <stdexcept>
 
 namespace {
 
-using logic::AtomicProposition;
 using logic::MTLFormula;
 using logic::TimeInterval;
+using mtl_ata_translation::translate;
+using utilities::arithmetic::BoundType;
 
-TEST_CASE("ATA satisfiability of a simple MTL formula", "[translator]")
+using AP = logic::AtomicProposition<std::string>;
+
+TEST_CASE("ATA satisfiability of simple MTL formulas", "[translator]")
 {
-	const AtomicProposition<std::string> a{"a"};
-	const AtomicProposition<std::string> b{"b"};
-	const MTLFormula phi = (MTLFormula{a} || MTLFormula{b}).until(MTLFormula{b}, TimeInterval(2, 3));
-	const auto       ata = mtl_ata_translation::translate(phi);
-	REQUIRE(ata.accepts_word({{"a", 0}, {"b", 2.5}}));
-	REQUIRE(!ata.accepts_word({{"a", 0}, {"b", 1.5}}));
+	const MTLFormula a{AP{"a"}};
+	const MTLFormula b{AP{"b"}};
+	const MTLFormula c{AP{"c"}};
+	const MTLFormula d{AP{"d"}};
+
+	SECTION("A simple until formula")
+	{
+		const MTLFormula phi = a.until(b);
+		const auto       ata = translate(phi);
+		INFO("ATA:\n" << ata);
+		CHECK(ata.accepts_word({{"a", 0}, {"a", 1}, {"b", 2.5}}));
+		CHECK(ata.accepts_word({{"a", 0}, {"a", 1}, {"b", 1.5}}));
+	}
+
+	SECTION("An until formula with time bounds")
+	{
+		const MTLFormula phi = a.until(b, TimeInterval(2, 3));
+		const auto       ata = translate(phi);
+		INFO("ATA:\n" << ata);
+		CHECK(ata.accepts_word({{"a", 0}, {"a", 0.5}, {"b", 2}}));
+		CHECK(ata.accepts_word({{"a", 0}, {"a", 1}, {"b", 3}}));
+		CHECK(ata.accepts_word({{"a", 0}, {"a", 2.9}, {"b", 3}}));
+		CHECK(!ata.accepts_word({{"a", 0}, {"a", 1}, {"b", 3.1}}));
+		CHECK(!ata.accepts_word({{"a", 0}, {"a", 5}, {"b", 7}}));
+		CHECK(!ata.accepts_word({{"a", 0}, {"a", 0.1}, {"b", 1.9}}));
+	}
+
+	SECTION("An until formula with strict lower time bound")
+	{
+		const MTLFormula phi = a.until(b, TimeInterval(2, BoundType::STRICT, 2, BoundType::INFTY));
+		const auto       ata = translate(phi);
+		INFO("ATA:\n" << ata);
+		CHECK(ata.accepts_word({{"a", 0}, {"a", 0.5}, {"b", 2.1}}));
+		CHECK(!ata.accepts_word({{"a", 0}, {"a", 0.5}, {"b", 2}}));
+		CHECK(ata.accepts_word({{"a", 0}, {"a", 0.5}, {"a", 5}, {"a", 10}, {"b", 12}}));
+		CHECK(ata.accepts_word({{"a", 0}, {"b", 12}}));
+		CHECK(ata.accepts_word({{"a", 0}, {"a", 0.1}, {"b", 12}}));
+	}
+
+	SECTION("An until formula with strict upper bound")
+	{
+		const MTLFormula phi = a.until(b, TimeInterval(2, BoundType::WEAK, 3, BoundType::STRICT));
+		const auto       ata = translate(phi);
+		INFO("ATA:\n" << ata);
+		CHECK(ata.accepts_word({{"a", 0}, {"a", 0.5}, {"b", 2}}));
+		CHECK(!ata.accepts_word({{"a", 0}, {"a", 1}, {"b", 3}}));
+	}
+
+	SECTION("An until with a negation")
+	{
+		const MTLFormula phi = (!a).until(b);
+		const auto       ata = translate(phi);
+		INFO("ATA:\n" << ata);
+		// TODO(morxa) this is broken because there is no c in the automaton
+		// CHECK(ata.accepts_word({{"c", 0}, {"c", 1}, {"b", 2.5}}));
+		CHECK(!ata.accepts_word({{"a", 0}, {"a", 1}, {"b", 1.5}}));
+	}
+
+	SECTION("An until with a disjunctive subformula")
+	{
+		const MTLFormula phi = (a || b).until(c);
+		const auto       ata = translate(phi);
+		INFO("ATA:\n" << ata);
+		CHECK(ata.accepts_word({{"a", 0}, {"a", 0.5}, {"c", 1}}));
+		CHECK(ata.accepts_word({{"b", 0}, {"b", 0.5}, {"c", 1}}));
+		CHECK(ata.accepts_word({{"b", 0}, {"a", 0.5}, {"b", 0.8}, {"c", 1}}));
+	}
+
+	SECTION("An until with a conjunctive subformula")
+	{
+		const MTLFormula phi = (a && b).until(c);
+		const auto       ata = translate(phi);
+		INFO("ATA:\n" << ata);
+		CHECK(!ata.accepts_word({{"a", 0}, {"a", 0.5}, {"c", 1}}));
+		CHECK(!ata.accepts_word({{"a", 0}, {"b", 0.5}, {"c", 1}}));
+		CHECK(ata.accepts_word({{"a", 0}, {"c", 0.5}, {"c", 1}}));
+	}
+
+	SECTION("An until with a conjunctive subformula with negations")
+	{
+		const MTLFormula phi = (!a && !b).until(c);
+		const auto       ata = translate(phi);
+		INFO("ATA:\n" << ata);
+		CHECK(!ata.accepts_word({{"a", 0}, {"a", 0.5}, {"c", 1}}));
+		CHECK(!ata.accepts_word({{"a", 0}, {"b", 0.5}, {"c", 1}}));
+		CHECK(ata.accepts_word({{"c", 0}, {"c", 0.5}, {"c", 1}}));
+		// TODO(morxa) this is broken because there is no c in the automaton
+		// CHECK(ata.accepts_word({{"a", 0}, {"d", 0.5}, {"c", 1}}));
+	}
+
+	SECTION("An until with a negation of a non-atomic formula")
+	{
+		const MTLFormula phi = (!(a && b)).until(c);
+		const auto       ata = translate(phi);
+		INFO("ATA:\n" << ata);
+		CHECK(ata.accepts_word({{"a", 0}, {"a", 0.5}, {"c", 1}}));
+		CHECK(ata.accepts_word({{"a", 0}, {"b", 0.5}, {"c", 1}}));
+		CHECK(ata.accepts_word({{"c", 0}, {"c", 0.5}, {"c", 1}}));
+		CHECK(!ata.accepts_word({{"a", 0}, {"a", 0.5}, {"a", 1}}));
+	}
+
+	SECTION("Nested until")
+	{
+		const MTLFormula phi = a.until(b.until(c));
+		const auto       ata = translate(phi);
+		INFO("ATA:\n" << ata);
+		CHECK(ata.accepts_word({{"a", 0}, {"b", 1}, {"c", 3}}));
+		CHECK(!ata.accepts_word({{"a", 0}, {"c", 1}, {"b", 1}}));
+	}
+
+	SECTION("Nested until with time bounds")
+	{
+		const MTLFormula phi = a.until(b.until(c, TimeInterval(1, 2)), TimeInterval(0, 1));
+		const auto       ata = translate(phi);
+		INFO("ATA:\n" << ata);
+		CHECK(ata.accepts_word({{"a", 0}, {"b", 1}, {"c", 3}}));
+		CHECK(!ata.accepts_word({{"a", 0}, {"b", 1}, {"c", 1.5}}));
+	}
+
+	SECTION("Dual until")
+	{
+		const MTLFormula phi = a.dual_until(b);
+		// ~ (~a U ~b)
+		const auto ata = translate(phi);
+		INFO("ATA:\n" << ata);
+		CHECK(ata.accepts_word({{"b", 0}}));
+		CHECK(ata.accepts_word({{"b", 0}, {"b", 1}, {"b", 2}}));
+		CHECK(ata.accepts_word({{"b", 0}, {"b", 1}, {"b", 2}, {"b", 3}}));
+		CHECK(!ata.accepts_word({{"a", 0}, {"b", 1}, {"a", 2}, {"b", 3}}));
+		CHECK(!ata.accepts_word({{"a", 0}, {"b", 1}, {"a", 2}, {"b", 3}, {"a", 4}}));
+	}
+
+	SECTION("Dual until with time bounds")
+	{
+		const MTLFormula phi = a.dual_until(b, TimeInterval(2, 3));
+		// ~ (~a U ~b)
+		const auto ata = translate(phi);
+		INFO("ATA:\n" << ata);
+		CHECK(ata.accepts_word({{"b", 0}, {"b", 1}, {"b", 3.0}, {"b", 4}}));
+		CHECK(!ata.accepts_word({{"a", 0}, {"b", 1}, {"a", 3.0}, {"b", 4}}));
+		CHECK(ata.accepts_word({{"a", 0}, {"b", 1}, {"a", 3.1}, {"b", 4}}));
+		CHECK(ata.accepts_word({{"a", 0}, {"b", 1}, {"a", 1.9}, {"b", 4}}));
+		CHECK(ata.accepts_word({{"a", 0}, {"b", 1}, {"a", 1.9}, {"a", 2.5}, {"b", 4}}));
+		CHECK(!ata.accepts_word({{"a", 0}, {"b", 1}, {"a", 2.0}, {"b", 4}}));
+		CHECK(!ata.accepts_word({{"a", 0}, {"b", 1}, {"a", 2}, {"b", 3}, {"a", 4}}));
+	}
+
+	SECTION("Dual until with strict time bounds")
+	{
+		const MTLFormula phi =
+		  a.dual_until(b, TimeInterval(2, BoundType::STRICT, 3, BoundType::STRICT));
+		// ~ (~a U ~b)
+		const auto ata = translate(phi);
+		INFO("ATA:\n" << ata);
+		CHECK(ata.accepts_word({{"b", 0}, {"b", 1}, {"b", 3.0}, {"b", 4}}));
+		CHECK(!ata.accepts_word({{"a", 0}, {"b", 1}, {"a", 2.9}, {"b", 4}}));
+		CHECK(ata.accepts_word({{"a", 0}, {"b", 1}, {"a", 3.0}, {"b", 4}}));
+		CHECK(ata.accepts_word({{"a", 0}, {"b", 1}, {"a", 3.1}, {"b", 4}}));
+		CHECK(ata.accepts_word({{"a", 0}, {"b", 1}, {"a", 1.9}, {"b", 4}}));
+		CHECK(ata.accepts_word({{"a", 0}, {"b", 1}, {"a", 1.9}, {"a", 2.5}, {"b", 4}}));
+		CHECK(ata.accepts_word({{"a", 0}, {"b", 1}, {"a", 2.0}, {"b", 4}}));
+		CHECK(!ata.accepts_word({{"a", 0}, {"b", 1}, {"a", 2.1}, {"b", 4}}));
+		CHECK(ata.accepts_word({{"a", 0}, {"b", 1}, {"a", 2}, {"b", 3}, {"a", 4}}));
+	}
+}
+
+TEST_CASE("MTL ATA Translation exceptions", "[translator][exceptions]")
+{
+	CHECK_THROWS_AS(translate(MTLFormula{AP{"phi_i"}}), std::invalid_argument);
 }
 
 } // namespace

--- a/test/test_print_ata.cpp
+++ b/test/test_print_ata.cpp
@@ -34,7 +34,7 @@ using automata::ata::LocationFormula;
 using automata::ata::State;
 using automata::ata::Transition;
 
-TEST_CASE("Print a state", "[ata]")
+TEST_CASE("Print a state", "[print][ata]")
 {
 	{
 		State<std::string> state{"s0", 0};
@@ -63,7 +63,7 @@ TEST_CASE("Print a state", "[ata]")
 	}
 }
 
-TEST_CASE("Print a transition", "[ata]")
+TEST_CASE("Print a transition", "[print][ata]")
 {
 	{
 		Transition<std::string, std::string> t("s0",
@@ -85,7 +85,7 @@ TEST_CASE("Print a transition", "[ata]")
 	}
 }
 
-TEST_CASE("Print a simple ATA", "[ata]")
+TEST_CASE("Print a simple ATA", "[print][ata]")
 {
 	std::set<Transition<std::string, std::string>> transitions;
 	transitions.insert(Transition<std::string, std::string>(
@@ -104,7 +104,7 @@ TEST_CASE("Print a simple ATA", "[ata]")
 	           u8"  s0 → b → s1");
 }
 
-TEST_CASE("Print a run", "[ata]")
+TEST_CASE("Print a run", "[print][ata]")
 {
 	std::set<Transition<std::string, std::string>> transitions;
 	transitions.insert(Transition<std::string, std::string>(
@@ -133,7 +133,7 @@ TEST_CASE("Print a run", "[ata]")
 	}
 }
 
-TEST_CASE("Print a run with multiple possible configurations", "[ata]")
+TEST_CASE("Print a run with multiple possible configurations", "[print][ata]")
 {
 	std::set<Transition<std::string, std::string>> transitions;
 	transitions.insert(

--- a/test/test_print_ata_formula.cpp
+++ b/test/test_print_ata_formula.cpp
@@ -31,7 +31,7 @@ namespace {
 
 using namespace automata::ata;
 
-TEST_CASE("Print a TrueFormula", "[ata_formula]")
+TEST_CASE("Print a TrueFormula", "[print][ata_formula]")
 {
 	TrueFormula<std::string> f{};
 	std::stringstream        s;
@@ -39,7 +39,7 @@ TEST_CASE("Print a TrueFormula", "[ata_formula]")
 	REQUIRE(s.str() == u8"⊤");
 }
 
-TEST_CASE("Print a FalseFormula", "[ata_formula]")
+TEST_CASE("Print a FalseFormula", "[print][ata_formula]")
 {
 	FalseFormula<std::string> f{};
 	std::stringstream         s;
@@ -47,7 +47,7 @@ TEST_CASE("Print a FalseFormula", "[ata_formula]")
 	REQUIRE(s.str() == u8"⊥");
 }
 
-TEST_CASE("Print a location formula", "[ata_formula]")
+TEST_CASE("Print a location formula", "[print][ata_formula]")
 {
 	{
 		LocationFormula<std::string> f{"s0"};
@@ -63,7 +63,7 @@ TEST_CASE("Print a location formula", "[ata_formula]")
 	}
 }
 
-TEST_CASE("Print a clock constraint formula", "[ata_formula]")
+TEST_CASE("Print a clock constraint formula", "[print][ata_formula]")
 {
 	{
 		ClockConstraintFormula<std::string> f(
@@ -109,7 +109,7 @@ TEST_CASE("Print a clock constraint formula", "[ata_formula]")
 	}
 }
 
-TEST_CASE("Print a conjunction formula", "[ata_formula]")
+TEST_CASE("Print a conjunction formula", "[print][ata_formula]")
 {
 	// A simple conjunction
 	{
@@ -141,7 +141,7 @@ TEST_CASE("Print a conjunction formula", "[ata_formula]")
 	}
 }
 
-TEST_CASE("Print a disjunction formula", "[ata_formula]")
+TEST_CASE("Print a disjunction formula", "[print][ata_formula]")
 {
 	// A simple disjunction
 	{
@@ -163,7 +163,7 @@ TEST_CASE("Print a disjunction formula", "[ata_formula]")
 	}
 }
 
-TEST_CASE("Print a ResetClockFormula", "[ata_formula]")
+TEST_CASE("Print a ResetClockFormula", "[print][ata_formula]")
 {
 	{
 		ResetClockFormula<std::string> f{std::make_unique<LocationFormula<std::string>>("s0")};

--- a/test/test_print_mtl_formula.cpp
+++ b/test/test_print_mtl_formula.cpp
@@ -1,0 +1,77 @@
+/***************************************************************************
+ *  test_print_mtl_formula.cpp - Test MTL Formula to string conversion
+ *
+ *  Created:   Mon 25 Jan 14:36:46 CET 2021
+ *  Copyright  2021  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ ****************************************************************************/
+/*  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Library General Public License for more details.
+ *
+ *  Read the full text in the LICENSE.md file.
+ */
+
+#include "mtl/MTLFormula.h"
+
+#include <catch2/catch.hpp>
+#include <sstream>
+
+namespace {
+
+using Formula = logic::MTLFormula<std::string>;
+using AP      = logic::AtomicProposition<std::string>;
+using logic::TimeInterval;
+
+TEST_CASE("Print MTL formulas", "[print][mtl]")
+{
+	{
+		std::stringstream s;
+		s << Formula{AP{"a"}};
+		CHECK(s.str() == "a");
+	}
+	{
+		std::stringstream s;
+		s << Formula(AP("a long atomic proposition"));
+		CHECK(s.str() == "a long atomic proposition");
+	}
+	{
+		std::stringstream s;
+		s << (Formula{AP{"a"}} && Formula{AP{"b"}});
+		CHECK(s.str() == "(a && b)");
+	}
+	{
+		std::stringstream s;
+		s << (Formula{AP{"a"}} || Formula{AP{"b"}});
+		CHECK(s.str() == "(a || b)");
+	}
+	{
+		std::stringstream s;
+		s << (Formula(AP{"a"}).until(Formula{AP{"b"}}));
+		CHECK(s.str() == "(a U b)");
+	}
+	{
+		std::stringstream s;
+		// TODO we should actually print the interval
+		s << (Formula(AP{"a"}).until(Formula{AP{"b"}}, TimeInterval(1, 2)));
+		CHECK(s.str() == "(a U b)");
+	}
+	{
+		std::stringstream s;
+		s << (Formula(AP{"a"}).dual_until(Formula{AP{"b"}}));
+		CHECK(s.str() == "(a ~U b)");
+	}
+	{
+		std::stringstream s;
+		// TODO we should actually print the interval
+		s << (Formula(AP{"a"}).dual_until(Formula{AP{"b"}}, TimeInterval(1, 2)));
+		CHECK(s.str() == "(a ~U b)");
+	}
+}
+
+} // namespace


### PR DESCRIPTION
Add test cases to maximize code coverage. Those new test cases also revealed two bugs:
1. Fix an off-by-one error in MTL satisfaction check
2. Fix the MTL ATA translation for dual untils, which had conjunctions and disjunctions switched around

