### PR TITLE
Implement search tree labeling

### DIFF
--- a/src/synchronous_product/include/synchronous_product/search.h
+++ b/src/synchronous_product/include/synchronous_product/search.h
@@ -163,6 +163,24 @@ public:
 		return true;
 	}
 
+	/** Compute the final tree labels.
+	 * @param node The node to start the labeling at (e.g., the root of the tree)
+	 */
+	void
+	label(Node *node)
+	{
+		if (node->state == NodeState::GOOD || node->state == NodeState::DEAD) {
+			node->label = NodeLabel::TOP;
+		} else if (node->state == NodeState::BAD) {
+			node->label = NodeLabel::BOTTOM;
+		} else {
+			for (const auto &child : node->children) {
+				label(child);
+			}
+			// TODO label non-leaf nodes
+		}
+	}
+
 private:
 	automata::ta::TimedAutomaton<Location, ActionType> *                            ta_;
 	automata::ata::AlternatingTimedAutomaton<logic::MTLFormula<ActionType>,

--- a/src/synchronous_product/include/synchronous_product/search.h
+++ b/src/synchronous_product/include/synchronous_product/search.h
@@ -198,8 +198,8 @@ public:
 				                return child->label == NodeLabel::TOP
 				                       || std::includes(std::begin(controller_actions_),
 				                                        std::end(controller_actions_),
-				                                        std::begin(node->incoming_actions),
-				                                        std::end(node->incoming_actions));
+				                                        std::begin(child->incoming_actions),
+				                                        std::end(child->incoming_actions));
 			                })) {
 				node->label = NodeLabel::TOP;
 			} else {

--- a/src/synchronous_product/include/synchronous_product/search_tree.h
+++ b/src/synchronous_product/include/synchronous_product/search_tree.h
@@ -86,6 +86,7 @@ print_to_ostream(std::ostream &                                                 
                  const synchronous_product::SearchTreeNode<Location, ActionType> &node,
                  unsigned int                                                     indent = 0)
 {
+	using synchronous_product::NodeLabel;
 	using synchronous_product::NodeState;
 	for (unsigned int i = 0; i < indent; i++) {
 		os << " ";
@@ -102,6 +103,12 @@ print_to_ostream(std::ostream &                                                 
 	case NodeState::GOOD: os << "GOOD"; break;
 	case NodeState::BAD: os << "BAD"; break;
 	case NodeState::DEAD: os << "DEAD"; break;
+	}
+	os << " ";
+	switch (node.label) {
+	case NodeLabel::TOP: os << u8"⊤"; break;
+	case NodeLabel::BOTTOM: os << u8"⊥"; break;
+	case NodeLabel::UNLABELED: os << u8"?"; break;
 	}
 	os << '\n';
 	for (const auto &child : node.children) {

--- a/src/synchronous_product/include/synchronous_product/search_tree.h
+++ b/src/synchronous_product/include/synchronous_product/search_tree.h
@@ -33,6 +33,13 @@ enum class NodeState {
 	DEAD,    /**< The node does not have any successors */
 };
 
+/** The label of the search node */
+enum class NodeLabel {
+	UNLABELED,
+	BOTTOM,
+	TOP,
+};
+
 /** A node in the search tree
  * @see TreeSearch */
 template <typename Location, typename ActionType>
@@ -54,6 +61,8 @@ struct SearchTreeNode
 	std::set<CanonicalABWord<Location, ActionType>> words;
 	/** The state of the node */
 	NodeState state = NodeState::UNKNOWN;
+	/** Whether we have a successful strategy in the node */
+	NodeLabel label = NodeLabel::UNLABELED;
 	/** The parent of the node, this node was directly reached from the parent */
 	SearchTreeNode *parent = nullptr;
 	/** A list of the children of the node, which are reachable by a single transition */

--- a/src/synchronous_product/include/synchronous_product/search_tree.h
+++ b/src/synchronous_product/include/synchronous_product/search_tree.h
@@ -96,7 +96,7 @@ print_to_ostream(std::ostream &                                                 
 	for (const auto &action : node.incoming_actions) {
 		os << action << " ";
 	}
-	os << "}: ";
+	os << "} -> ";
 	os << node.words << ": ";
 	switch (node.state) {
 	case NodeState::UNKNOWN: os << "UNKNOWN"; break;

--- a/src/synchronous_product/include/synchronous_product/synchronous_product.h
+++ b/src/synchronous_product/include/synchronous_product/synchronous_product.h
@@ -443,7 +443,7 @@ get_candidate(const CanonicalABWord<Location, ActionType> &word)
  * @return CanonicalABWord
  */
 template <typename Location, typename ActionType>
-std::vector<CanonicalABWord<Location, ActionType>>
+std::vector<std::pair<ActionType, CanonicalABWord<Location, ActionType>>>
 get_next_canonical_words(
   const automata::ta::TimedAutomaton<Location, ActionType> &                            ta,
   const automata::ata::AlternatingTimedAutomaton<logic::MTLFormula<ActionType>,
@@ -451,7 +451,7 @@ get_next_canonical_words(
   CanonicalABWord<Location, ActionType> canonical_word,
   RegionIndex                           K)
 {
-	std::vector<CanonicalABWord<Location, ActionType>> res;
+	std::vector<std::pair<ActionType, CanonicalABWord<Location, ActionType>>> res;
 
 	// Compute all time successors
 	// TODO Refactor into a separate function
@@ -491,7 +491,9 @@ get_next_canonical_words(
 			              // For all successors, compute the canonical word and add it to the result.
 			              for (const auto &ta_successor : ta_successors) {
 				              for (const auto &ata_successor : ata_successors) {
-					              res.push_back(get_canonical_word(ta_successor, ata_successor, K));
+					              res.push_back(
+					                std::make_pair(symbol,
+					                               get_canonical_word(ta_successor, ata_successor, K)));
 					              std::cout << "Getting " << res.back() << " from "
 					                        << "(" << ab_configuration.first << ", "
 					                        << ab_configuration.second << ")"
@@ -583,6 +585,41 @@ template <typename Location, typename ActionType>
 std::ostream &
 operator<<(std::ostream &                                                                 os,
            const std::vector<synchronous_product::CanonicalABWord<Location, ActionType>> &ab_words)
+{
+	if (ab_words.empty()) {
+		os << "{}";
+		return os;
+	}
+	os << "{ ";
+	bool first = true;
+	for (const auto &ab_word : ab_words) {
+		if (!first) {
+			os << ", ";
+		} else {
+			first = false;
+		}
+		os << ab_word;
+	}
+	os << " }";
+	return os;
+}
+
+template <typename Location, typename ActionType>
+std::ostream &
+operator<<(
+  std::ostream &                                                                           os,
+  const std::pair<ActionType, synchronous_product::CanonicalABWord<Location, ActionType>> &ab_word)
+{
+	os << "(" << ab_word.first << ", " << ab_word.second << ")";
+	return os;
+}
+
+template <typename Location, typename ActionType>
+std::ostream &
+operator<<(
+  std::ostream &os,
+  const std::vector<
+    std::pair<ActionType, synchronous_product::CanonicalABWord<Location, ActionType>>> &ab_words)
 {
 	if (ab_words.empty()) {
 		os << "{}";

--- a/test/test_search.cpp
+++ b/test/test_search.cpp
@@ -159,7 +159,7 @@ TEST_CASE("Search in an ABConfiguration tree", "[search]")
 		CHECK(search.get_root()->children[0]->children[2]->state == NodeState::BAD);
 
 		CHECK(search.get_root()->label == NodeLabel::TOP);
-		CHECK(search.get_root()->children[0]->label == NodeLabel::TOP);
+		CHECK(search.get_root()->children[0]->label == NodeLabel::BOTTOM);
 		CHECK(search.get_root()->children[1]->label == NodeLabel::TOP);
 		CHECK(search.get_root()->children[2]->label == NodeLabel::TOP);
 		CHECK(search.get_root()->children[0]->children[0]->label == NodeLabel::TOP);

--- a/test/test_search.cpp
+++ b/test/test_search.cpp
@@ -36,6 +36,7 @@ using CanonicalABWord = synchronous_product::CanonicalABWord<std::string, std::s
 using TARegionState   = synchronous_product::TARegionState<std::string>;
 using ATARegionState  = synchronous_product::ATARegionState<std::string>;
 using AP              = logic::AtomicProposition<std::string>;
+using synchronous_product::NodeLabel;
 using synchronous_product::NodeState;
 
 TEST_CASE("Search in an ABConfiguration tree", "[search]")
@@ -138,6 +139,7 @@ TEST_CASE("Search in an ABConfiguration tree", "[search]")
 			REQUIRE(search.step());
 		}
 		REQUIRE(!search.step());
+		search.label();
 
 		INFO("Tree:\n" << *search.get_root());
 		REQUIRE(search.get_root()->children.size() == 3);
@@ -155,6 +157,14 @@ TEST_CASE("Search in an ABConfiguration tree", "[search]")
 		CHECK(search.get_root()->children[0]->children[0]->state == NodeState::GOOD);
 		CHECK(search.get_root()->children[0]->children[1]->state == NodeState::BAD);
 		CHECK(search.get_root()->children[0]->children[2]->state == NodeState::BAD);
+
+		CHECK(search.get_root()->label == NodeLabel::TOP);
+		CHECK(search.get_root()->children[0]->label == NodeLabel::TOP);
+		CHECK(search.get_root()->children[1]->label == NodeLabel::TOP);
+		CHECK(search.get_root()->children[2]->label == NodeLabel::TOP);
+		CHECK(search.get_root()->children[0]->children[0]->label == NodeLabel::TOP);
+		CHECK(search.get_root()->children[0]->children[1]->label == NodeLabel::BOTTOM);
+		CHECK(search.get_root()->children[0]->children[2]->label == NodeLabel::BOTTOM);
 	}
 }
 

--- a/test/test_search.cpp
+++ b/test/test_search.cpp
@@ -65,6 +65,7 @@ TEST_CASE("Search in an ABConfiguration tree", "[search]")
 		        {{TARegionState{"l0", "x", 0}, ATARegionState{logic::MTLFormula{AP{"phi_i"}}, 0}}})});
 		CHECK(search.get_root()->state == NodeState::UNKNOWN);
 		CHECK(search.get_root()->parent == nullptr);
+		CHECK(search.get_root()->incoming_actions.empty());
 		CHECK(search.get_root()->children.empty());
 	}
 
@@ -79,12 +80,15 @@ TEST_CASE("Search in an ABConfiguration tree", "[search]")
 		        CanonicalABWord({{TARegionState{"l0", "x", 0}}, {ATARegionState{a.until(b), 3}}}),
 		        CanonicalABWord({{TARegionState{"l0", "x", 0}, ATARegionState{a.until(b), 4}}}),
 		        CanonicalABWord({{TARegionState{"l0", "x", 0}}, {ATARegionState{a.until(b), 5}}})});
+		CHECK(children[0]->incoming_actions == std::set<std::string>{"a"});
 		CHECK(
 		  children[1]->words
 		  == std::set{CanonicalABWord({{TARegionState{"l1", "x", 0}, ATARegionState{a.until(b), 0}}})});
+		CHECK(children[1]->incoming_actions == std::set<std::string>{"b"});
 		CHECK(
 		  children[2]->words
 		  == std::set{CanonicalABWord({{TARegionState{"l1", "x", 1}, ATARegionState{a.until(b), 1}}})});
+		CHECK(children[2]->incoming_actions == std::set<std::string>{"b"});
 	}
 
 	SECTION("The next steps compute the right children")
@@ -104,8 +108,11 @@ TEST_CASE("Search in an ABConfiguration tree", "[search]")
 			CHECK(children[0]->words
 			      == std::set{
 			        CanonicalABWord({{TARegionState{"l0", "x", 0}}, {ATARegionState{a.until(b), 5}}})});
+			CHECK(children[0]->incoming_actions == std::set<std::string>{"a"});
 			CHECK(children[1]->words == std::set{CanonicalABWord({{TARegionState{"l1", "x", 0}}})});
+			CHECK(children[1]->incoming_actions == std::set<std::string>{"b"});
 			CHECK(children[2]->words == std::set{CanonicalABWord({{TARegionState{"l1", "x", 1}}})});
+			CHECK(children[2]->incoming_actions == std::set<std::string>{"b"});
 			CHECK(root_children[0]->state == NodeState::UNKNOWN);
 		}
 

--- a/test/test_search.cpp
+++ b/test/test_search.cpp
@@ -168,4 +168,29 @@ TEST_CASE("Search in an ABConfiguration tree", "[search]")
 	}
 }
 
+TEST_CASE("Search in an ABConfiguration tree without solution", "[search]")
+{
+	using automata::AtomicClockConstraintT;
+	using AP = logic::AtomicProposition<std::string>;
+	using utilities::arithmetic::BoundType;
+	TA ta{{"e", "c"}, "l0", {"l1"}};
+	ta.add_clock("x");
+	ta.add_transition(TATransition("l0", "e", "l0"));
+	ta.add_transition(TATransition("l1", "e", "l1"));
+	ta.add_transition(TATransition("l1", "c", "l1"));
+	ta.add_transition(TATransition(
+	  "l0", "c", "l1", {{"x", AtomicClockConstraintT<std::greater<automata::Time>>(1)}}));
+	logic::MTLFormula<std::string> e{AP("e")};
+	logic::MTLFormula<std::string> c{AP("c")};
+
+	logic::MTLFormula f =
+	  e.dual_until(!c, logic::TimeInterval(2, BoundType::WEAK, 2, BoundType::INFTY));
+	auto       ata = mtl_ata_translation::translate(f);
+	TreeSearch search(&ta, &ata, {"b"}, {"a"}, 2);
+	while (search.step()) {};
+	search.label();
+	INFO("Tree:\n" << *search.get_root());
+	CHECK(search.get_root()->label == NodeLabel::BOTTOM);
+}
+
 } // namespace

--- a/test/test_search.cpp
+++ b/test/test_search.cpp
@@ -56,7 +56,7 @@ TEST_CASE("Search in an ABConfiguration tree", "[search]")
 
 	logic::MTLFormula f   = a.until(b, logic::TimeInterval(2, BoundType::WEAK, 2, BoundType::INFTY));
 	auto              ata = mtl_ata_translation::translate(f);
-	TreeSearch        search(&ta, &ata, 2);
+	TreeSearch        search(&ta, &ata, {"a"}, {"b", "c"}, 2);
 
 	SECTION("The search tree is initialized correctly")
 	{

--- a/test/test_synchronous_product_print.cpp
+++ b/test/test_synchronous_product_print.cpp
@@ -132,4 +132,26 @@ TEST_CASE("Print a pair (action, canonical word)", "[print]")
 	CHECK(str.str() == "(a, [ { (s, c, 1) } ])");
 }
 
+TEST_CASE("Print a vector of (action, canonical word) pairs", "[print]")
+{
+	std::stringstream str;
+	SECTION("Empty vector")
+	{
+		str << std::vector<
+		  std::pair<std::string, synchronous_product::CanonicalABWord<std::string, std::string>>>{};
+		CHECK(str.str() == "{}");
+	}
+	SECTION("Vector of two words")
+	{
+		str << std::vector{
+		  std::make_pair(std::string{"a"},
+		                 synchronous_product::CanonicalABWord<std::string, std::string>{
+		                   {TARegionState("l0", "c", 1)}}),
+		  std::make_pair(std::string{"b"},
+		                 synchronous_product::CanonicalABWord<std::string, std::string>{
+		                   {TARegionState("l1", "c", 1)}})};
+		CHECK(str.str() == "{ (a, [ { (l0, c, 1) } ]), (b, [ { (l1, c, 1) } ]) }");
+	}
+}
+
 } // namespace

--- a/test/test_synchronous_product_print.cpp
+++ b/test/test_synchronous_product_print.cpp
@@ -123,4 +123,13 @@ TEST_CASE("Print the canonical word H(s)", "[print]")
 	}
 }
 
+TEST_CASE("Print a pair (action, canonical word)", "[print]")
+{
+	std::stringstream str;
+	str << std::make_pair(std::string{"a"},
+	                      synchronous_product::CanonicalABWord<std::string, std::string>{
+	                        {TARegionState("s", "c", 1)}});
+	CHECK(str.str() == "(a, [ { (s, c, 1) } ])");
+}
+
 } // namespace


### PR DESCRIPTION
Label the search tree recursively bottom-up, with the following rules:
* good and dead leave nodes are labeled with TOP
* bad leave nodes are labeled with BOTTOM
* a non-leave node is labeled with TOP if each child
  * is labeled with TOP, or
  * is only eachable with a controller action (in which case it can be ignored)

This implicitly implements the validity function mentioned in Bouyer et al, 2006, assuming that any selection is valid if it does not constrain the environment actions.