### PR TITLE
Add product construction for TAs

### DIFF
--- a/src/automata/include/automata/automata.h
+++ b/src/automata/include/automata/automata.h
@@ -19,7 +19,7 @@
  */
 
 #ifndef SRC_AUTOMATA_INCLUDE_AUTOMATA_AUTOMATA_H
-#define SRC_AUTOMATA_INCLUDE_AUTOMATA_AUTOMATA_H value
+#define SRC_AUTOMATA_INCLUDE_AUTOMATA_AUTOMATA_H
 
 #include <boost/format.hpp>
 #include <functional>
@@ -144,10 +144,8 @@ class InvalidLocationException : public std::invalid_argument
 {
 public:
 	/** Constructor
-	 * @param location The name of the invalid location
 	 */
-	explicit InvalidLocationException(const Location &location)
-	: std::invalid_argument(str(boost::format("Invalid location: %1%") % location))
+	explicit InvalidLocationException(const Location &) : std::invalid_argument("Invalid location")
 	{
 	}
 };
@@ -163,7 +161,7 @@ public:
 	 * @param clock_name The name of the invalid clock
 	 */
 	explicit InvalidClockException(const std::string &clock_name)
-	: std::invalid_argument(str(boost::format("Invalid clock: %1%") % clock_name))
+	: std::invalid_argument((boost::format("Invalid clock: %1%") % clock_name).str())
 	{
 	}
 };

--- a/src/automata/include/automata/ta.h
+++ b/src/automata/include/automata/ta.h
@@ -19,7 +19,7 @@
  */
 
 #ifndef SRC_AUTOMATA_INCLUDE_AUTOMATA_TA_H
-#define SRC_AUTOMATA_INCLUDE_AUTOMATA_TA_H value
+#define SRC_AUTOMATA_INCLUDE_AUTOMATA_TA_H
 
 #include "automata.h"
 
@@ -54,6 +54,9 @@ std::ostream &operator<<(std::ostream &                                 os,
 
 template <typename LocationT, typename AP>
 std::ostream &operator<<(std::ostream &os, const automata::ta::TimedAutomaton<LocationT, AP> &ta);
+
+template <typename T1, typename T2>
+std::ostream &operator<<(std::ostream &os, const std::tuple<T1, T2> &t);
 
 namespace automata::ta {
 /// Compare two transitions.
@@ -217,6 +220,42 @@ public:
 	get_alphabet() const
 	{
 		return alphabet_;
+	}
+
+	/** Get the locations.
+	 * @return A reference to the set of locations
+	 */
+	const std::set<LocationT> &
+	get_locations() const
+	{
+		return locations_;
+	}
+
+	/** Get the initial location.
+	 * @return The initial location
+	 */
+	const LocationT &
+	get_initial_location() const
+	{
+		return initial_location_;
+	}
+
+	/** Get the final locations.
+	 * @return The final locations
+	 */
+	const std::set<LocationT> &
+	get_final_locations() const
+	{
+		return final_locations_;
+	}
+
+	/** Get the transitions of the TA.
+	 * @return A multimap with entries (location, transition)
+	 */
+	const std::multimap<LocationT, Transition<LocationT, AP>> &
+	get_transitions() const
+	{
+		return transitions_;
 	}
 
 	/** Add a location to the TA.

--- a/src/automata/include/automata/ta.h
+++ b/src/automata/include/automata/ta.h
@@ -258,6 +258,15 @@ public:
 		return transitions_;
 	}
 
+	/** Get the clock names of the automaton.
+	 * @return a set of clock names
+	 */
+	const std::set<std::string> &
+	get_clocks() const
+	{
+		return clocks_;
+	}
+
 	/** Add a location to the TA.
 	 * @param location the location to add
 	 */

--- a/src/automata/include/automata/ta.hpp
+++ b/src/automata/include/automata/ta.hpp
@@ -75,6 +75,14 @@ operator<<(std::ostream &os, const automata::ta::TimedAutomaton<LocationT, AP> &
 	return os;
 }
 
+template <typename T1, typename T2>
+std::ostream &
+operator<<(std::ostream &os, const std::tuple<T1, T2> &t)
+{
+	os << "(" << std::get<0>(t) << ", " << std::get<1>(t) << ")";
+	return os;
+}
+
 namespace automata::ta {
 template <typename LocationT, typename AP>
 bool

--- a/src/automata/include/automata/ta_product.h
+++ b/src/automata/include/automata/ta_product.h
@@ -1,0 +1,58 @@
+/***************************************************************************
+ *  ta_product.h - Compute the product automaton of timed automata
+ *
+ *  Created:   Mon  1 Mar 12:49:54 CET 2021
+ *  Copyright  2021  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ ****************************************************************************/
+/*  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Library General Public License for more details.
+ *
+ *  Read the full text in the LICENSE.md file.
+ */
+
+#ifndef SRC_AUTOMATA_INCLUDE_AUTOMATA_TA_PRODUCT_H_
+#define SRC_AUTOMATA_INCLUDE_AUTOMATA_TA_PRODUCT_H_
+
+#include "ta.h"
+
+#include <iostream>
+#include <tuple>
+
+namespace automata::ta {
+
+/** Compute the product automaton of two timed automata.
+ * The resulting automaton's location set is the cartesian product of the
+ * input automata's locations.
+ * The product automaton either takes a single transition in either one of the automata for a
+ * non-synchronized action, or it simultaneously takes a transition in both automata for a
+ * synchronized action:
+ * 1. For every action a in H, (l1, l2) -- (a, G1 U G2, Y1 U G2) --> (l1', l2') if
+ *    a. l1 -- (a, G1, Y1) -> l1'
+ *    b. l2 -- (a, G2, Y2) -> l2'
+ * 2. For every action a not in H (l1, l2) -- (a, G1 U G2, Y1 U G2) --> (l1', l2') if either
+ *    a. l1 -- (a, G1, Y1) -> l1' and l2' = l2, or
+ *    b. l2 -- (a, G2, Y2) -> l2' and l1' = l1
+ *
+ * @param ta1 The first timed automaton
+ * @param ta2 The second timed automaton
+ * @param synchronized_actions The actions on which the two TAs must synchronize
+ * @return The product automaton
+ */
+template <typename LocationT1, typename LocationT2, typename ActionT>
+TimedAutomaton<std::tuple<LocationT1, LocationT2>, ActionT>
+get_product(const TimedAutomaton<LocationT1, ActionT> &ta1,
+            const TimedAutomaton<LocationT2, ActionT> &ta2,
+            const std::set<ActionT>                    synchronized_actions = {});
+
+} // namespace automata::ta
+
+#include "ta_product.hpp"
+
+#endif /* ifndef SRC_AUTOMATA_INCLUDE_AUTOMATA_TA_PRODUCT_H_ */

--- a/src/automata/include/automata/ta_product.h
+++ b/src/automata/include/automata/ta_product.h
@@ -49,7 +49,7 @@ template <typename LocationT1, typename LocationT2, typename ActionT>
 TimedAutomaton<std::tuple<LocationT1, LocationT2>, ActionT>
 get_product(const TimedAutomaton<LocationT1, ActionT> &ta1,
             const TimedAutomaton<LocationT2, ActionT> &ta2,
-            const std::set<ActionT>                    synchronized_actions = {});
+            const std::set<ActionT> &                  synchronized_actions = {});
 
 } // namespace automata::ta
 

--- a/src/automata/include/automata/ta_product.hpp
+++ b/src/automata/include/automata/ta_product.hpp
@@ -43,6 +43,12 @@ get_product(const TimedAutomaton<LocationT1, ActionT> &ta1,
 	    | ranges::to<std::set>()};
 	res.add_locations(ranges::views::cartesian_product(ta1.get_locations(), ta2.get_locations())
 	                  | ranges::to<std::set>());
+	for (const auto &clock : ta1.get_clocks()) {
+		res.add_clock(clock);
+	}
+	for (const auto &clock : ta2.get_clocks()) {
+		res.add_clock(clock);
+	}
 	for (const auto &[location, transition] : ta1.get_transitions()) {
 		for (const auto &l2 : ta2.get_locations()) {
 			res.add_transition(Transition{std::make_tuple(location, l2),

--- a/src/automata/include/automata/ta_product.hpp
+++ b/src/automata/include/automata/ta_product.hpp
@@ -1,0 +1,67 @@
+/***************************************************************************
+ *  ta_product.h - Compute the product automaton of timed automata
+ *
+ *  Created:   Mon  1 Mar 12:49:54 CET 2021
+ *  Copyright  2021  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ ****************************************************************************/
+/*  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Library General Public License for more details.
+ *
+ *  Read the full text in the LICENSE.md file.
+ */
+
+#pragma once
+
+#include "automata/ta.h"
+#include "ta_product.h"
+
+#include <iterator>
+#include <range/v3/view.hpp>
+#include <range/v3/view/cartesian_product.hpp>
+
+namespace automata::ta {
+
+template <typename LocationT1, typename LocationT2, typename ActionT>
+TimedAutomaton<std::tuple<LocationT1, LocationT2>, ActionT>
+get_product(const TimedAutomaton<LocationT1, ActionT> &ta1,
+            const TimedAutomaton<LocationT2, ActionT> &ta2,
+            const std::set<ActionT>                    synchronized_actions)
+{
+	// TODO implement synchronized actions
+	assert(synchronized_actions.empty());
+	TimedAutomaton<std::tuple<LocationT1, LocationT2>, ActionT> res{
+	  ranges::views::concat(ta1.get_alphabet(), ta2.get_alphabet()) | ranges::to<std::set>(),
+	  std::make_tuple(ta1.get_initial_location(), ta2.get_initial_location()),
+	  ranges::views::cartesian_product(ta1.get_final_locations(), ta2.get_final_locations())
+	    | ranges::to<std::set>()};
+	res.add_locations(ranges::views::cartesian_product(ta1.get_locations(), ta2.get_locations())
+	                  | ranges::to<std::set>());
+	for (const auto &[location, transition] : ta1.get_transitions()) {
+		for (const auto &l2 : ta2.get_locations()) {
+			res.add_transition(Transition{std::make_tuple(location, l2),
+			                              transition.symbol_,
+			                              std::make_tuple(transition.target_, l2),
+			                              transition.clock_constraints_,
+			                              transition.clock_resets_});
+		}
+	}
+	for (const auto &[location, transition] : ta2.get_transitions()) {
+		for (const auto &l1 : ta1.get_locations()) {
+			res.add_transition(Transition{std::make_tuple(l1, location),
+			                              transition.symbol_,
+			                              std::make_tuple(l1, transition.target_),
+			                              transition.clock_constraints_,
+			                              transition.clock_resets_});
+		}
+	}
+	return res;
+}
+
+} // namespace automata::ta

--- a/src/automata/include/automata/ta_product.hpp
+++ b/src/automata/include/automata/ta_product.hpp
@@ -32,7 +32,7 @@ template <typename LocationT1, typename LocationT2, typename ActionT>
 TimedAutomaton<std::tuple<LocationT1, LocationT2>, ActionT>
 get_product(const TimedAutomaton<LocationT1, ActionT> &ta1,
             const TimedAutomaton<LocationT2, ActionT> &ta2,
-            const std::set<ActionT>                    synchronized_actions)
+            const std::set<ActionT> &                  synchronized_actions)
 {
 	// TODO implement synchronized actions
 	assert(synchronized_actions.empty());

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -10,7 +10,7 @@ add_executable(test_clock test_clock.cpp catch2_main.cpp)
 target_link_libraries(test_clock PRIVATE ta Catch2::Catch2)
 catch_discover_tests(test_clock)
 
-add_executable(testta test_ta.cpp test_ta_region.cpp test_ta_print.cpp catch2_main.cpp)
+add_executable(testta test_ta.cpp test_ta_region.cpp test_ta_print.cpp test_ta_product.cpp catch2_main.cpp)
 target_link_libraries(testta PRIVATE ta PRIVATE Catch2::Catch2)
 catch_discover_tests(testta)
 

--- a/test/test_ta_product.cpp
+++ b/test/test_ta_product.cpp
@@ -17,18 +17,22 @@
  *  Read the full text in the LICENSE.md file.
  */
 
+#include "automata/automata.h"
 #include "automata/ta.h"
 #include "automata/ta_product.h"
 
 #include <catch2/catch.hpp>
 
 namespace {
+
 using TA               = automata::ta::TimedAutomaton<std::string, std::string>;
 using SingleTransition = automata::ta::Transition<std::string, std::string>;
 using ProductTransition =
   automata::ta::Transition<std::tuple<std::string, std::string>, std::string>;
+using automata::AtomicClockConstraintT;
+using automata::Time;
 
-TEST_CASE("The product of two automata", "[ta]")
+TEST_CASE("The product of two timed automata", "[ta]")
 {
 	TA ta1{{"a", "b"}, "1l1", {"1l1"}};
 	TA ta2{{"c", "d"}, "2l1", {"2l2"}};
@@ -47,5 +51,48 @@ TEST_CASE("The product of two automata", "[ta]")
 	         {{"1l1", "2l1"}, ProductTransition{{"1l1", "2l1"}, "c", {"1l1", "2l2"}}},
 	         {{"1l2", "2l1"}, ProductTransition{{"1l2", "2l1"}, "c", {"1l2", "2l2"}}}}});
 	CHECK(product.accepts_word({{"a", 0}, {"c", 1}}));
+}
+
+TEST_CASE("The product of two timed automata with clock constraints", "[ta]")
+{
+	TA ta1{{"a", "b"}, "1l1", {"1l1"}};
+	ta1.add_location("1l2");
+	ta1.add_clock("c1");
+	ta1.add_transition(
+	  SingleTransition{"1l1", "a", "1l1", {{"c1", AtomicClockConstraintT<std::less<Time>>{1}}}});
+	TA ta2{{"c", "d"}, "2l1", {"2l2"}};
+	ta2.add_clock("c2");
+	ta2.add_transition(
+	  SingleTransition{"2l1", "c", "2l2", {{"c2", AtomicClockConstraintT<std::greater<Time>>{2}}}});
+	const auto product = automata::ta::get_product(ta1, ta2);
+	CHECK(product.get_alphabet() == std::set<std::string>{"a", "b", "c", "d"});
+	CHECK(product.get_initial_location() == std::make_tuple(std::string{"1l1"}, std::string{"2l1"}));
+	CHECK(product.get_final_locations()
+	      == std::set<std::tuple<std::string, std::string>>{{"1l1", "2l2"}});
+	CHECK(product.get_transitions()
+	      == std::multimap<std::tuple<std::string, std::string>, ProductTransition>{
+	        {{{"1l1", "2l1"},
+	          ProductTransition{{"1l1", "2l1"},
+	                            "a",
+	                            {"1l1", "2l1"},
+	                            {{"c1", AtomicClockConstraintT<std::less<Time>>{1}}}}},
+	         {{"1l1", "2l2"},
+	          ProductTransition{{"1l1", "2l2"},
+	                            "a",
+	                            {"1l1", "2l2"},
+	                            {{"c1", AtomicClockConstraintT<std::less<Time>>{1}}}}},
+	         {{"1l1", "2l1"},
+	          ProductTransition{{"1l1", "2l1"},
+	                            "c",
+	                            {"1l1", "2l2"},
+	                            {{"c2", AtomicClockConstraintT<std::greater<Time>>{2}}}}},
+	         {{"1l2", "2l1"},
+	          ProductTransition{{"1l2", "2l1"},
+	                            "c",
+	                            {"1l2", "2l2"},
+	                            {{"c2", AtomicClockConstraintT<std::greater<Time>>{2}}}}}}});
+	CHECK(!product.accepts_word({{"a", 0}, {"c", 1}}));
+	CHECK(product.accepts_word({{"a", 0}, {"c", 3}}));
+	CHECK(!product.accepts_word({{"a", 2}, {"c", 3}}));
 }
 } // namespace

--- a/test/test_ta_product.cpp
+++ b/test/test_ta_product.cpp
@@ -1,0 +1,51 @@
+/***************************************************************************
+ *  test_ta_product.cpp - Test the product of Timed Automata
+ *
+ *  Created:   Mon  1 Mar 13:58:57 CET 2021
+ *  Copyright  2021  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ ****************************************************************************/
+/*  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Library General Public License for more details.
+ *
+ *  Read the full text in the LICENSE.md file.
+ */
+
+#include "automata/ta.h"
+#include "automata/ta_product.h"
+
+#include <catch2/catch.hpp>
+
+namespace {
+using TA               = automata::ta::TimedAutomaton<std::string, std::string>;
+using SingleTransition = automata::ta::Transition<std::string, std::string>;
+using ProductTransition =
+  automata::ta::Transition<std::tuple<std::string, std::string>, std::string>;
+
+TEST_CASE("The product of two automata", "[ta]")
+{
+	TA ta1{{"a", "b"}, "1l1", {"1l1"}};
+	TA ta2{{"c", "d"}, "2l1", {"2l2"}};
+	ta1.add_location("1l2");
+	ta1.add_transition(SingleTransition{"1l1", "a", "1l1"});
+	ta2.add_transition(SingleTransition{"2l1", "c", "2l2"});
+	const auto product = automata::ta::get_product(ta1, ta2);
+	CHECK(product.get_alphabet() == std::set<std::string>{"a", "b", "c", "d"});
+	CHECK(product.get_initial_location() == std::make_tuple(std::string{"1l1"}, std::string{"2l1"}));
+	CHECK(product.get_final_locations()
+	      == std::set<std::tuple<std::string, std::string>>{{"1l1", "2l2"}});
+	CHECK(product.get_transitions()
+	      == std::multimap<std::tuple<std::string, std::string>, ProductTransition>{
+	        {{{"1l1", "2l1"}, ProductTransition{{"1l1", "2l1"}, "a", {"1l1", "2l1"}}},
+	         {{"1l1", "2l2"}, ProductTransition{{"1l1", "2l2"}, "a", {"1l1", "2l2"}}},
+	         {{"1l1", "2l1"}, ProductTransition{{"1l1", "2l1"}, "c", {"1l1", "2l2"}}},
+	         {{"1l2", "2l1"}, ProductTransition{{"1l2", "2l1"}, "c", {"1l2", "2l2"}}}}});
+	CHECK(product.accepts_word({{"a", 0}, {"c", 1}}));
+}
+} // namespace


### PR DESCRIPTION
Add a new function `automata::ta::get_product` that construct the product of two timed automata. The resulting automaton's location set is the cartesian product of the input automata's locations.

The API already allows synchronized actions, with the following meaning: The product automaton either takes a single transition in either one of the automata for a non-synchronized action, or it simultaneously takes a transition in both automata for a synchronized action. However, we currently require the synchronized actions to be empty. Therefore, we currently always take an action in either one of the automata, not in both simultaneously.