### PR TITLE
Build with -Wextra and -Wpedantic, fix pedantic warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ include(CTest)
 option(MTLSYN_BUILD_DOC "Allow building documentation, requires doxygen." ON)
 option(COVERAGE "Generate coverage report" OFF)
 
-add_compile_options(-W -Wall -Werror)
+add_compile_options(-W -Wall -Werror -Wextra -Wpedantic)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 

--- a/src/automata/include/automata/ata_formula.hpp
+++ b/src/automata/include/automata/ata_formula.hpp
@@ -59,7 +59,7 @@ FalseFormula<LocationT>::is_satisfied(const std::set<State<LocationT>> &,
                                       const ClockValuation &) const
 {
 	return false;
-};
+}
 
 template <typename LocationT>
 std::set<std::set<State<LocationT>>>

--- a/src/synchronous_product/include/synchronous_product/synchronous_product.h
+++ b/src/synchronous_product/include/synchronous_product/synchronous_product.h
@@ -235,7 +235,7 @@ increment_region_indexes(const std::set<ABRegionSymbol<Location, ActionType>> &c
 		               return configuration;
 	               });
 	return res;
-};
+}
 
 /** Get the CanonicalABWord that directly follows the given word. The next word
  * is the word Abs where the Abs_i with the maximal fractional part is


### PR DESCRIPTION
This gives us additional warnings that are not enabled with -Wall.