### PR TITLE
Implement unfolding of the search tree DT~ 

### DIFF
--- a/src/automata/include/automata/ata.h
+++ b/src/automata/include/automata/ata.h
@@ -287,6 +287,18 @@ public:
 		}
 		return res;
 	}
+
+	/** Check if the given configuration is accepting.
+	 * @param configuration The configuration to check
+	 * @return true if the configuration is an accepting configuration of the ATA
+	 */
+	[[nodiscard]] bool
+	is_accepting_configuration(const Configuration<LocationT> &configuration) const
+	{
+		return std::all_of(configuration.begin(), configuration.end(), [this](auto const &state) {
+			return final_locations_.count(state.first) > 0;
+		});
+	}
 	/** Check if the ATA accepts a timed word.
 	 * @param word The timed word to check
 	 * @return true if the given word is accepted
@@ -321,11 +333,7 @@ public:
 			// ... where the final configuration ...
 			auto final_configuration = run.back().second;
 			// ... only consists of accepting locations.
-			return std::all_of(final_configuration.begin(),
-			                   final_configuration.end(),
-			                   [this](auto const &state) {
-				                   return final_locations_.count(state.first) > 0;
-			                   });
+			return is_accepting_configuration(final_configuration);
 		});
 	}
 

--- a/src/automata/include/automata/ta.h
+++ b/src/automata/include/automata/ta.h
@@ -419,6 +419,16 @@ public:
 		return std::make_pair(initial_location_, clock_valuations);
 	}
 
+	/** Check if the given configuration is an accepting configuration of this automaton
+	 * @param configuration The configuration to check
+	 * @return true if the given configuration is an accepting configuration
+	 */
+	[[nodiscard]] bool
+	is_accepting_configuration(const Configuration<LocationT> &configuration) const
+	{
+		return (final_locations_.find(configuration.first) != final_locations_.end());
+	}
+
 private:
 	std::set<AP>                                        alphabet_;
 	std::set<LocationT>                                 locations_;

--- a/src/automata/include/automata/ta.h
+++ b/src/automata/include/automata/ta.h
@@ -406,6 +406,19 @@ public:
 		return res;
 	}
 
+	/** Get the initial configuration of the automaton.
+	 * @return The initial configuration
+	 */
+	Configuration<LocationT>
+	get_initial_configuration() const
+	{
+		ClockSetValuation clock_valuations;
+		for (const auto &clock_name : clocks_) {
+			clock_valuations[clock_name] = 0;
+		}
+		return std::make_pair(initial_location_, clock_valuations);
+	}
+
 private:
 	std::set<AP>                                        alphabet_;
 	std::set<LocationT>                                 locations_;

--- a/src/synchronous_product/include/synchronous_product/operators.h
+++ b/src/synchronous_product/include/synchronous_product/operators.h
@@ -1,0 +1,65 @@
+/***************************************************************************
+ *  operators.h - Operators for relations between words
+ *
+ *  Created:   Mon  8 Feb 14:01:53 CET 2021
+ *  Copyright  2021  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ ****************************************************************************/
+/*  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Library General Public License for more details.
+ *
+ *  Read the full text in the LICENSE.md file.
+ */
+
+#pragma once
+#include "synchronous_product.h"
+
+#include <bits/c++config.h>
+
+#include <algorithm>
+
+namespace synchronous_product {
+
+/**
+ * @brief Checks if the word w1 is monotonically dominated by w2.
+ *
+ * @tparam LocationT
+ * @tparam ActionT
+ * @param w1 The word which may be dominated.
+ * @param w2 The potentially dominating word.
+ * @return true if w2 dominates w1.
+ * @return false otherwise.
+ */
+template <typename LocationT, typename ActionT>
+bool
+is_monotonically_dominated(const CanonicalABWord<LocationT, ActionT> &w1,
+                           const CanonicalABWord<LocationT, ActionT> &w2)
+{
+	// required to guarantee global monotonicity in w2
+	std::size_t next_w2_idx = 0;
+	// iterate over all sets in w1
+	for (std::size_t w1_idx = 0; w1_idx < w1.size(); ++w1_idx) {
+		bool found = false;
+		// find matching set in w2, keep track of monotonicity via initialization of w2_idx
+		for (std::size_t w2_idx = next_w2_idx; w2_idx < w2.size(); ++w2_idx) {
+			if (std::includes(
+			      w2[w2_idx].begin(), w2[w2_idx].end(), w1[w1_idx].begin(), w1[w1_idx].end())) {
+				next_w2_idx = w2_idx + 1;
+				found       = true;
+				break;
+			}
+		}
+		if (!found) {
+			return false;
+		}
+	}
+	return true;
+}
+
+} // namespace synchronous_product

--- a/src/synchronous_product/include/synchronous_product/operators.h
+++ b/src/synchronous_product/include/synchronous_product/operators.h
@@ -62,4 +62,27 @@ is_monotonically_dominated(const CanonicalABWord<LocationT, ActionT> &w1,
 	return true;
 }
 
+/**
+ * @brief Checks if each word of the first set is monotonically dominated by some word in the second
+ * set.
+ *
+ * @tparam LocationT
+ * @tparam ActionT
+ * @param set1 First set of canonical words which is to be dominated.
+ * @param set2 Second set of canonical words which should dominate the first set.
+ * @return true if all words in the first set are dominated by some word in the second set.
+ * @return false otherwise.
+ */
+template <typename LocationT, typename ActionT>
+bool
+is_monotonically_dominated(const std::set<CanonicalABWord<LocationT, ActionT>> &set1,
+                           const std::set<CanonicalABWord<LocationT, ActionT>> &set2)
+{
+	return std::all_of(set1.begin(), set1.end(), [&set2](const auto &word1) {
+		return std::any_of(set2.begin(), set2.end(), [&word1](const auto &word2) {
+			return is_monotonically_dominated(word1, word2);
+		});
+	});
+}
+
 } // namespace synchronous_product

--- a/src/synchronous_product/include/synchronous_product/reg_a.h
+++ b/src/synchronous_product/include/synchronous_product/reg_a.h
@@ -1,0 +1,54 @@
+/***************************************************************************
+ *  reg_a.h - Definition of the function reg_a(w)
+ *
+ *  Created:   Fri  5 Feb 14:25:02 CET 2021
+ *  Copyright  2021  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ ****************************************************************************/
+/*  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Library General Public License for more details.
+ *
+ *  Read the full text in the LICENSE.md file.
+ */
+
+#pragma once
+
+#include "synchronous_product.h"
+
+#include <variant>
+
+namespace synchronous_product {
+
+/** Compute reg_a(w), which is w with all configuration components from B omitted.
+ * The resulting word only contains configurations from the timed automaton A.
+ * @param word The word to compute reg_a(word) of
+ * @return The word reg_a(word), which is the same as word, but without any configurations from the
+ * ATA
+ */
+template <typename Location, typename ActionType>
+CanonicalABWord<Location, ActionType>
+reg_a(const CanonicalABWord<Location, ActionType> &word)
+{
+	CanonicalABWord<Location, ActionType> res;
+	for (const auto &partition : word) {
+		std::set<ABRegionSymbol<Location, ActionType>> res_i;
+		for (const auto &ab_symbol : partition) {
+			if (std::holds_alternative<TARegionState<Location>>(ab_symbol)) {
+				res_i.insert(ab_symbol);
+			}
+		}
+		// TODO check if we can just skip the whole partition
+		if (!res_i.empty()) {
+			res.push_back(res_i);
+		}
+	}
+	return res;
+}
+
+} // namespace synchronous_product

--- a/src/synchronous_product/include/synchronous_product/search.h
+++ b/src/synchronous_product/include/synchronous_product/search.h
@@ -70,10 +70,11 @@ public:
 	 * @return true if the node is bad
 	 */
 	bool
-	is_bad_node(__attribute__((unused)) Node *node) const
+	is_bad_node(Node *node) const
 	{
-		// TODO implement
-		return false;
+		const auto candidate = get_candidate(node->word);
+		return ta_->is_accepting_configuration(candidate.first)
+		       && ata_->is_accepting_configuration(candidate.second);
 	}
 
 	/** Check if there is an ancestor that monotonally dominates the given node

--- a/src/synchronous_product/include/synchronous_product/search.h
+++ b/src/synchronous_product/include/synchronous_product/search.h
@@ -96,7 +96,7 @@ public:
 		if (queue_.empty()) {
 			return false;
 		}
-		Node *current = queue_.top();
+		Node *current = queue_.front();
 		queue_.pop();
 		if (is_bad_node(current)) {
 			current->state = NodeState::BAD;
@@ -123,9 +123,9 @@ private:
 	automata::ata::AlternatingTimedAutomaton<logic::MTLFormula<ActionType>,
 	                                         logic::AtomicProposition<ActionType>> *ata_;
 
-	std::unique_ptr<Node>       tree_root_;
-	std::priority_queue<Node *> queue_;
-	RegionIndex                 K_;
+	std::unique_ptr<Node> tree_root_;
+	std::queue<Node *>    queue_;
+	RegionIndex           K_;
 };
 
 } // namespace synchronous_product

--- a/src/synchronous_product/include/synchronous_product/search.h
+++ b/src/synchronous_product/include/synchronous_product/search.h
@@ -53,6 +53,7 @@ public:
 	  K_(K)
 	{
 		queue_.push(tree_root_.get());
+		assert(queue_.size() == 1);
 	}
 
 	/** Get the root of the search tree.
@@ -98,6 +99,7 @@ public:
 		}
 		Node *current = queue_.front();
 		queue_.pop();
+		std::cout << "Processing " << current << ": " << *current;
 		if (is_bad_node(current)) {
 			current->state = NodeState::BAD;
 			return true;
@@ -109,8 +111,9 @@ public:
 		assert(current->children.empty());
 		for (const auto &word : get_next_canonical_words(*ta_, *ata_, current->word, K_)) {
 			auto child = std::make_unique<Node>(word, current);
-			queue_.push(child.get());
+			std::cout << "New child " << child.get() << ": " << *child;
 			current->children.push_back(std::move(child));
+			queue_.push(current->children.back().get());
 		}
 		if (current->children.empty()) {
 			current->state = NodeState::DEAD;

--- a/src/synchronous_product/include/synchronous_product/search.h
+++ b/src/synchronous_product/include/synchronous_product/search.h
@@ -1,0 +1,76 @@
+/***************************************************************************
+ *  search.h - Construct the search tree over ABConfigurations
+ *
+ *  Created:   Mon  1 Feb 16:21:53 CET 2021
+ *  Copyright  2021  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ ****************************************************************************/
+/*  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Library General Public License for more details.
+ *
+ *  Read the full text in the LICENSE.md file.
+ */
+
+#pragma once
+
+#include "automata/ata.h"
+#include "automata/ta.h"
+#include "mtl/MTLFormula.h"
+#include "search_tree.h"
+#include "synchronous_product.h"
+
+#include <memory>
+#include <queue>
+
+namespace synchronous_product {
+
+/** Search the configuration tree for a valid controller. */
+template <typename Location, typename ActionType>
+class TreeSearch
+{
+	using Node = SearchTreeNode<Location, ActionType>;
+
+public:
+	/** Initialize the search.
+	 * @param ta The plant to be controlled
+	 * @param ata The specification of undesired behaviors
+	 * @param K The maximal constant occurring in a clock constraint
+	 */
+	TreeSearch(automata::ta::TimedAutomaton<Location, ActionType> *                            ta,
+	           automata::ata::AlternatingTimedAutomaton<logic::MTLFormula<ActionType>,
+	                                                    logic::AtomicProposition<ActionType>> *ata,
+	           RegionIndex                                                                     K)
+	: ta_(ta),
+	  ata_(ata),
+	  tree_root_(std::make_unique<Node>(
+	    get_canonical_word(ta->get_initial_configuration(), ata->get_initial_configuration(), K)))
+	{
+		queue_.push(tree_root_.get());
+	}
+
+	/** Get the root of the search tree.
+	 * @return A pointer to the root, only valid as long as the TreeSearch object has not been
+	 * destroyed
+	 */
+	Node *
+	get_root() const
+	{
+		return tree_root_.get();
+	}
+
+private:
+	automata::ta::TimedAutomaton<Location, ActionType> *                            ta_;
+	automata::ata::AlternatingTimedAutomaton<logic::MTLFormula<ActionType>,
+	                                         logic::AtomicProposition<ActionType>> *ata_;
+
+	std::unique_ptr<Node>       tree_root_;
+	std::priority_queue<Node *> queue_;
+};
+
+} // namespace synchronous_product

--- a/src/synchronous_product/include/synchronous_product/search.h
+++ b/src/synchronous_product/include/synchronous_product/search.h
@@ -22,6 +22,7 @@
 #include "automata/ata.h"
 #include "automata/ta.h"
 #include "mtl/MTLFormula.h"
+#include "operators.h"
 #include "reg_a.h"
 #include "search_tree.h"
 #include "synchronous_product.h"
@@ -86,9 +87,15 @@ public:
 	 * @param node The node to check
 	 */
 	bool
-	is_monotonically_dominated(__attribute__((unused)) Node *node) const
+	is_monotonically_dominated_by_ancestor(Node *node) const
 	{
-		// TODO implement
+		const Node *ancestor = node->parent;
+		while (ancestor != nullptr) {
+			if (is_monotonically_dominated(node->words, ancestor->words)) {
+				return true;
+			}
+			ancestor = ancestor->parent;
+		}
 		return false;
 	}
 
@@ -108,7 +115,7 @@ public:
 			current->state = NodeState::BAD;
 			return true;
 		}
-		if (is_monotonically_dominated(current)) {
+		if (is_monotonically_dominated_by_ancestor(current)) {
 			current->state = NodeState::GOOD;
 			return true;
 		}

--- a/src/synchronous_product/include/synchronous_product/search_tree.h
+++ b/src/synchronous_product/include/synchronous_product/search_tree.h
@@ -39,23 +39,27 @@ template <typename Location, typename ActionType>
 struct SearchTreeNode
 {
 	/** Construct a node.
-	 * @param word The CanonicalABWord of the node
+	 * @param words The CanonicalABWords of the node (being of the same reg_a class)
 	 * @param parent The parent of this node, nullptr is this is the root
 	 */
-	SearchTreeNode(const CanonicalABWord<Location, ActionType> &word,
-	               SearchTreeNode *                             parent = nullptr)
-	: word(word), parent(parent)
+	SearchTreeNode(const std::set<CanonicalABWord<Location, ActionType>> &words,
+	               SearchTreeNode *                                       parent = nullptr)
+	: words(words), parent(parent)
 	{
+		assert(std::all_of(std::begin(words), std::end(words), [&words](const auto &word) {
+			return words.empty() || reg_a(*std::begin(words)) == reg_a(word);
+		}));
 	}
-	/** The word of the node */
-	CanonicalABWord<Location, ActionType> word;
+	/** The words of the node */
+	std::set<CanonicalABWord<Location, ActionType>> words;
 	/** The state of the node */
 	NodeState state = NodeState::UNKNOWN;
 	/** The parent of the node, this node was directly reached from the parent */
 	SearchTreeNode *parent = nullptr;
 	/** A list of the children of the node, which are reachable by a single transition */
-	std::vector<std::unique_ptr<SearchTreeNode>> children =
-	  {}; // TODO change container to set to avoid duplicates (also better performance)
+	// TODO change container with custom comparator to set to avoid duplicates (also better
+	// performance)
+	std::vector<std::unique_ptr<SearchTreeNode>> children = {};
 };
 
 } // namespace synchronous_product
@@ -70,7 +74,7 @@ print_to_ostream(std::ostream &                                                 
 	for (unsigned int i = 0; i < indent; i++) {
 		os << " ";
 	}
-	os << node.word << ": ";
+	os << node.words << ": ";
 	switch (node.state) {
 	case NodeState::UNKNOWN: os << "UNKNOWN"; break;
 	case NodeState::GOOD: os << "GOOD"; break;

--- a/src/synchronous_product/include/synchronous_product/search_tree.h
+++ b/src/synchronous_product/include/synchronous_product/search_tree.h
@@ -59,6 +59,29 @@ struct SearchTreeNode
 
 } // namespace synchronous_product
 
+template <typename Location, typename ActionType>
+void
+print_to_ostream(std::ostream &                                                   os,
+                 const synchronous_product::SearchTreeNode<Location, ActionType> &node,
+                 unsigned int                                                     indent = 0)
+{
+	using synchronous_product::NodeState;
+	for (unsigned int i = 0; i < indent; i++) {
+		os << " ";
+	}
+	os << node.word << ": ";
+	switch (node.state) {
+	case NodeState::UNKNOWN: os << "UNKNOWN"; break;
+	case NodeState::GOOD: os << "GOOD"; break;
+	case NodeState::BAD: os << "BAD"; break;
+	case NodeState::DEAD: os << "DEAD"; break;
+	}
+	os << '\n';
+	for (const auto &child : node.children) {
+		print_to_ostream(os, *child, indent + 2);
+	}
+}
+
 /** Print a node
  * @param os The ostream to print to
  * @param node The node to print
@@ -68,14 +91,7 @@ template <typename Location, typename ActionType>
 std::ostream &
 operator<<(std::ostream &os, const synchronous_product::SearchTreeNode<Location, ActionType> &node)
 {
-	using synchronous_product::NodeState;
-	os << node.word << ": ";
-	switch (node.state) {
-	case NodeState::UNKNOWN: os << "UNKNOWN"; break;
-	case NodeState::GOOD: os << "GOOD"; break;
-	case NodeState::BAD: os << "BAD"; break;
-	case NodeState::DEAD: os << "DEAD"; break;
-	}
+	print_to_ostream(os, node);
 	return os;
 }
 
@@ -92,7 +108,7 @@ operator<<(
     &nodes)
 {
 	for (const auto &node : nodes) {
-		os << *node << '\n';
+		os << *node;
 	}
 	return os;
 }

--- a/src/synchronous_product/include/synchronous_product/search_tree.h
+++ b/src/synchronous_product/include/synchronous_product/search_tree.h
@@ -1,0 +1,56 @@
+/***************************************************************************
+ *  search_tree.h - Search tree data structure for the AB search tree
+ *
+ *  Created:   Mon  1 Feb 15:58:24 CET 2021
+ *  Copyright  2021  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ ****************************************************************************/
+/*  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Library General Public License for more details.
+ *
+ *  Read the full text in the LICENSE.md file.
+ */
+
+#pragma once
+
+#include "synchronous_product.h"
+
+#include <memory>
+
+namespace synchronous_product {
+
+/** The state of the search node */
+enum class NodeState {
+	UNKNOWN, /**< The node is not explored yet */
+	GOOD,    /**< No undesired behavior is possible */
+	BAD,     /**< Undesired behavior, i.e., the specification is violated */
+};
+
+/** A node in the search tree
+ * @see TreeSearch */
+template <typename Location, typename ActionType>
+struct SearchTreeNode
+{
+	/** Construct a node.
+	 * @param word The CanonicalABWord of the node
+	 */
+	SearchTreeNode(const CanonicalABWord<Location, ActionType> &word) : word(word)
+	{
+	}
+	/** The word of the node */
+	CanonicalABWord<Location, ActionType> word;
+	/** The state of the node */
+	NodeState state = NodeState::UNKNOWN;
+	/** The parent of the node, this node was directly reached from the parent */
+	SearchTreeNode *parent = nullptr;
+	/** A list of the children of the node, which are reachable by a single transition */
+	std::vector<std::unique_ptr<SearchTreeNode>> children = {};
+};
+
+} // namespace synchronous_product

--- a/src/synchronous_product/include/synchronous_product/search_tree.h
+++ b/src/synchronous_product/include/synchronous_product/search_tree.h
@@ -30,6 +30,7 @@ enum class NodeState {
 	UNKNOWN, /**< The node is not explored yet */
 	GOOD,    /**< No undesired behavior is possible */
 	BAD,     /**< Undesired behavior, i.e., the specification is violated */
+	DEAD,    /**< The node does not have any successors */
 };
 
 /** A node in the search tree
@@ -39,8 +40,11 @@ struct SearchTreeNode
 {
 	/** Construct a node.
 	 * @param word The CanonicalABWord of the node
+	 * @param parent The parent of this node, nullptr is this is the root
 	 */
-	SearchTreeNode(const CanonicalABWord<Location, ActionType> &word) : word(word)
+	SearchTreeNode(const CanonicalABWord<Location, ActionType> &word,
+	               SearchTreeNode *                             parent = nullptr)
+	: word(word), parent(parent)
 	{
 	}
 	/** The word of the node */
@@ -54,3 +58,41 @@ struct SearchTreeNode
 };
 
 } // namespace synchronous_product
+
+/** Print a node
+ * @param os The ostream to print to
+ * @param node The node to print
+ * @return A reference to the ostream
+ */
+template <typename Location, typename ActionType>
+std::ostream &
+operator<<(std::ostream &os, const synchronous_product::SearchTreeNode<Location, ActionType> &node)
+{
+	using synchronous_product::NodeState;
+	os << node.word << ": ";
+	switch (node.state) {
+	case NodeState::UNKNOWN: os << "UNKNOWN"; break;
+	case NodeState::GOOD: os << "GOOD"; break;
+	case NodeState::BAD: os << "BAD"; break;
+	case NodeState::DEAD: os << "DEAD"; break;
+	}
+	return os;
+}
+
+/** Print a vector of node pointers
+ * @param os The ostream to print to
+ * @param nodes The node pointers to print
+ * @return A reference to the ostream
+ */
+template <typename Location, typename ActionType>
+std::ostream &
+operator<<(
+  std::ostream &os,
+  const std::vector<std::unique_ptr<synchronous_product::SearchTreeNode<Location, ActionType>>>
+    &nodes)
+{
+	for (const auto &node : nodes) {
+		os << *node << '\n';
+	}
+	return os;
+}

--- a/src/synchronous_product/include/synchronous_product/search_tree.h
+++ b/src/synchronous_product/include/synchronous_product/search_tree.h
@@ -54,7 +54,8 @@ struct SearchTreeNode
 	/** The parent of the node, this node was directly reached from the parent */
 	SearchTreeNode *parent = nullptr;
 	/** A list of the children of the node, which are reachable by a single transition */
-	std::vector<std::unique_ptr<SearchTreeNode>> children = {};
+	std::vector<std::unique_ptr<SearchTreeNode>> children =
+	  {}; // TODO change container to set to avoid duplicates (also better performance)
 };
 
 } // namespace synchronous_product

--- a/src/synchronous_product/include/synchronous_product/synchronous_product.h
+++ b/src/synchronous_product/include/synchronous_product/synchronous_product.h
@@ -585,18 +585,39 @@ operator<<(std::ostream &                                                       
 		os << "{}";
 		return os;
 	}
-	os << "{ " << '\n';
-	// bool first = true;
+	os << "{ ";
+	bool first = true;
 	for (const auto &ab_word : ab_words) {
-		/*
 		if (!first) {
-		  os << ", ";
+			os << ", ";
 		} else {
-		  first = false;
+			first = false;
 		}
-		*/
-		os << "  " << ab_word << '\n';
+		os << ab_word;
 	}
-	os << "}";
+	os << " }";
+	return os;
+}
+
+template <typename Location, typename ActionType>
+std::ostream &
+operator<<(std::ostream &                                                              os,
+           const std::set<synchronous_product::CanonicalABWord<Location, ActionType>> &ab_words)
+{
+	if (ab_words.empty()) {
+		os << "{}";
+		return os;
+	}
+	os << "{ ";
+	bool first = true;
+	for (const auto &ab_word : ab_words) {
+		if (!first) {
+			os << ", ";
+		} else {
+			first = false;
+		}
+		os << ab_word;
+	}
+	os << " }";
 	return os;
 }

--- a/src/synchronous_product/include/synchronous_product/synchronous_product.h
+++ b/src/synchronous_product/include/synchronous_product/synchronous_product.h
@@ -428,12 +428,12 @@ get_candidate(const CanonicalABWord<Location, ActionType> &word)
  * @brief Get the next canonical words from the passed word.
  * @details A successor of a regionalized configuration in the regionalized synchronous product is
  * built from a time t >= 0 and a letter a for which there exists both a successor in A and a
- * successor in B. To compute possible successors, we need to individually compute region-successors
- * for A and B for all letters of the alphabet and for all possible time durations/delays. For a
- * single letter a, we need to find a common time interval T for which both in A and B, after
- * letting time t in T pass, a transition labeled with a is enabled. The regionalized product
- * successor is then built from the resulting regions after letting time t pass and taking the
- * transition labeled with a in both automata.
+ * successor in B. To compute possible successors, we need to individually compute
+ * region-successors for A and B for all letters of the alphabet and for all possible time
+ * durations/delays. For a single letter a, we need to find a common time interval T for which
+ * both in A and B, after letting time t in T pass, a transition labeled with a is enabled. The
+ * regionalized product successor is then built from the resulting regions after letting time t
+ * pass and taking the transition labeled with a in both automata.
  * @tparam Location
  * @tparam ActionType
  * @param ta
@@ -454,6 +454,8 @@ get_next_canonical_words(
 	std::vector<CanonicalABWord<Location, ActionType>> res;
 
 	// Compute all time successors
+	// TODO Refactor into a separate function
+	std::cout << "Computing time successors of " << canonical_word << " with K=" << K << '\n';
 	auto                                               cur = get_time_successor(canonical_word, K);
 	std::vector<CanonicalABWord<Location, ActionType>> time_successors;
 	time_successors.push_back(canonical_word);
@@ -462,6 +464,7 @@ get_next_canonical_words(
 		time_successors.emplace_back(cur);
 		prev = time_successors.back();
 		cur  = get_time_successor(prev, K);
+		std::cout << "Next time successor: " << cur << '\n';
 	}
 
 	std::cout << "Time successors: " << time_successors << '\n';

--- a/src/synchronous_product/include/synchronous_product/synchronous_product.h
+++ b/src/synchronous_product/include/synchronous_product/synchronous_product.h
@@ -153,20 +153,22 @@ is_valid_canonical_word(const CanonicalABWord<Location, ActionType> &word)
 	if (std::any_of(word.begin(), word.end(), [](const auto &configurations) {
 		    return configurations.empty();
 	    })) {
-		throw InvalidCanonicalWordException("Word ", word, " contains no configuration");
+		throw InvalidCanonicalWordException("Word ", word, " contains an empty configuration");
 	}
 	// Each partition either contains only even or only odd region indexes. This is because the word
 	// is partitioned by the fractional part and the region index can only be even if the fractional
 	// part is 0. If that is the case, there cannot be any configuration with an odd region index in
 	// the same partition, as that configuration's fractional part would be > 0.
-	std::for_each(word.begin(), word.end(), [](const auto &configurations) {
+	std::for_each(word.begin(), word.end(), [&word](const auto &configurations) {
 		if (std::any_of(configurations.begin(),
 		                configurations.end(),
 		                [](const auto &w) { return get_region_index(w) % 2 == 0; })
 		    && std::any_of(configurations.begin(), configurations.end(), [](const auto &w) {
 			       return get_region_index(w) % 2 == 1;
 		       })) {
-			throw InvalidCanonicalWordException("Inconsistent regions in ",
+			throw InvalidCanonicalWordException("Word ",
+			                                    word,
+			                                    " has inconsistent regions in ",
 			                                    configurations,
 			                                    ": both odd and even region indexes");
 		}

--- a/src/synchronous_product/include/synchronous_product/synchronous_product.h
+++ b/src/synchronous_product/include/synchronous_product/synchronous_product.h
@@ -561,16 +561,18 @@ operator<<(std::ostream &                                                       
 		os << "{}";
 		return os;
 	}
-	os << "{ ";
-	bool first = true;
+	os << "{ " << '\n';
+	// bool first = true;
 	for (const auto &ab_word : ab_words) {
+		/*
 		if (!first) {
-			os << ", ";
+		  os << ", ";
 		} else {
-			first = false;
+		  first = false;
 		}
-		os << ab_word;
+		*/
+		os << "  " << ab_word << '\n';
 	}
-	os << " }";
+	os << "}";
 	return os;
 }

--- a/src/synchronous_product/include/synchronous_product/synchronous_product.h
+++ b/src/synchronous_product/include/synchronous_product/synchronous_product.h
@@ -446,6 +446,8 @@ get_next_canonical_words(
 		cur  = get_time_successor(prev, K);
 	}
 
+	std::cout << "Time successors: " << time_successors << '\n';
+
 	// Intermediate step: Create concrete candidate for each abstract time successor (represented by
 	// the respective canonical word).
 	std::vector<std::pair<TAConfiguration<Location>, ATAConfiguration<ActionType>>>
@@ -469,6 +471,10 @@ get_next_canonical_words(
 			              for (const auto &ta_successor : ta_successors) {
 				              for (const auto &ata_successor : ata_successors) {
 					              res.push_back(get_canonical_word(ta_successor, ata_successor, K));
+					              std::cout << "Getting " << res.back() << " from "
+					                        << "(" << ab_configuration.first << ", "
+					                        << ab_configuration.second << ")"
+					                        << " with symbol " << symbol << '\n';
 				              }
 			              }
 		              }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -38,6 +38,10 @@ add_executable(test_synchronous_product test_synchronous_product.cpp test_synchr
 target_link_libraries(test_synchronous_product PRIVATE mtl_ata_translation synchronous_product Catch2::Catch2)
 catch_discover_tests(test_synchronous_product)
 
+add_executable(test_search test_search.cpp catch2_main.cpp)
+target_link_libraries(test_search PRIVATE mtl_ata_translation synchronous_product Catch2::Catch2)
+catch_discover_tests(test_search)
+
 if (COVERAGE)
   # Depend on all targets in the current directory.
   get_property(test_targets DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -40,6 +40,7 @@ catch_discover_tests(test_synchronous_product)
 
 add_executable(test_search test_search.cpp catch2_main.cpp)
 target_link_libraries(test_search PRIVATE mtl_ata_translation synchronous_product Catch2::Catch2)
+target_compile_options(test_search PRIVATE "-DCATCH_CONFIG_CONSOLE_WIDTH=200")
 catch_discover_tests(test_search)
 
 if (COVERAGE)

--- a/test/test_search.cpp
+++ b/test/test_search.cpp
@@ -37,7 +37,7 @@ using TARegionState   = synchronous_product::TARegionState<std::string>;
 using ATARegionState  = synchronous_product::ATARegionState<std::string>;
 using AP              = logic::AtomicProposition<std::string>;
 
-TEST_CASE("Search initialization", "[search]")
+TEST_CASE("Search in an ABConfiguration tree", "[search]")
 {
 	using automata::AtomicClockConstraintT;
 	using AP = logic::AtomicProposition<std::string>;
@@ -55,12 +55,24 @@ TEST_CASE("Search initialization", "[search]")
 
 	logic::MTLFormula f   = a.until(b, logic::TimeInterval(2, BoundType::WEAK, 2, BoundType::INFTY));
 	auto              ata = mtl_ata_translation::translate(f);
-	TreeSearch        search(&ta, &ata, 5);
-	CHECK(search.get_root()->word
-	      == CanonicalABWord(
-	        {{TARegionState{"l0", "x", 0}, ATARegionState{logic::MTLFormula{AP{"phi_i"}}, 0}}}));
-	CHECK(search.get_root()->state == synchronous_product::NodeState::UNKNOWN);
-	CHECK(search.get_root()->parent == nullptr);
-	CHECK(search.get_root()->children.empty());
+	TreeSearch        search(&ta, &ata, 3);
+
+	SECTION("The search tree is initialized correctly")
+	{
+		CHECK(search.get_root()->word
+		      == CanonicalABWord(
+		        {{TARegionState{"l0", "x", 0}, ATARegionState{logic::MTLFormula{AP{"phi_i"}}, 0}}}));
+		CHECK(search.get_root()->state == synchronous_product::NodeState::UNKNOWN);
+		CHECK(search.get_root()->parent == nullptr);
+		CHECK(search.get_root()->children.empty());
+	}
+
+	SECTION("The next step computes the right children")
+	{
+		search.step();
+		INFO("Children of the root node:\n" << search.get_root()->children);
+		CHECK(search.get_root()->children.size() == 7);
+	}
 }
+
 } // namespace

--- a/test/test_search.cpp
+++ b/test/test_search.cpp
@@ -1,0 +1,66 @@
+/***************************************************************************
+ *  test_search.cpp - Test the main search algorithm
+ *
+ *  Created:   Mon  1 Feb 17:23:48 CET 2021
+ *  Copyright  2021  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ ****************************************************************************/
+/*  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Library General Public License for more details.
+ *
+ *  Read the full text in the LICENSE.md file.
+ */
+
+#include "mtl/MTLFormula.h"
+#include "mtl_ata_translation/translator.h"
+#include "synchronous_product/search.h"
+#include "synchronous_product/search_tree.h"
+#include "synchronous_product/synchronous_product.h"
+
+#include <catch2/catch.hpp>
+
+namespace {
+
+using TreeSearch      = synchronous_product::TreeSearch<std::string, std::string>;
+using TATransition    = automata::ta::Transition<std::string, std::string>;
+using TA              = automata::ta::TimedAutomaton<std::string, std::string>;
+using TAConfiguration = automata::ta::Configuration<std::string>;
+using TreeSearch      = synchronous_product::TreeSearch<std::string, std::string>;
+using CanonicalABWord = synchronous_product::CanonicalABWord<std::string, std::string>;
+using TARegionState   = synchronous_product::TARegionState<std::string>;
+using ATARegionState  = synchronous_product::ATARegionState<std::string>;
+using AP              = logic::AtomicProposition<std::string>;
+
+TEST_CASE("Search initialization", "[search]")
+{
+	using automata::AtomicClockConstraintT;
+	using AP = logic::AtomicProposition<std::string>;
+	using utilities::arithmetic::BoundType;
+	TA ta{{"a", "b", "c"}, "l0", {"l0", "l1", "l2"}};
+	ta.add_clock("x");
+	ta.add_transition(TATransition(
+	  "l0", "a", "l0", {{"x", AtomicClockConstraintT<std::greater<automata::Time>>(1)}}, {"x"}));
+	ta.add_transition(
+	  TATransition("l0", "b", "l1", {{"x", AtomicClockConstraintT<std::less<automata::Time>>(1)}}));
+	ta.add_transition(TATransition("l0", "c", "l2"));
+	ta.add_transition(TATransition("l2", "b", "l1"));
+	logic::MTLFormula<std::string> a{AP("a")};
+	logic::MTLFormula<std::string> b{AP("b")};
+
+	logic::MTLFormula f   = a.until(b, logic::TimeInterval(2, BoundType::WEAK, 2, BoundType::INFTY));
+	auto              ata = mtl_ata_translation::translate(f);
+	TreeSearch        search(&ta, &ata, 5);
+	CHECK(search.get_root()->word
+	      == CanonicalABWord(
+	        {{TARegionState{"l0", "x", 0}, ATARegionState{logic::MTLFormula{AP{"phi_i"}}, 0}}}));
+	CHECK(search.get_root()->state == synchronous_product::NodeState::UNKNOWN);
+	CHECK(search.get_root()->parent == nullptr);
+	CHECK(search.get_root()->children.empty());
+}
+} // namespace

--- a/test/test_search.cpp
+++ b/test/test_search.cpp
@@ -88,7 +88,35 @@ TEST_CASE("Search in an ABConfiguration tree", "[search]")
 	{
 		REQUIRE(search.step());
 		INFO("Tree:\n" << *search.get_root());
-		REQUIRE(!search.get_root()->children[0]->children.empty());
+		// REQUIRE(!search.get_root()->children[0]->children.empty());
+		REQUIRE(search.step());
+		INFO("Tree:\n" << *search.get_root());
+		const auto &children = search.get_root()->children;
+		REQUIRE(children.size() == std::size_t(5));
+		REQUIRE(children[0]->children.empty()); // should be ((l1, x, 0), ((a U b), 0))
+		// the node has no time-symbol successors (only time successors)
+		REQUIRE(children[0]->state == synchronous_product::NodeState::DEAD);
+
+		// perform next step
+		REQUIRE(search.step());
+		INFO("Tree:\n" << *search.get_root());
+		REQUIRE(children[1]->children.empty()); // should be ((l1, x, 1), ((a U b), 1))
+		// the node has no time-symbol successors (only time successors)
+		REQUIRE(children[1]->state == synchronous_product::NodeState::DEAD);
+
+		// perform next step
+		REQUIRE(search.step());
+		INFO("Tree:\n" << *search.get_root());
+		REQUIRE(children[2]->children.size() == 4); // should be ((l0, x, 0) }, { ((a U b), 3)
+		// the node has no time-symbol successors (only time successors)
+		REQUIRE(children[2]->state == synchronous_product::NodeState::UNKNOWN);
+		REQUIRE(children[2]->children[0]->word == CanonicalABWord({{TARegionState{"l1", "x", 1}}}));
+		REQUIRE(children[2]->children[1]->word
+		        == CanonicalABWord({{TARegionState{"l0", "x", 0}}, {ATARegionState{a.until(b), 5}}}));
+		REQUIRE(children[2]->children[2]->word
+		        == CanonicalABWord({{TARegionState{"l0", "x", 0}}, {ATARegionState{a.until(b), 5}}}));
+		REQUIRE(children[2]->children[3]->word
+		        == CanonicalABWord({{TARegionState{"l0", "x", 0}}, {ATARegionState{a.until(b), 5}}}));
 	}
 }
 

--- a/test/test_search.cpp
+++ b/test/test_search.cpp
@@ -55,7 +55,7 @@ TEST_CASE("Search in an ABConfiguration tree", "[search]")
 
 	logic::MTLFormula f   = a.until(b, logic::TimeInterval(2, BoundType::WEAK, 2, BoundType::INFTY));
 	auto              ata = mtl_ata_translation::translate(f);
-	TreeSearch        search(&ta, &ata, 3);
+	TreeSearch        search(&ta, &ata, 2);
 
 	SECTION("The search tree is initialized correctly")
 	{
@@ -70,8 +70,19 @@ TEST_CASE("Search in an ABConfiguration tree", "[search]")
 	SECTION("The next step computes the right children")
 	{
 		search.step();
-		INFO("Children of the root node:\n" << search.get_root()->children);
-		CHECK(search.get_root()->children.size() == 7);
+		const auto &children = search.get_root()->children;
+		INFO("Children of the root node:\n" << children);
+		REQUIRE(children.size() == 5);
+		CHECK(children[0]->word
+		      == CanonicalABWord({{TARegionState{"l1", "x", 0}, ATARegionState{a.until(b), 0}}}));
+		CHECK(children[1]->word
+		      == CanonicalABWord({{TARegionState{"l1", "x", 1}, ATARegionState{a.until(b), 1}}}));
+		CHECK(children[2]->word
+		      == CanonicalABWord({{TARegionState{"l0", "x", 0}}, {ATARegionState{a.until(b), 3}}}));
+		CHECK(children[3]->word
+		      == CanonicalABWord({{TARegionState{"l0", "x", 0}, ATARegionState{a.until(b), 4}}}));
+		CHECK(children[4]->word
+		      == CanonicalABWord({{TARegionState{"l0", "x", 0}}, {ATARegionState{a.until(b), 5}}}));
 	}
 }
 

--- a/test/test_search.cpp
+++ b/test/test_search.cpp
@@ -67,9 +67,9 @@ TEST_CASE("Search in an ABConfiguration tree", "[search]")
 		CHECK(search.get_root()->children.empty());
 	}
 
-	SECTION("The next step computes the right children")
+	SECTION("The first step computes the right children")
 	{
-		search.step();
+		REQUIRE(search.step());
 		const auto &children = search.get_root()->children;
 		INFO("Children of the root node:\n" << children);
 		REQUIRE(children.size() == 5);
@@ -83,6 +83,12 @@ TEST_CASE("Search in an ABConfiguration tree", "[search]")
 		      == CanonicalABWord({{TARegionState{"l0", "x", 0}, ATARegionState{a.until(b), 4}}}));
 		CHECK(children[4]->word
 		      == CanonicalABWord({{TARegionState{"l0", "x", 0}}, {ATARegionState{a.until(b), 5}}}));
+	}
+	SECTION("The second step computes the right children")
+	{
+		REQUIRE(search.step());
+		INFO("Tree:\n" << *search.get_root());
+		REQUIRE(!search.get_root()->children[0]->children.empty());
 	}
 }
 

--- a/test/test_synchronous_product.cpp
+++ b/test/test_synchronous_product.cpp
@@ -24,6 +24,7 @@
 #include "automata/ta_regions.h"
 #include "mtl/MTLFormula.h"
 #include "mtl_ata_translation/translator.h"
+#include "synchronous_product/operators.h"
 #include "synchronous_product/reg_a.h"
 #include "synchronous_product/synchronous_product.h"
 #include "utilities/Interval.h"
@@ -370,6 +371,31 @@ TEST_CASE("reg_a", "[canonical_word]")
 	CHECK(synchronous_product::reg_a(CanonicalABWord(
 	        {{TARegionState{"s1", "c0", 0}}, {ATARegionState{logic::MTLFormula{AP{"b"}}, 3}}}))
 	      == CanonicalABWord({{TARegionState{"s1", "c0", 0}}}));
+}
+
+TEST_CASE("monotone_domination_order", "[canonical_word]")
+{
+	CHECK(synchronous_product::is_monotonically_dominated(
+	  CanonicalABWord({{TARegionState{"s0", "c0", 0}}}),
+	  CanonicalABWord({{TARegionState{"s0", "c0", 0}}})));
+	CHECK(!synchronous_product::is_monotonically_dominated(
+	  CanonicalABWord({{TARegionState{"s0", "c0", 0}}}),
+	  CanonicalABWord({{TARegionState{"s0", "c0", 1}}})));
+	CHECK(!synchronous_product::is_monotonically_dominated(
+	  CanonicalABWord(
+	    {{TARegionState{"s0", "c0", 0}, ATARegionState{logic::MTLFormula{AP{"a"}}, 0}}}),
+	  CanonicalABWord({{TARegionState{"s0", "c0", 0}}})));
+	CHECK(synchronous_product::is_monotonically_dominated(
+	  CanonicalABWord({{TARegionState{"s0", "c0", 0}, TARegionState{"s0", "c1", 0}}}),
+	  CanonicalABWord({{TARegionState{"s0", "c0", 0}, TARegionState{"s0", "c1", 0}}})));
+	CHECK(!synchronous_product::is_monotonically_dominated(
+	  CanonicalABWord({{TARegionState{"s0", "c0", 0}, TARegionState{"s0", "c1", 1}},
+	                   {ATARegionState{logic::MTLFormula{AP{"a"}}, 0}}}),
+	  CanonicalABWord({{TARegionState{"s0", "c0", 0}, TARegionState{"s0", "c1", 1}}})));
+	CHECK(synchronous_product::is_monotonically_dominated(
+	  CanonicalABWord({{TARegionState{"s0", "c0", 0}, TARegionState{"s0", "c1", 1}}}),
+	  CanonicalABWord({{TARegionState{"s0", "c0", 0}, TARegionState{"s0", "c1", 1}},
+	                   {ATARegionState{logic::MTLFormula{AP{"a"}}, 0}}})));
 }
 
 } // namespace

--- a/test/test_synchronous_product.cpp
+++ b/test/test_synchronous_product.cpp
@@ -24,6 +24,7 @@
 #include "automata/ta_regions.h"
 #include "mtl/MTLFormula.h"
 #include "mtl_ata_translation/translator.h"
+#include "synchronous_product/reg_a.h"
 #include "synchronous_product/synchronous_product.h"
 #include "utilities/Interval.h"
 #include "utilities/numbers.h"
@@ -46,6 +47,7 @@ using synchronous_product::get_time_successor;
 using synchronous_product::InvalidCanonicalWordException;
 using synchronous_product::is_valid_canonical_word;
 using TARegionState = synchronous_product::TARegionState<std::string>;
+using AP            = logic::AtomicProposition<std::string>;
 
 TEST_CASE("Get a canonical word of a simple state", "[canonical_word]")
 {
@@ -333,7 +335,6 @@ TEST_CASE("Get the next canonical word(s)", "[canonical_word]")
 	using TAConfiguration = automata::ta::Configuration<std::string>;
 	// using ATAConfiguration = automata::ata::Configuration<std::string>;
 	using automata::AtomicClockConstraintT;
-	using AP = logic::AtomicProposition<std::string>;
 	using utilities::arithmetic::BoundType;
 	TA ta{{"a", "b", "c"}, "l0", {"l0", "l1", "l2"}};
 	ta.add_clock("x");
@@ -357,6 +358,18 @@ TEST_CASE("Get the next canonical word(s)", "[canonical_word]")
 	        {{TARegionState{"l0", "x", 0}, ATARegionState{logic::MTLFormula{AP{"phi_i"}}, 0}}}));
 	auto next_words = synchronous_product::get_next_canonical_words(ta, ata, initial_word, 2);
 	INFO("Next words: " << next_words);
+}
+
+TEST_CASE("reg_a", "[canonical_word]")
+{
+	CHECK(synchronous_product::reg_a(CanonicalABWord({{TARegionState{"s0", "c0", 0}}}))
+	      == CanonicalABWord({{TARegionState{"s0", "c0", 0}}}));
+	CHECK(synchronous_product::reg_a(CanonicalABWord(
+	        {{TARegionState{"s0", "c0", 0}, ATARegionState{logic::MTLFormula{AP{"a"}}, 0}}}))
+	      == CanonicalABWord({{TARegionState{"s0", "c0", 0}}}));
+	CHECK(synchronous_product::reg_a(CanonicalABWord(
+	        {{TARegionState{"s1", "c0", 0}}, {ATARegionState{logic::MTLFormula{AP{"b"}}, 3}}}))
+	      == CanonicalABWord({{TARegionState{"s1", "c0", 0}}}));
 }
 
 } // namespace

--- a/test/test_synchronous_product.cpp
+++ b/test/test_synchronous_product.cpp
@@ -174,6 +174,9 @@ TEST_CASE("Get the time successor for a canonical AB word", "[canonical_word]")
 	//    {{TARegionState{"s1", "c0", 5}}, {ATARegionState{a, 7}}, {TARegionState{"s0", "c0", 3}}}));
 	CHECK(get_time_successor(CanonicalABWord({{ATARegionState{b, 1}, ATARegionState{a, 3}}}), 3)
 	      == CanonicalABWord({{ATARegionState{b, 2}, ATARegionState{a, 4}}}));
+	CHECK(
+	  get_time_successor(CanonicalABWord({{TARegionState{"l0", "x", 1}, ATARegionState{a, 5}}}), 2)
+	  == CanonicalABWord({{TARegionState{"l0", "x", 2}}, {ATARegionState{a, 5}}}));
 }
 
 TEST_CASE("Get a concrete candidate for a canonical word", "[canonical_word]")
@@ -273,14 +276,16 @@ TEST_CASE("Get a concrete candidate for a canonical word", "[canonical_word]")
 	}
 
 	{
-		// two states, both clocks fractional with equal fractional parts and equal integer parts
+		// two states, both clocks fractional with equal fractional parts and equal integer
+		// parts
 		const Candidate cand = get_candidate(
 		  CanonicalABWord({{TARegionState{"s0", "c0", 1}, TARegionState{"s0", "c1", 1}}}));
 		CHECK(cand.first.second.at("c0") == cand.first.second.at("c1"));
 	}
 
 	{
-		// two states, both clocks fractional with equal fractional parts but different integer parts
+		// two states, both clocks fractional with equal fractional parts but different integer
+		// parts
 		const Candidate cand = get_candidate(
 		  CanonicalABWord({{TARegionState{"s0", "c0", 1}, TARegionState{"s0", "c1", 3}}}));
 		CHECK(getFractionalPart<Integer>(cand.first.second.at("c0"))
@@ -290,7 +295,8 @@ TEST_CASE("Get a concrete candidate for a canonical word", "[canonical_word]")
 	}
 
 	{
-		// two states, both clocks fractional with different fractional parts but same integer parts
+		// two states, both clocks fractional with different fractional parts but same integer
+		// parts
 		const Candidate cand = get_candidate(
 		  CanonicalABWord({{TARegionState{"s0", "c0", 1}}, {TARegionState{"s0", "c1", 1}}}));
 		CHECK(cand.first.second.at("c0") < cand.first.second.at("c1"));

--- a/test/test_synchronous_product.cpp
+++ b/test/test_synchronous_product.cpp
@@ -398,4 +398,49 @@ TEST_CASE("monotone_domination_order", "[canonical_word]")
 	                   {ATARegionState{logic::MTLFormula{AP{"a"}}, 0}}})));
 }
 
+TEST_CASE("monotone_domination_order_sets", "[canonical_word]")
+{
+	CHECK(synchronous_product::is_monotonically_dominated(std::set<CanonicalABWord>{},
+	                                                      std::set<CanonicalABWord>{}));
+
+	CHECK(synchronous_product::is_monotonically_dominated(
+	  std::set<CanonicalABWord>{
+	    CanonicalABWord({{TARegionState{"s0", "c0", 0}, TARegionState{"s0", "c1", 1}}})},
+	  std::set<CanonicalABWord>{
+	    CanonicalABWord({{TARegionState{"s0", "c0", 0}, TARegionState{"s0", "c1", 1}}})}));
+
+	CHECK(!synchronous_product::is_monotonically_dominated(
+	  std::set<CanonicalABWord>{
+	    CanonicalABWord({{TARegionState{"s0", "c0", 0}, TARegionState{"s0", "c1", 1}}})},
+	  std::set<CanonicalABWord>{}));
+
+	CHECK(synchronous_product::is_monotonically_dominated(
+	  std::set<CanonicalABWord>{},
+	  std::set<CanonicalABWord>{
+	    CanonicalABWord({{TARegionState{"s0", "c0", 0}, TARegionState{"s0", "c1", 1}}})}));
+
+	CHECK(!synchronous_product::is_monotonically_dominated(
+	  std::set<CanonicalABWord>{CanonicalABWord({{TARegionState{"s0", "c0", 0}}})},
+	  std::set<CanonicalABWord>{CanonicalABWord({{TARegionState{"s0", "c0", 2}}})}));
+
+	CHECK(!synchronous_product::is_monotonically_dominated(
+	  std::set<CanonicalABWord>{
+	    CanonicalABWord({{TARegionState{"s0", "c0", 0}, TARegionState{"s0", "c1", 1}},
+	                     {ATARegionState{logic::MTLFormula{AP{"a"}}, 0}}}),
+	    CanonicalABWord({{TARegionState{"s0", "c0", 0}, TARegionState{"s0", "c1", 1}},
+	                     {ATARegionState{logic::MTLFormula{AP{"a"}}, 1}}})},
+	  std::set<CanonicalABWord>{
+	    CanonicalABWord({{TARegionState{"s0", "c0", 0}, TARegionState{"s0", "c1", 1}},
+	                     {ATARegionState{logic::MTLFormula{AP{"a"}}, 0}}})}));
+
+	CHECK(synchronous_product::is_monotonically_dominated(
+	  std::set<CanonicalABWord>{
+	    CanonicalABWord({{TARegionState{"s0", "c0", 0}, TARegionState{"s0", "c1", 1}},
+	                     {ATARegionState{logic::MTLFormula{AP{"a"}}, 0}}})},
+	  std::set<CanonicalABWord>{
+	    CanonicalABWord({{TARegionState{"s0", "c0", 0}, TARegionState{"s0", "c1", 1}},
+	                     {ATARegionState{logic::MTLFormula{AP{"a"}}, 0}}}),
+	    CanonicalABWord({{TARegionState{"s0", "c0", 0}, TARegionState{"s0", "c1", 1}},
+	                     {ATARegionState{logic::MTLFormula{AP{"a"}}, 1}}})}));
+}
 } // namespace

--- a/test/test_ta.cpp
+++ b/test/test_ta.cpp
@@ -59,6 +59,8 @@ TEST_CASE("Simple TA", "[ta]")
 	TimedAutomaton<std::string, std::string> ta{{"a", "b"}, "s0", {"s0"}};
 	ta.add_transition(Transition<std::string, std::string>("s0", "a", "s0"));
 
+	CHECK(ta.get_initial_configuration() == Configuration{"s0", {}});
+
 	CHECK(ta.make_symbol_step({{"s0"}, {}}, "a") == std::set{Configuration{"s0", {}}});
 	CHECK(ta.make_symbol_step({{"s0"}, {}}, "b").empty());
 
@@ -77,6 +79,8 @@ TEST_CASE("TA with a simple guard", "[ta]")
 	ta.add_clock("x");
 	ta.add_transition(Transition<std::string, std::string>("s0", "a", "s0", {{"x", c}}));
 
+	CHECK(ta.get_initial_configuration() == Configuration{"s0", {{"x", 0}}});
+
 	CHECK(ta.make_symbol_step({"s0", {{"x", 0}}}, "a") == std::set{Configuration{"s0", {{"x", 0}}}});
 	CHECK(ta.make_symbol_step({"s0", {{"x", 1}}}, "a").empty());
 
@@ -91,6 +95,7 @@ TEST_CASE("TA with clock reset", "[ta]")
 	ClockConstraint                          c = AtomicClockConstraintT<std::less<Time>>(2);
 	ta.add_clock("x");
 	ta.add_transition(Transition<std::string, std::string>("s0", "a", "s0", {{"x", c}}, {"x"}));
+	CHECK(ta.get_initial_configuration() == Configuration{"s0", {{"x", 0}}});
 
 	CHECK(ta.make_symbol_step({"s0", {{"x", 1}}}, "a") == std::set{Configuration{"s0", {{"x", 0}}}});
 
@@ -199,5 +204,7 @@ TEST_CASE("Get enabled transitions", "[ta]")
 	CHECK(ta.get_enabled_transitions({"s0", {{"c0", 0}}})
 	      == std::vector<Transition<std::string, std::string>>{{t1, t3, t5}});
 }
+
+// TODO Test case with multiple clocks
 
 } // namespace


### PR DESCRIPTION
Implement the main search algorithm that creates a tree over the regionalized A/B configurations. Each node consists of a set of regionalized A/B configurations, where all configurations in one node have the same `reg_A` (i.e., the A components of the word are the same). Create child nodes by creating getting all successor words of each word in the node, and then partitioning those successors by their reg_A component.

Also fix a bug where the region increment would fail to compute the correct time successor if one configuration was already maxed out, but the other one wasn't. This also simplifies the function `increment_region_indexes`.

This does not yet implement the labeling of the resulting tree, which requires further steps.

This resolves #19 and #20.