### PR TITLE
Adapt to clang and also do CI builds with clang

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,27 +1,32 @@
 version: 2.1
-jobs:
-  build_fedora:
-    docker:
-      - image: fedora:33
+commands:
+  install_build_env:
+    parameters:
+      compiler:
+        default: gcc-c++
+        type: string
     steps:
       - run:
           name: Install build environment
           command: |
             dnf install -y --nodocs \
+              << parameters.compiler >> \
+              boost-devel \
               catch-devel \
               cmake \
               doxygen \
-              boost-devel \
-              gcc-c++ \
               git \
               lcov \
               make \
               python3-pip \
               range-v3-devel
-      - checkout
+  build:
+    steps:
       - run:
           name: Build the project
           command: cmake -B build && cmake --build build -j`nproc`
+  test:
+    steps:
       - run:
           name: Run tests
           working_directory: build
@@ -30,14 +35,38 @@ jobs:
           name: Build documentation
           working_directory: build
           command: make doc
+
+
+jobs:
+  build_gcc:
+    docker:
+      - image: fedora:33
+    steps:
+      - install_build_env
+      - checkout
+      - build
+      - test
       - run:
           name: Generate coverage report
           command: |
             cmake -B build_coverage -DCMAKE_BUILD_TYPE=Debug -DCOVERAGE=ON && \
             cmake --build build_coverage -j1 --target coverage && \
             bash <(curl -s https://codecov.io/bash)
+  build_clang:
+    docker:
+      - image: fedora:33
+    environment:
+      CXX: /usr/bin/clang++
+      CC: /usr/bin/clang
+    steps:
+      - install_build_env:
+          compiler: clang
+      - checkout
+      - build
+      - test
 
 workflows:
   build:
     jobs:
-      - build_fedora
+      - build_gcc
+      - build_clang

--- a/src/automata/automata.cpp
+++ b/src/automata/automata.cpp
@@ -28,15 +28,18 @@ is_satisfied(const ClockConstraint &constraint, const Time &valuation)
 	return std::visit([&](auto &&c) { return c.is_satisfied(valuation); }, constraint);
 }
 
+} // namespace automata
+
 std::ostream &
-operator<<(std::ostream &os, const ClockConstraint &constraint)
+operator<<(std::ostream &os, const automata::ClockConstraint &constraint)
 {
 	std::visit([&os](auto &&c) { os << c; }, constraint);
 	return os;
 }
 
 std::ostream &
-operator<<(std::ostream &os, const std::multimap<std::string, const ClockConstraint> &constraints)
+operator<<(std::ostream &                                                     os,
+           const std::multimap<std::string, const automata::ClockConstraint> &constraints)
 {
 	if (constraints.empty()) {
 		os << u8"⊤";
@@ -53,5 +56,3 @@ operator<<(std::ostream &os, const std::multimap<std::string, const ClockConstra
 	}
 	return os;
 }
-
-} // namespace automata

--- a/src/automata/include/automata/ata.h
+++ b/src/automata/include/automata/ata.h
@@ -62,13 +62,34 @@ class AlternatingTimedAutomaton;
 
 template <typename LocationT, typename SymbolT>
 class Transition;
-
-template <typename LocationT, typename SymbolT>
-std::ostream &operator<<(std::ostream &os, const Transition<LocationT, SymbolT> &transition);
+} // namespace automata::ata
 
 template <typename LocationT, typename SymbolT>
 std::ostream &operator<<(std::ostream &                                       os,
-                         const AlternatingTimedAutomaton<LocationT, SymbolT> &ata);
+                         const automata::ata::Transition<LocationT, SymbolT> &transition);
+
+template <typename LocationT, typename SymbolT>
+std::ostream &operator<<(std::ostream &                                                      os,
+                         const automata::ata::AlternatingTimedAutomaton<LocationT, SymbolT> &ata);
+
+/** Print a configuration to an ostream.
+ * @param os The ostream to print to
+ * @param configuration The configuration to print
+ * @return A reference to the ostream
+ */
+template <typename LocationT>
+std::ostream &operator<<(std::ostream &                                 os,
+                         const automata::ata::Configuration<LocationT> &configuration);
+
+/** Print a run to an ostream.
+ * @param os The ostream to print to
+ * @param run The run to print
+ * @return A reference to the ostream
+ */
+template <typename LocationT, typename SymbolT>
+std::ostream &operator<<(std::ostream &os, const automata::ata::Run<LocationT, SymbolT> &run);
+
+namespace automata::ata {
 
 template <typename LocationT, typename SymbolT>
 bool operator<(const Transition<LocationT, SymbolT> &first,
@@ -212,23 +233,6 @@ private:
 };
 
 } // namespace automata::ata
-
-/** Print a configuration to an ostream.
- * @param os The ostream to print to
- * @param configuration The configuration to print
- * @return A reference to the ostream
- */
-template <typename LocationT>
-std::ostream &operator<<(std::ostream &                                 os,
-                         const automata::ata::Configuration<LocationT> &configuration);
-
-/** Print a run to an ostream.
- * @param os The ostream to print to
- * @param run The run to print
- * @return A reference to the ostream
- */
-template <typename LocationT, typename SymbolT>
-std::ostream &operator<<(std::ostream &os, const automata::ata::Run<LocationT, SymbolT> &run);
 
 #include "ata.hpp"
 

--- a/src/automata/include/automata/ata.hpp
+++ b/src/automata/include/automata/ata.hpp
@@ -21,11 +21,9 @@
 
 #include "ata.h"
 
-namespace automata::ata {
-
 template <typename LocationT, typename SymbolT>
 std::ostream &
-operator<<(std::ostream &os, const Transition<LocationT, SymbolT> &transition)
+operator<<(std::ostream &os, const automata::ata::Transition<LocationT, SymbolT> &transition)
 {
 	os << transition.source_ << u8" → " << transition.symbol_ << u8" → " << *transition.formula_;
 	return os;
@@ -33,18 +31,35 @@ operator<<(std::ostream &os, const Transition<LocationT, SymbolT> &transition)
 
 template <typename LocationT, typename SymbolT>
 std::ostream &
-operator<<(std::ostream &os, const AlternatingTimedAutomaton<LocationT, SymbolT> &ata)
+operator<<(std::ostream &                                                      os,
+           const automata::ata::AlternatingTimedAutomaton<LocationT, SymbolT> &ata)
 {
 	os << "Alphabet: {";
-	std::copy(ata.alphabet_.begin(),
-	          ata.alphabet_.end(),
-	          std::experimental::make_ostream_joiner(os, ", "));
+	{
+		bool first = true;
+		for (const auto &symbol : ata.alphabet_) {
+			if (!first) {
+				os << ", ";
+			} else {
+				first = false;
+			}
+			os << symbol;
+		}
+	}
 	os << "}";
 	os << ", initial location: " << ata.initial_location_;
 	os << ", final locations: {";
-	std::copy(ata.final_locations_.begin(),
-	          ata.final_locations_.end(),
-	          std::experimental::make_ostream_joiner(os, ", "));
+	{
+		bool first = true;
+		for (const auto &location : ata.final_locations_) {
+			if (!first) {
+				os << ", ";
+			} else {
+				first = false;
+			}
+			os << location;
+		}
+	}
 	os << "}";
 	os << ", transitions:";
 	for (const auto &transition : ata.transitions_) {
@@ -53,6 +68,41 @@ operator<<(std::ostream &os, const AlternatingTimedAutomaton<LocationT, SymbolT>
 
 	return os;
 }
+
+template <typename LocationT>
+std::ostream &
+operator<<(std::ostream &os, const automata::ata::Configuration<LocationT> &configuration)
+{
+	os << "{ ";
+	bool first = true;
+	for (const auto &state : configuration) {
+		if (!first) {
+			os << ", ";
+		} else {
+			first = false;
+		}
+		os << state;
+	}
+	os << " }";
+	return os;
+}
+
+template <typename LocationT, typename SymbolT>
+std::ostream &
+operator<<(std::ostream &os, const automata::ata::Run<LocationT, SymbolT> &run)
+{
+	for (const auto &[step, configuration] : run) {
+		// simple arrow for symbol step, dashed arrow for time step
+		const std::string arrow = step.index() == 0 ? u8"→" : u8"⇢";
+		os << " " << arrow << " ";
+		std::visit([&os](const auto &s) { os << s; }, step);
+		os << " " << arrow << " ";
+		os << configuration;
+	}
+	return os;
+}
+
+namespace automata::ata {
 
 template <typename LocationT, typename SymbolT>
 bool
@@ -270,36 +320,3 @@ AlternatingTimedAutomaton<LocationT, SymbolT>::get_minimal_models(Formula<Locati
 }
 
 } // namespace automata::ata
-
-template <typename LocationT>
-std::ostream &
-operator<<(std::ostream &os, const automata::ata::Configuration<LocationT> &configuration)
-{
-	os << "{ ";
-	bool first = true;
-	for (const auto &state : configuration) {
-		if (!first) {
-			os << ", ";
-		} else {
-			first = false;
-		}
-		os << state;
-	}
-	os << " }";
-	return os;
-}
-
-template <typename LocationT, typename SymbolT>
-std::ostream &
-operator<<(std::ostream &os, const automata::ata::Run<LocationT, SymbolT> &run)
-{
-	for (const auto &[step, configuration] : run) {
-		// simple arrow for symbol step, dashed arrow for time step
-		const std::string arrow = step.index() == 0 ? u8"→" : u8"⇢";
-		os << " " << arrow << " ";
-		std::visit([&os](const auto &s) { os << s; }, step);
-		os << " " << arrow << " ";
-		os << configuration;
-	}
-	return os;
-}

--- a/src/automata/include/automata/ata_formula.h
+++ b/src/automata/include/automata/ata_formula.h
@@ -29,8 +29,7 @@
 #include <range/v3/view.hpp>
 #include <utility>
 
-namespace automata {
-namespace ata {
+namespace automata::ata {
 
 template <typename LocationT>
 using State = std::pair<LocationT, ClockValuation>;
@@ -38,14 +37,25 @@ using State = std::pair<LocationT, ClockValuation>;
 template <typename LocationT>
 class Formula;
 
+} // namespace automata::ata
+
 /** Print a Formula to an ostream.
  * @param os The ostream to print to
  * @param formula The formula to print
  * @return A reference to the ostream
  */
 template <typename LocationT>
-std::ostream &operator<<(std::ostream &os, const Formula<LocationT> &formula);
+std::ostream &operator<<(std::ostream &os, const automata::ata::Formula<LocationT> &formula);
 
+/** Print a State to an ostream
+ * @param os The ostream to print to
+ * @param state The state to print
+ * @return A reference to the ostream
+ */
+template <typename LocationT>
+std::ostream &operator<<(std::ostream &os, const automata::ata::State<LocationT> &state);
+
+namespace automata::ata {
 /// An abstract ATA formula.
 template <typename LocationT>
 class Formula
@@ -249,16 +259,7 @@ private:
 	std::unique_ptr<Formula<LocationT>> sub_formula_;
 };
 
-} // namespace ata
-} // namespace automata
-
-/** Print a State to an ostream
- * @param os The ostream to print to
- * @param state The state to print
- * @return A reference to the ostream
- */
-template <typename LocationT>
-std::ostream & operator<<(std::ostream &os, const automata::ata::State<LocationT> &state);
+} // namespace automata::ata
 
 #include "ata_formula.hpp"
 

--- a/src/automata/include/automata/ata_formula.hpp
+++ b/src/automata/include/automata/ata_formula.hpp
@@ -21,15 +21,23 @@
 
 #include "ata_formula.h"
 
-namespace automata::ata {
-
 template <typename LocationT>
 std::ostream &
-operator<<(std::ostream &os, const Formula<LocationT> &formula)
+operator<<(std::ostream &os, const automata::ata::Formula<LocationT> &formula)
 {
 	formula.print_to_ostream(os);
 	return os;
 }
+
+template <typename LocationT>
+std::ostream &
+operator<<(std::ostream &os, const automata::ata::State<LocationT> &state)
+{
+	os << "(" << state.first << ", " << state.second << std::string(")");
+	return os;
+}
+
+namespace automata::ata {
 
 template <typename LocationT>
 bool
@@ -202,11 +210,3 @@ ResetClockFormula<LocationT>::print_to_ostream(std::ostream &os) const
 }
 
 } // namespace automata::ata
-
-template <typename LocationT>
-std::ostream &
-operator<<(std::ostream &os, const automata::ata::State<LocationT> &state)
-{
-	os << "(" << state.first << ", " << state.second << std::string(")");
-	return os;
-}

--- a/src/automata/include/automata/automata.h
+++ b/src/automata/include/automata/automata.h
@@ -43,6 +43,40 @@ using ClockSetValuation = std::map<std::string, Clock>;
 using Endpoint          = unsigned int;
 using TimedWord         = std::vector<std::pair<Symbol, Time>>;
 
+template <typename Comp>
+class AtomicClockConstraintT;
+
+using ClockConstraint = std::variant<AtomicClockConstraintT<std::less<Time>>,
+                                     AtomicClockConstraintT<std::less_equal<Time>>,
+                                     AtomicClockConstraintT<std::equal_to<Time>>,
+                                     AtomicClockConstraintT<std::not_equal_to<Time>>,
+                                     AtomicClockConstraintT<std::greater_equal<Time>>,
+                                     AtomicClockConstraintT<std::greater<Time>>>;
+
+} // namespace automata
+
+template <class Comp>
+std::ostream &operator<<(std::ostream &                                os,
+                         const automata::AtomicClockConstraintT<Comp> &constraint);
+
+/** Print a ClockConstraint to an ostream
+ * @param os The ostream to print to
+ * @param constraint The constraint to print
+ * @return A reference to the ostream
+ */
+std::ostream &operator<<(std::ostream &os, const automata::ClockConstraint &constraint);
+
+/** Print a multimap of ClockConstraints to an ostream
+ * @param os The ostream to print to
+ * @param constraints The constraints to print
+ * @return A reference to the ostream
+ */
+std::ostream &
+operator<<(std::ostream &                                                     os,
+           const std::multimap<std::string, const automata::ClockConstraint> &constraints);
+
+namespace automata {
+
 /// Invalid timed word, e.g., first time is not initialized at 0.
 class InvalidTimedWordException : public std::invalid_argument
 {
@@ -162,9 +196,6 @@ public:
 template <class Comp>
 class AtomicClockConstraintT;
 
-template <class Comp>
-std::ostream &operator<<(std::ostream &os, const AtomicClockConstraintT<Comp> &constraint);
-
 /// An atomic clock constraint.
 /**
  * This is a templated atomic constraint, where the template parameter is the comparison operator,
@@ -221,29 +252,7 @@ private:
 	const Endpoint comparand_;
 };
 
-using ClockConstraint = std::variant<AtomicClockConstraintT<std::less<Time>>,
-                                     AtomicClockConstraintT<std::less_equal<Time>>,
-                                     AtomicClockConstraintT<std::equal_to<Time>>,
-                                     AtomicClockConstraintT<std::not_equal_to<Time>>,
-                                     AtomicClockConstraintT<std::greater_equal<Time>>,
-                                     AtomicClockConstraintT<std::greater<Time>>>;
-
 bool is_satisfied(const ClockConstraint &constraint, const ClockValuation &valuation);
-
-/** Print a ClockConstraint to an ostream
- * @param os The ostream to print to
- * @param constraint The constraint to print
- * @return A reference to the ostream
- */
-std::ostream &operator<<(std::ostream &os, const ClockConstraint &constraint);
-
-/** Print a multimap of ClockConstraints to an ostream
- * @param os The ostream to print to
- * @param constraints The constraints to print
- * @return A reference to the ostream
- */
-std::ostream &operator<<(std::ostream &                                           os,
-                         const std::multimap<std::string, const ClockConstraint> &constraints);
 
 } // namespace automata
 

--- a/src/automata/include/automata/automata.hpp
+++ b/src/automata/include/automata/automata.hpp
@@ -21,12 +21,13 @@
 
 #include "automata.h"
 
-namespace automata {
-
 template <class Comp>
 std::ostream &
-operator<<(std::ostream &os, const AtomicClockConstraintT<Comp> &constraint)
+operator<<(std::ostream &os, const automata::AtomicClockConstraintT<Comp> &constraint)
 {
+	using automata::InvalidClockComparisonOperatorException;
+	using automata::Time;
+
 	if constexpr (std::is_same_v<Comp, std::less<Time>>) {
 		os << "<";
 	} else if constexpr (std::is_same_v<Comp, std::less_equal<Time>>) {
@@ -45,5 +46,3 @@ operator<<(std::ostream &os, const AtomicClockConstraintT<Comp> &constraint)
 	os << " " << constraint.comparand_;
 	return os;
 }
-
-} // namespace automata

--- a/src/automata/include/automata/ta.h
+++ b/src/automata/include/automata/ta.h
@@ -53,7 +53,7 @@ std::ostream &operator<<(std::ostream &                                 os,
                          const automata::ta::Transition<LocationT, AP> &transition);
 
 template <typename LocationT, typename AP>
-std::ostream &operator<<(std::ostream &os, const automata::ta::TimedAutomaton<LocationT, AP> ta);
+std::ostream &operator<<(std::ostream &os, const automata::ta::TimedAutomaton<LocationT, AP> &ta);
 
 namespace automata::ta {
 /// Compare two transitions.
@@ -190,7 +190,9 @@ class TimedAutomaton
 {
 public:
 	/** Print a TimedAutomaton to an ostream. */
-	friend std::ostream &operator<<<>(std::ostream &os, const TimedAutomaton<LocationT, AP> ta);
+	// clang-format off
+	friend std::ostream &operator<< <>(std::ostream &os, const TimedAutomaton<LocationT, AP> &ta);
+	// clang-format on
 	TimedAutomaton() = delete;
 	/** Constructor.
 	 * @param alphabet The valid symbols in the TimedAutomaton

--- a/src/automata/include/automata/ta.h
+++ b/src/automata/include/automata/ta.h
@@ -41,7 +41,21 @@ class TimedAutomaton;
 
 template <typename LocationT, typename AP>
 class Transition;
+} // namespace automata::ta
 
+/** Print a transition
+ * @param os The ostream to print to
+ * @param transition The transition to print
+ * @return A reference to the ostream
+ */
+template <typename LocationT, typename AP>
+std::ostream &operator<<(std::ostream &                                 os,
+                         const automata::ta::Transition<LocationT, AP> &transition);
+
+template <typename LocationT, typename AP>
+std::ostream &operator<<(std::ostream &os, const automata::ta::TimedAutomaton<LocationT, AP> ta);
+
+namespace automata::ta {
 /// Compare two transitions.
 /** Two transitions are equal if they use the same source, target, read the
  * same symbol, have the same clock constraints, and reset the same clocks.
@@ -50,14 +64,6 @@ class Transition;
  */
 template <typename LocationT, typename AP>
 bool operator==(const Transition<LocationT, AP> &lhs, const Transition<LocationT, AP> &rhs);
-
-/** Print a transition
- * @param os The ostream to print to
- * @param transition The transition to print
- * @return A reference to the ostream
- */
-template <typename LocationT, typename AP>
-std::ostream &operator<<(std::ostream &os, const Transition<LocationT, AP> &transition);
 
 /// A transition in a timed automaton.
 /** @see TimedAutomaton
@@ -74,7 +80,9 @@ public:
 	 * @param transition The transition to print
 	 * @return A reference to the ostream
 	 */
-	friend std::ostream &operator<<<>(std::ostream &os, const Transition &transition);
+	// clang-format off
+	friend std::ostream &operator<< <>(std::ostream &os, const Transition &transition);
+	// clang-format on
 
 	/** Constructor.
 	 * @param source the source location
@@ -163,8 +171,8 @@ private:
 };
 
 /// A timed automaton.
-/** A TimedAutomaton consists of a set of locations, an initial location, a final location, a set of
- * clocks, and a set of transitions. A simple timed automaton with two locations and a single
+/** A TimedAutomaton consists of a set of locations, an initial location, a final location, a set
+ * of clocks, and a set of transitions. A simple timed automaton with two locations and a single
  * transition without constraints can be constructed with
  * @code
  * TimedAutomaton ta{"s0", {"s1"}};
@@ -182,14 +190,7 @@ class TimedAutomaton
 {
 public:
 	/** Print a TimedAutomaton to an ostream. */
-	friend std::ostream &
-	operator<<(std::ostream &os, const TimedAutomaton<LocationT, AP> ta)
-	{
-		os << "Alphabet: " << ta.alphabet_ << ", initial location: " << ta.initial_location_
-		   << ", final locations: " << ta.final_locations_ << ", transitions:\n"
-		   << ta.transitions_;
-		return os;
-	}
+	friend std::ostream &operator<<<>(std::ostream &os, const TimedAutomaton<LocationT, AP> ta);
 	TimedAutomaton() = delete;
 	/** Constructor.
 	 * @param alphabet The valid symbols in the TimedAutomaton
@@ -256,9 +257,9 @@ public:
 	/// Let the TA make a transition on the given symbol at the given time.
 	/** Check if there is a transition that can be enabled on the given symbol at the given time,
 	 * starting with the given path. If so, modify the given path, i.e., apply the transition by
-	 * switching to the new location, increasing all clocks by the time difference, and resetting all
-	 * clocks specified in the transition. This always uses the first transition that is enabled,
-	 * i.e., it does not work properly on non-deterministic TAs.
+	 * switching to the new location, increasing all clocks by the time difference, and resetting
+	 * all clocks specified in the transition. This always uses the first transition that is
+	 * enabled, i.e., it does not work properly on non-deterministic TAs.
 	 * @param path The path prefix to start at
 	 * @param symbol The symbol to read
 	 * @param time The (absolute) time associated with the symbol
@@ -305,17 +306,18 @@ private:
 	std::multimap<LocationT, Transition<LocationT, AP>> transitions_;
 };
 
+} // namespace automata::ta
+
+/** Print a multimap of transitions. */
+template <typename LocationT, typename AP>
+std::ostream &
+operator<<(std::ostream &                                                           os,
+           const std::multimap<LocationT, automata::ta::Transition<LocationT, AP>> &transitions);
+
 /** Print a set of strings.
  * This is useful, e.g., to print the set of clock resets.
  */
 std::ostream &operator<<(std::ostream &os, const std::set<std::string> &strings);
-
-/** Print a multimap of transitions. */
-template <typename LocationT, typename AP>
-std::ostream &operator<<(std::ostream &                                             os,
-                         const std::multimap<LocationT, Transition<LocationT, AP>> &transitions);
-
-} // namespace automata::ta
 
 template <typename Location>
 std::ostream &operator<<(std::ostream &                               os,

--- a/src/automata/include/automata/ta.hpp
+++ b/src/automata/include/automata/ta.hpp
@@ -21,6 +21,60 @@
 
 #include "ta.h"
 
+template <typename LocationT, typename AP>
+std::ostream &
+operator<<(std::ostream &                                                           os,
+           const std::multimap<LocationT, automata::ta::Transition<LocationT, AP>> &transitions)
+{
+	for (const auto &[source, transition] : transitions) {
+		os << transition << '\n';
+	}
+	return os;
+}
+
+template <typename Location>
+std::ostream &
+operator<<(std::ostream &os, const automata::ta::Configuration<Location> &configuration)
+{
+	os << "(" << configuration.first << ", ";
+	if (configuration.second.empty()) {
+		os << "{})";
+		return os;
+	}
+	os << "{ ";
+	bool first = true;
+	for (const auto &[clock, value] : configuration.second) {
+		if (first) {
+			first = false;
+		} else {
+			os << ", ";
+		}
+		os << clock << ": " << value;
+	}
+	os << " } )";
+	return os;
+}
+
+template <typename LocationT, typename AP>
+std::ostream &
+operator<<(std::ostream &os, const automata::ta::Transition<LocationT, AP> &transition)
+{
+	os << transition.source_ << u8" → " << transition.symbol_ << " / "
+	   << transition.clock_constraints_ << " / " << transition.clock_resets_ << u8" → "
+	   << transition.target_;
+	return os;
+}
+
+template <typename LocationT, typename AP>
+std::ostream &
+operator<<(std::ostream &os, const automata::ta::TimedAutomaton<LocationT, AP> ta)
+{
+	os << "Alphabet: " << ta.alphabet_ << ", initial location: " << ta.initial_location_
+	   << ", final locations: " << ta.final_locations_ << ", transitions:\n"
+	   << ta.transitions_;
+	return os;
+}
+
 namespace automata::ta {
 template <typename LocationT, typename AP>
 bool
@@ -43,16 +97,6 @@ operator==(const Transition<LocationT, AP> &lhs, const Transition<LocationT, AP>
 	return lhs.source_ == rhs.source_ && lhs.target_ == rhs.target_ && lhs.symbol_ == rhs.symbol_
 	       && lhs.clock_constraints_ == rhs.clock_constraints_
 	       && lhs.clock_resets_ == rhs.clock_resets_;
-}
-
-template <typename LocationT, typename AP>
-std::ostream &
-operator<<(std::ostream &os, const Transition<LocationT, AP> &transition)
-{
-	os << transition.source_ << u8" → " << transition.symbol_ << " / "
-	   << transition.clock_constraints_ << " / " << transition.clock_resets_ << u8" → "
-	   << transition.target_;
-	return os;
 }
 
 template <typename LocationT, typename AP>
@@ -216,37 +260,4 @@ TimedAutomaton<LocationT, AP>::is_accepting_configuration(
 	return (final_locations_.find(configuration.first) != final_locations_.end());
 }
 
-template <typename LocationT, typename AP>
-std::ostream &
-operator<<(std::ostream &os, const std::multimap<LocationT, Transition<LocationT, AP>> &transitions)
-{
-	for (const auto &[source, transition] : transitions) {
-		os << transition << '\n';
-	}
-	return os;
-}
-
 } // namespace automata::ta
-
-template <typename Location>
-std::ostream &
-operator<<(std::ostream &os, const automata::ta::Configuration<Location> &configuration)
-{
-	os << "(" << configuration.first << ", ";
-	if (configuration.second.empty()) {
-		os << "{})";
-		return os;
-	}
-	os << "{ ";
-	bool first = true;
-	for (const auto &[clock, value] : configuration.second) {
-		if (first) {
-			first = false;
-		} else {
-			os << ", ";
-		}
-		os << clock << ": " << value;
-	}
-	os << " } )";
-	return os;
-}

--- a/src/automata/include/automata/ta.hpp
+++ b/src/automata/include/automata/ta.hpp
@@ -67,7 +67,7 @@ operator<<(std::ostream &os, const automata::ta::Transition<LocationT, AP> &tran
 
 template <typename LocationT, typename AP>
 std::ostream &
-operator<<(std::ostream &os, const automata::ta::TimedAutomaton<LocationT, AP> ta)
+operator<<(std::ostream &os, const automata::ta::TimedAutomaton<LocationT, AP> &ta)
 {
 	os << "Alphabet: " << ta.alphabet_ << ", initial location: " << ta.initial_location_
 	   << ", final locations: " << ta.final_locations_ << ", transitions:\n"

--- a/src/automata/ta.cpp
+++ b/src/automata/ta.cpp
@@ -24,9 +24,6 @@
 #include "automata/ta.hpp"
 #include "automata/ta_regions.h"
 
-namespace automata {
-namespace ta {
-
 std::ostream &
 operator<<(std::ostream &os, const std::set<std::string> &strings)
 {
@@ -39,6 +36,3 @@ operator<<(std::ostream &os, const std::set<std::string> &strings)
 	os << " }";
 	return os;
 }
-
-} // namespace ta
-} // namespace automata

--- a/src/mtl/include/mtl/MTLFormula.h
+++ b/src/mtl/include/mtl/MTLFormula.h
@@ -87,9 +87,6 @@ struct AtomicProposition
 
 	APType ap_; ///< String representation of the ap
 };
-/// outstream operator
-template <typename APType>
-std::ostream &operator<<(std::ostream &out, const AtomicProposition<APType> &a);
 
 /// Comparison override
 template <typename APType>
@@ -303,11 +300,15 @@ operator!(const AtomicProposition<APType> &ap)
 	return !MTLFormula<APType>(ap);
 }
 
+} // namespace logic
+
 /// outstream operator
 template <typename APType>
-std::ostream &operator<<(std::ostream &out, const MTLFormula<APType> &f);
+std::ostream &operator<<(std::ostream &out, const logic::AtomicProposition<APType> &a);
 
-} // namespace logic
+/// outstream operator
+template <typename APType>
+std::ostream &operator<<(std::ostream &out, const logic::MTLFormula<APType> &f);
 
 #include "MTLFormula.hpp"
 

--- a/src/mtl/include/mtl/MTLFormula.hpp
+++ b/src/mtl/include/mtl/MTLFormula.hpp
@@ -21,15 +21,39 @@
 
 #include "MTLFormula.h"
 
-namespace logic {
-
 template <typename APType>
 std::ostream &
-operator<<(std::ostream &out, const AtomicProposition<APType> &a)
+operator<<(std::ostream &out, const logic::AtomicProposition<APType> &a)
 {
 	out << a.ap_;
 	return out;
 }
+
+template <typename APType>
+std::ostream &
+operator<<(std::ostream &out, const logic::MTLFormula<APType> &f)
+{
+	using logic::LOP;
+	switch (f.get_operator()) {
+	case LOP::AP: out << f.get_atomicProposition(); break;
+	case LOP::LAND:
+		out << "(" << f.get_operands().front() << " && " << f.get_operands().back() << ")";
+		break;
+	case LOP::LOR:
+		out << "(" << f.get_operands().front() << " || " << f.get_operands().back() << ")";
+		break;
+	case LOP::LNEG: out << "!(" << f.get_operands().front() << ")"; break;
+	case LOP::LUNTIL:
+		out << "(" << f.get_operands().front() << " U " << f.get_operands().back() << ")";
+		break;
+	case LOP::LDUNTIL:
+		out << "(" << f.get_operands().front() << " ~U " << f.get_operands().back() << ")";
+		break;
+	}
+	return out;
+}
+
+namespace logic {
 
 template <typename APType>
 bool
@@ -248,29 +272,6 @@ MTLFormula<APType>::get_subformulas_of_type(LOP op) const
 	});
 
 	return res;
-}
-
-template <typename APType>
-std::ostream &
-operator<<(std::ostream &out, const MTLFormula<APType> &f)
-{
-	switch (f.get_operator()) {
-	case LOP::AP: out << f.get_atomicProposition(); break;
-	case LOP::LAND:
-		out << "(" << f.get_operands().front() << " && " << f.get_operands().back() << ")";
-		break;
-	case LOP::LOR:
-		out << "(" << f.get_operands().front() << " || " << f.get_operands().back() << ")";
-		break;
-	case LOP::LNEG: out << "!(" << f.get_operands().front() << ")"; break;
-	case LOP::LUNTIL:
-		out << "(" << f.get_operands().front() << " U " << f.get_operands().back() << ")";
-		break;
-	case LOP::LDUNTIL:
-		out << "(" << f.get_operands().front() << " ~U " << f.get_operands().back() << ")";
-		break;
-	}
-	return out;
 }
 
 } // namespace logic

--- a/src/mtl_ata_translation/include/mtl_ata_translation/translator.h
+++ b/src/mtl_ata_translation/include/mtl_ata_translation/translator.h
@@ -20,8 +20,9 @@
 
 #pragma once
 
-#include "automata/ata.h"
 #include "mtl/MTLFormula.h"
+// MTL needs to be included first to have operator<< available for MTLFormula.
+#include "automata/ata.h"
 
 namespace mtl_ata_translation {
 

--- a/src/synchronous_product/include/synchronous_product/search.h
+++ b/src/synchronous_product/include/synchronous_product/search.h
@@ -192,7 +192,7 @@ public:
 			}
 			if (std::all_of(std::begin(node->children),
 			                std::end(node->children),
-			                [this, node](const auto &child) {
+			                [this](const auto &child) {
 				                // The child is either labeled with TOP or it is only reachable with
 				                // controller actions (in which case we can choose to ignore it).
 				                return child->label == NodeLabel::TOP


### PR DESCRIPTION
clang seems to be more strict regarding operator overloading in namespaces. In particular, if it finds an operator with the wrong overload in the current namespace, it no longer checks the global namespace for additional overloads. AFAIU, this is actually intended by the C++ standard, and this is a bug in GCC: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=51577 Let's not rely on the bug and instead move all operators to the global namespace.

The second problem regarding overloads is the following:
If we use a using-declaration, we cannot define the operator overload in the same namespace, as we don't actually define the type in the namespace, but merely alias it. Instead, it needs to be defined in the global namespace or the namespace of the type being aliased (e.g., `std`).

For now, just define the operators in the global namespace. We may want to reconsider this later and for example define more generic overloads for the `operator<<`.

Also add a clang build to circleci so we notice issues with clang right away.