### PR TITLE
Feature/incremental labeling

### DIFF
--- a/src/synchronous_product/include/synchronous_product/preorder_traversal.h
+++ b/src/synchronous_product/include/synchronous_product/preorder_traversal.h
@@ -102,11 +102,21 @@ private:
 	void
 	increment()
 	{
+		// do nothing if end has been reached (indicated by cur_ == nullptr)
+		if (cur_ == nullptr) {
+			return;
+		}
 		// descend through children
 		if (!cur_->children.empty()) {
 			cur_ = cur_->children[0].get();
 			return;
 		} else {
+			// corner case: if only one node, cur_->parent == nullptr
+			if (cur_->parent == nullptr) {
+				assert(cur_ == root_);
+				cur_ = nullptr;
+				return;
+			}
 			// if this is the last child, ascend
 			if (cur_ == cur_->parent->children.back().get()) {
 				while (cur_ != root_ && cur_ == cur_->parent->children.back().get()) {

--- a/src/synchronous_product/include/synchronous_product/preorder_traversal.h
+++ b/src/synchronous_product/include/synchronous_product/preorder_traversal.h
@@ -113,14 +113,22 @@ private:
 		} else {
 			// corner case: if only one node, cur_->parent == nullptr
 			if (cur_->parent == nullptr) {
-				assert(cur_ == root_);
+				if (cur_ != root_) {
+					throw InconsistentTreeException(
+					  "Parent-child relation between current and parent node is not bidirectional");
+				}
 				cur_ = nullptr;
 				return;
 			}
 			// if this is the last child, ascend
+			assert(cur_->parent != nullptr);
 			if (cur_ == cur_->parent->children.back().get()) {
 				while (cur_ != root_ && cur_ == cur_->parent->children.back().get()) {
 					cur_ = cur_->parent;
+					if (cur_->parent == nullptr && cur_ != root_) {
+						throw InconsistentTreeException(
+						  "Parent-child relation between current and parent node is not bidirectional");
+					}
 				}
 				// reached root - end reached
 				if (cur_ == root_) {

--- a/src/synchronous_product/include/synchronous_product/preorder_traversal.h
+++ b/src/synchronous_product/include/synchronous_product/preorder_traversal.h
@@ -27,13 +27,25 @@ template <class Node>
 class preorder_iterator : public std::iterator<std::forward_iterator_tag, Node>
 {
 public:
+	/// Default constructor
 	preorder_iterator() = default;
+	/**
+	 * @brief Construct a new preorder iterator object from a root node
+	 * @param root
+	 */
 	preorder_iterator(Node *root) : root_(root), cur_(root)
 	{
 	}
+	/**
+	 * @brief Construct a new preorder iterator object from a root node and allows setting the current
+	 * node (only used to construct the end-iterator.)
+	 * @param root
+	 * @param cur
+	 */
 	preorder_iterator(Node *root, Node *cur) : root_(root), cur_(cur)
 	{
 	}
+	/// Destructor
 	virtual ~preorder_iterator()
 	{
 	}
@@ -58,25 +70,41 @@ public:
 		increment();
 		return *this;
 	}
-
+	/**
+	 * @brief Dereference operator
+	 * @return Node&
+	 */
 	Node &
 	operator*()
 	{
 		return *cur_;
 	}
-
+	/**
+	 * @brief Dereference operator
+	 * @return Node*
+	 */
 	Node *
 	operator->()
 	{
 		return cur_;
 	}
-
+	/**
+	 * @brief Comparison for equality, uses underlying node comparator.
+	 * @param rhs Right-hand side iterator
+	 * @return true If both nodes pointed to are equal
+	 * @return false Otherwise
+	 */
 	bool
 	operator==(const preorder_iterator<Node> &rhs) const
 	{
 		return cur_ == rhs.cur_;
 	}
-
+	/**
+	 * @brief Comparison for inequality, uses underlying node comparator.
+	 * @param rhs Right-hand side iterator
+	 * @return true If both nodes pointed to are not equal
+	 * @return false Otherwise
+	 */
 	bool
 	operator!=(const preorder_iterator<Node> &rhs) const
 	{
@@ -84,6 +112,10 @@ public:
 	}
 
 private:
+	/**
+	 * @brief Implements forward preorder iteration. The end is reached when the root node is reached
+	 * again and marked by setting cur_ to nullptr.
+	 */
 	void
 	increment()
 	{
@@ -128,17 +160,27 @@ private:
 		}
 	}
 
-	Node *root_ = nullptr;
-	Node *cur_  = nullptr;
+	Node *root_ = nullptr; ///< stored root node to determine end
+	Node *cur_  = nullptr; ///< stored current node
 };
-
+/**
+ * @brief Create begin-iterator from node for preorder traversal.
+ * @tparam Node
+ * @param root
+ * @return preorder_iterator<Node>
+ */
 template <typename Node>
 preorder_iterator<Node>
 begin(Node *root)
 {
 	return preorder_iterator<Node>{root};
 }
-
+/**
+ * @brief Create end-iterator from node for preorder traversal.
+ * @tparam Node
+ * @param root
+ * @return preorder_iterator<Node>
+ */
 template <typename Node>
 preorder_iterator<Node>
 end(Node *root)

--- a/src/synchronous_product/include/synchronous_product/preorder_traversal.h
+++ b/src/synchronous_product/include/synchronous_product/preorder_traversal.h
@@ -18,6 +18,16 @@ public:
 	}
 };
 
+/// forward declaration of iterator class
+template <class Node>
+class preorder_iterator;
+/// forward declaration of end iterator
+template <typename Node>
+preorder_iterator<Node> end(Node *root);
+/// forward declaration of equality comparison operator
+template <typename Node>
+bool operator==(const preorder_iterator<Node> &lhs, const preorder_iterator<Node> &rhs);
+
 /**
  * @brief Preorder iteratior class.
  * @details Assumes that the tree is built via unique_ptr to child nodes and raw_ptr to parent node.
@@ -26,6 +36,10 @@ public:
 template <class Node>
 class preorder_iterator : public std::iterator<std::forward_iterator_tag, Node>
 {
+	friend preorder_iterator<Node> end<Node>(Node *root);
+	friend bool                    operator==<Node>(const preorder_iterator<Node> &lhs,
+                               const preorder_iterator<Node> &rhs);
+
 public:
 	/// Default constructor
 	preorder_iterator() = default;
@@ -34,15 +48,6 @@ public:
 	 * @param root
 	 */
 	preorder_iterator(Node *root) : root_(root), cur_(root)
-	{
-	}
-	/**
-	 * @brief Construct a new preorder iterator object from a root node and allows setting the current
-	 * node (only used to construct the end-iterator.)
-	 * @param root
-	 * @param cur
-	 */
-	preorder_iterator(Node *root, Node *cur) : root_(root), cur_(cur)
 	{
 	}
 	/// Destructor
@@ -87,28 +92,6 @@ public:
 	operator->()
 	{
 		return cur_;
-	}
-	/**
-	 * @brief Comparison for equality, uses underlying node comparator.
-	 * @param rhs Right-hand side iterator
-	 * @return true If both nodes pointed to are equal
-	 * @return false Otherwise
-	 */
-	bool
-	operator==(const preorder_iterator<Node> &rhs) const
-	{
-		return cur_ == rhs.cur_;
-	}
-	/**
-	 * @brief Comparison for inequality, uses underlying node comparator.
-	 * @param rhs Right-hand side iterator
-	 * @return true If both nodes pointed to are not equal
-	 * @return false Otherwise
-	 */
-	bool
-	operator!=(const preorder_iterator<Node> &rhs) const
-	{
-		return !(*this == rhs);
 	}
 
 private:
@@ -164,6 +147,30 @@ private:
 	Node *cur_  = nullptr; ///< stored current node
 };
 /**
+ * @brief Comparison for equality, uses underlying node comparator.
+ * @param rhs Right-hand side iterator
+ * @return true If both nodes pointed to are equal
+ * @return false Otherwise
+ */
+template <typename Node>
+bool
+operator==(const preorder_iterator<Node> &lhs, const preorder_iterator<Node> &rhs)
+{
+	return lhs.cur_ == rhs.cur_;
+}
+/**
+ * @brief Comparison for inequality, uses underlying node comparator.
+ * @param rhs Right-hand side iterator
+ * @return true If both nodes pointed to are not equal
+ * @return false Otherwise
+ */
+template <typename Node>
+bool
+operator!=(const preorder_iterator<Node> &lhs, const preorder_iterator<Node> &rhs)
+{
+	return !(lhs == rhs);
+}
+/**
  * @brief Create begin-iterator from node for preorder traversal.
  * @tparam Node
  * @param root
@@ -185,7 +192,9 @@ template <typename Node>
 preorder_iterator<Node>
 end(Node *root)
 {
-	return preorder_iterator<Node>{root, nullptr};
+	preorder_iterator<Node> it{root};
+	it.cur_ = nullptr;
+	return it;
 }
 
 } // namespace synchronous_product

--- a/src/synchronous_product/include/synchronous_product/preorder_traversal.h
+++ b/src/synchronous_product/include/synchronous_product/preorder_traversal.h
@@ -1,0 +1,149 @@
+#pragma once
+
+#include <spdlog/spdlog.h>
+
+#include <stdexcept>
+
+namespace synchronous_product {
+
+/// Exception thrown if the tree is inconsistent
+class InconsistentTreeException : public std::logic_error
+{
+public:
+	/** Constructor.
+	 * @param what The error message
+	 */
+	InconsistentTreeException(const std::string &what) : std::logic_error(what)
+	{
+	}
+};
+
+/**
+ * @brief Preorder iteratior class.
+ * @details Assumes that the tree is built via unique_ptr to child nodes and raw_ptr to parent node.
+ * @tparam Node Node type
+ */
+template <class Node>
+class preorder_iterator : public std::iterator<std::forward_iterator_tag, Node>
+{
+public:
+	preorder_iterator() = default;
+	preorder_iterator(Node *root) : root_(root), cur_(root)
+	{
+	}
+	preorder_iterator(Node *root, Node *cur) : root_(root), cur_(cur)
+	{
+	}
+	virtual ~preorder_iterator()
+	{
+	}
+	/**
+	 * @brief Postfix increment
+	 * @return preorder_iterator<Node>
+	 */
+	preorder_iterator<Node>
+	operator++(int)
+	{
+		auto tmp = cur_;
+		increment();
+		return tmp;
+	}
+	/**
+	 * @brief Prefix increment
+	 * @return preorder_iterator<Node>
+	 */
+	preorder_iterator<Node> &
+	operator++()
+	{
+		increment();
+		return *this;
+	}
+
+	Node &
+	operator*()
+	{
+		return *cur_;
+	}
+
+	Node *
+	operator->()
+	{
+		return cur_;
+	}
+
+	bool
+	operator==(const preorder_iterator<Node> &rhs) const
+	{
+		return cur_ == rhs.cur_;
+	}
+
+	bool
+	operator!=(const preorder_iterator<Node> &rhs) const
+	{
+		return !(*this == rhs);
+	}
+
+private:
+	void
+	increment()
+	{
+		// descend through children
+		if (!cur_->children.empty()) {
+			cur_ = cur_->children[0].get();
+			return;
+		} else {
+			// if this is the last child, ascend
+			if (cur_ == cur_->parent->children.back().get()) {
+				while (cur_ != root_ && cur_ == cur_->parent->children.back().get()) {
+					cur_ = cur_->parent;
+				}
+				// reached root - end reached
+				if (cur_ == root_) {
+					cur_ = nullptr;
+					return;
+				} else {
+					// find pos of cur and increment
+					for (auto cPtrIt = cur_->parent->children.begin(); cPtrIt != cur_->parent->children.end();
+					     ++cPtrIt) {
+						if (cPtrIt->get() == cur_) {
+							cur_ = std::next(cPtrIt)->get();
+							return;
+						}
+					}
+					throw InconsistentTreeException(
+					  "Parent-child relation between current and parent node is not bidirectional");
+				}
+			} else {
+				// find pos of cur and increment
+				for (auto cPtrIt = cur_->parent->children.begin(); cPtrIt != cur_->parent->children.end();
+				     ++cPtrIt) {
+					if (cPtrIt->get() == cur_) {
+						cur_ = std::next(cPtrIt)->get();
+						return;
+					}
+				}
+				throw InconsistentTreeException(
+				  "Parent-child relation between current and parent node is not bidirectional");
+			}
+		}
+	}
+
+	Node *root_ = nullptr;
+	Node *cur_  = nullptr;
+};
+
+template <typename Node>
+preorder_iterator<Node>
+begin(Node *root)
+{
+	return preorder_iterator<Node>{root};
+}
+
+template <typename Node>
+preorder_iterator<Node>
+end(Node *root)
+{
+	return preorder_iterator<Node>{root, nullptr};
+}
+
+} // namespace synchronous_product

--- a/src/synchronous_product/include/synchronous_product/preorder_traversal.h
+++ b/src/synchronous_product/include/synchronous_product/preorder_traversal.h
@@ -120,9 +120,12 @@ private:
 				cur_ = nullptr;
 				return;
 			}
-			// if this is the last child, ascend
+			// if this is the last child, ascend until descending to a sibling is possible or the root is
+			// reached
 			assert(cur_->parent != nullptr);
 			if (cur_ == cur_->parent->children.back().get()) {
+				// ascend as long as the node is the last in the parent's children list or until the root
+				// has been reached
 				while (cur_ != root_ && cur_ == cur_->parent->children.back().get()) {
 					cur_ = cur_->parent;
 					if (cur_->parent == nullptr && cur_ != root_) {
@@ -130,34 +133,26 @@ private:
 						  "Parent-child relation between current and parent node is not bidirectional");
 					}
 				}
-				// reached root - end reached
+				// reached root - end reached, terminate iteration
 				if (cur_ == root_) {
 					cur_ = nullptr;
 					return;
-				} else {
-					// find pos of cur and increment
-					for (auto cPtrIt = cur_->parent->children.begin(); cPtrIt != cur_->parent->children.end();
-					     ++cPtrIt) {
-						if (cPtrIt->get() == cur_) {
-							cur_ = std::next(cPtrIt)->get();
-							return;
-						}
-					}
-					throw InconsistentTreeException(
-					  "Parent-child relation between current and parent node is not bidirectional");
 				}
-			} else {
-				// find pos of cur and increment
-				for (auto cPtrIt = cur_->parent->children.begin(); cPtrIt != cur_->parent->children.end();
-				     ++cPtrIt) {
-					if (cPtrIt->get() == cur_) {
-						cur_ = std::next(cPtrIt)->get();
-						return;
-					}
-				}
-				throw InconsistentTreeException(
-				  "Parent-child relation between current and parent node is not bidirectional");
 			}
+			// descend into a sibling (can happen either after ascending or directly, if ascending
+			// is not necessary). To do so, identify position of the current node in the parent's
+			// children-vector and descend into the according next child.
+			for (auto cPtrIt = cur_->parent->children.begin(); cPtrIt != cur_->parent->children.end();
+			     ++cPtrIt) {
+				// found position of child in the parent'S children-vector, increment to descend into next
+				// sibling
+				if (cPtrIt->get() == cur_) {
+					cur_ = std::next(cPtrIt)->get();
+					return;
+				}
+			}
+			throw InconsistentTreeException(
+			  "Parent-child relation between current and parent node is not bidirectional");
 		}
 	}
 

--- a/src/synchronous_product/include/synchronous_product/preorder_traversal.h
+++ b/src/synchronous_product/include/synchronous_product/preorder_traversal.h
@@ -29,7 +29,7 @@ template <typename Node>
 bool operator==(const preorder_iterator<Node> &lhs, const preorder_iterator<Node> &rhs);
 
 /**
- * @brief Preorder iteratior class.
+ * @brief Preorder iterator class.
  * @details Assumes that the tree is built via unique_ptr to child nodes and raw_ptr to parent node.
  * @tparam Node Node type
  */
@@ -160,7 +160,8 @@ private:
 	Node *cur_  = nullptr; ///< stored current node
 };
 /**
- * @brief Comparison for equality, uses underlying node comparator.
+ * @brief Comparison for equality of lhs and rhs, uses underlying node comparator.
+ * @param lhs Left-hand side iterator
  * @param rhs Right-hand side iterator
  * @return true If both nodes pointed to are equal
  * @return false Otherwise
@@ -172,7 +173,8 @@ operator==(const preorder_iterator<Node> &lhs, const preorder_iterator<Node> &rh
 	return lhs.cur_ == rhs.cur_;
 }
 /**
- * @brief Comparison for inequality, uses underlying node comparator.
+ * @brief Comparison for inequality of lhs and rhs, uses underlying node comparator.
+ * @param lhs Left-hand side iterator
  * @param rhs Right-hand side iterator
  * @return true If both nodes pointed to are not equal
  * @return false Otherwise

--- a/src/synchronous_product/include/synchronous_product/search.h
+++ b/src/synchronous_product/include/synchronous_product/search.h
@@ -281,7 +281,7 @@ private:
 	const std::set<ActionType> controller_actions_;
 	const std::set<ActionType> environment_actions_;
 	RegionIndex                K_;
-	bool                       incremental_labeling_;
+	const bool                 incremental_labeling_;
 
 	std::unique_ptr<Node>   tree_root_;
 	utilities::ThreadPool<> pool_{utilities::ThreadPool<>::StartOnInit::NO};

--- a/src/synchronous_product/include/synchronous_product/search_tree.h
+++ b/src/synchronous_product/include/synchronous_product/search_tree.h
@@ -89,6 +89,7 @@ struct SearchTreeNode
 	label_propagate(const std::set<ActionType> &controller_actions,
 	                const std::set<ActionType> &environment_actions)
 	{
+		SPDLOG_TRACE("Call propagate on node {}", *this);
 		// leaf-nodes should always be labelled directly
 		assert(!children.empty() || label != NodeLabel::UNLABELED);
 		// if not already happened: call recursively on parent node

--- a/src/synchronous_product/include/synchronous_product/search_tree.h
+++ b/src/synchronous_product/include/synchronous_product/search_tree.h
@@ -98,12 +98,14 @@ struct SearchTreeNode
 				SPDLOG_TRACE("Node {} is a leaf, propagate labels.", *this);
 				parent->label_propagate(controller_actions, environment_actions);
 			}
+			return;
 		}
 		// do nothing if the node is already labelled
 		if (label != NodeLabel::UNLABELED && !children.empty()) {
 			SPDLOG_TRACE("Node is already labelled, abort.");
 			return;
 		}
+		assert(!children.empty());
 		// find good and bad child nodes which are already labelled and determine their order (with
 		// respect to time). Also keep track of yet unlabelled nodes (both cases, environmental and
 		// controller action).
@@ -148,26 +150,26 @@ struct SearchTreeNode
 			if (parent != nullptr) {
 				parent->label_propagate(controller_actions, environment_actions);
 			}
-		}
-		/*
-		else if (first_bad_environment_step == std::numeric_limits<RegionIndex>::max()
+		} else if (first_bad_environment_step == std::numeric_limits<RegionIndex>::max()
 		           && first_non_good_environment_step == std::numeric_limits<RegionIndex>::max()
 		           && first_good_controller_step == std::numeric_limits<RegionIndex>::max()
 		           && first_non_bad_controller_step == std::numeric_limits<RegionIndex>::max()) {
-		  // Here, there is no case where a controller can enforce a good action
-		  // and no case where the environment can enforce a bad action. Moreover, there is no
-		  // unlabelled node, as the non-good/non-bad labels also have not been set. Thus, waiting,
-		  // i.e., no controller action at all solves the case and the node can be labelled as GOOD.
-		  assert(std::none_of(children.begin(), children.end(), [](const auto &child) {
-		    return child->label == NodeLabel::UNLABELED;
-		  }));
-		  label = NodeLabel::TOP;
-		  SPDLOG_TRACE("Label with TOP");
-		  if (parent != nullptr) {
-		    parent->label_propagate(controller_actions, environment_actions);
-		  }
+			// Here, there is no case where a controller can enforce a good action
+			// and no case where the environment can enforce a bad action. Moreover, there is no
+			// unlabelled node, as the non-good/non-bad labels also have not been set. Thus, waiting,
+			// i.e., no controller action at all solves the case and the node can be labelled as GOOD.
+			assert(std::none_of(children.begin(), children.end(), [](const auto &child) {
+				return child->label == NodeLabel::UNLABELED;
+			}));
+			SPDLOG_TRACE(
+			  "Label node {} with TOP as all labels are determined and no good controller action is "
+			  "available and no bad environment action is possible.",
+			  *this);
+			label = NodeLabel::TOP;
+			if (parent != nullptr) {
+				parent->label_propagate(controller_actions, environment_actions);
+			}
 		}
-		*/
 	}
 
 	/**

--- a/src/synchronous_product/include/synchronous_product/search_tree.h
+++ b/src/synchronous_product/include/synchronous_product/search_tree.h
@@ -69,7 +69,9 @@ struct SearchTreeNode
 		assert(!incoming_actions.empty() || parent == nullptr);
 	}
 	/**
-	 * @brief Implements incremental labeling as discussed.
+	 * @brief Implements incremental labeling during search, bottom up. Nodes are labelled as soon as
+	 * their label state can definitely be determined either because they are leaf-nodes or because
+	 * the labeling of child nodes permits to determine a label (see details).
 	 * @details Leaf-nodes can directly be labelled (in most cases?), the corresponding label pushed
 	 * upwards in the search tree may allow for shortening the search significantly in the following
 	 * cases: 1) A child is labelled "BAD" and there is no control-action which can be taken before

--- a/src/synchronous_product/include/synchronous_product/search_tree.h
+++ b/src/synchronous_product/include/synchronous_product/search_tree.h
@@ -140,16 +140,41 @@ struct SearchTreeNode
 		}
 	}
 
+	/**
+	 * @brief Iterator to the beginning of the sequence induced by preorder traversal of the subtree
+	 * induced by this node.
+	 * @return preorder_iterator<SearchTreeNode<Location, ActionType>>
+	 */
 	preorder_iterator<SearchTreeNode<Location, ActionType>>
 	begin()
 	{
 		return synchronous_product::begin(this);
 	}
 
+	/**
+	 * @brief Iterator to the end of the sequence induced by preorder traversal of the subtree induced
+	 * by this node.
+	 * @return preorder_iterator<SearchTreeNode<Location, ActionType>>
+	 */
 	preorder_iterator<SearchTreeNode<Location, ActionType>>
 	end()
 	{
 		return synchronous_product::end(this);
+	}
+
+	/**
+	 * @brief Compares two nodes for equality.
+	 * @param other The other node
+	 * @return true If both nodes are the same (without considering subtrees)
+	 * @return false Otherwise
+	 */
+	bool
+	operator==(const SearchTreeNode<Location, ActionType> &other) const
+	{
+		return this->words == other.words && this->state == other.state
+		       && this->label == other.label
+		       //&& this->parent == other.parent && this->children == other.children
+		       && this->incoming_actions == other.incoming_actions;
 	}
 
 	/** The words of the node */

--- a/src/synchronous_product/include/synchronous_product/search_tree.h
+++ b/src/synchronous_product/include/synchronous_product/search_tree.h
@@ -19,13 +19,16 @@
 
 #pragma once
 
+#include "automata/ta_regions.h"
 #include "canonical_word.h"
 #include "preorder_traversal.h"
 #include "reg_a.h"
 
 #include <spdlog/spdlog.h>
 
+#include <algorithm>
 #include <iostream>
+#include <limits>
 #include <memory>
 
 namespace synchronous_product {
@@ -146,6 +149,25 @@ struct SearchTreeNode
 				parent->label_propagate(controller_actions, environment_actions);
 			}
 		}
+		/*
+		else if (first_bad_environment_step == std::numeric_limits<RegionIndex>::max()
+		           && first_non_good_environment_step == std::numeric_limits<RegionIndex>::max()
+		           && first_good_controller_step == std::numeric_limits<RegionIndex>::max()
+		           && first_non_bad_controller_step == std::numeric_limits<RegionIndex>::max()) {
+		  // Here, there is no case where a controller can enforce a good action
+		  // and no case where the environment can enforce a bad action. Moreover, there is no
+		  // unlabelled node, as the non-good/non-bad labels also have not been set. Thus, waiting,
+		  // i.e., no controller action at all solves the case and the node can be labelled as GOOD.
+		  assert(std::none_of(children.begin(), children.end(), [](const auto &child) {
+		    return child->label == NodeLabel::UNLABELED;
+		  }));
+		  label = NodeLabel::TOP;
+		  SPDLOG_TRACE("Label with TOP");
+		  if (parent != nullptr) {
+		    parent->label_propagate(controller_actions, environment_actions);
+		  }
+		}
+		*/
 	}
 
 	/**

--- a/src/synchronous_product/include/synchronous_product/search_tree.h
+++ b/src/synchronous_product/include/synchronous_product/search_tree.h
@@ -20,6 +20,7 @@
 #pragma once
 
 #include "canonical_word.h"
+#include "preorder_traversal.h"
 #include "reg_a.h"
 
 #include <spdlog/spdlog.h>
@@ -137,6 +138,18 @@ struct SearchTreeNode
 				parent->label_propagate(controller_actions, environment_actions);
 			}
 		}
+	}
+
+	preorder_iterator<SearchTreeNode<Location, ActionType>>
+	begin()
+	{
+		return synchronous_product::begin(this);
+	}
+
+	preorder_iterator<SearchTreeNode<Location, ActionType>>
+	end()
+	{
+		return synchronous_product::end(this);
 	}
 
 	/** The words of the node */

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -66,6 +66,9 @@ add_executable(test_priority_thread_pool test_priority_thread_pool.cpp)
 target_link_libraries(test_priority_thread_pool PRIVATE utilities Catch2::Catch2WithMain)
 catch_discover_tests(test_priority_thread_pool)
 
+add_executable(test_tree_iteration test_tree_iteration.cpp)
+target_link_libraries(test_tree_iteration PRIVATE  synchronous_product Catch2::Catch2WithMain)
+catch_discover_tests(test_tree_iteration)
 
 if (COVERAGE)
   # Depend on all targets in the current directory.

--- a/test/test_search.cpp
+++ b/test/test_search.cpp
@@ -67,6 +67,7 @@ TEST_CASE("Search in an ABConfiguration tree", "[search]")
 	logic::MTLFormula f   = a.until(b, logic::TimeInterval(2, BoundType::WEAK, 2, BoundType::INFTY));
 	auto              ata = mtl_ata_translation::translate(f);
 	TreeSearch        search(&ta, &ata, {"a"}, {"b", "c"}, 2);
+	TreeSearch        search_incremental_labeling(&ta, &ata, {"a"}, {"b", "c"}, 2, true);
 
 	SECTION("The search tree is initialized correctly")
 	{
@@ -178,6 +179,26 @@ TEST_CASE("Search in an ABConfiguration tree", "[search]")
 		CHECK(search.get_root()->children[0]->children[0]->label == NodeLabel::TOP);
 		CHECK(search.get_root()->children[0]->children[1]->label == NodeLabel::BOTTOM);
 		CHECK(search.get_root()->children[0]->children[2]->label == NodeLabel::BOTTOM);
+	}
+	SECTION("Compare to incremental labeling")
+	{
+		// build standard tree
+		while (search.step()) {};
+		search.label();
+		// comparison to incremental labeling approach
+		while (search_incremental_labeling.step()) {};
+		// check trees for equivalence
+		CHECK(search.get_root()->label == search_incremental_labeling.get_root()->label);
+		auto searchTreeIt            = search.get_root()->begin();
+		auto searchTreeIncrementalIt = search_incremental_labeling.get_root()->begin();
+		while (searchTreeIt != search.get_root()->end()) {
+			CHECK(*searchTreeIt == *searchTreeIncrementalIt);
+			++searchTreeIt;
+			++searchTreeIncrementalIt;
+		}
+		// print trees
+		INFO("Tree:\n" << *search.get_root());
+		INFO("Tree (incremental):\n" << *search_incremental_labeling.get_root());
 	}
 }
 

--- a/test/test_search.cpp
+++ b/test/test_search.cpp
@@ -412,6 +412,20 @@ TEST_CASE("Incremental labeling on constructed cases", "[search]")
 		root->children[0]->children[0]->label_propagate(controller_actions, environment_actions);
 		CHECK(root->children[0]->label == NodeLabel::TOP);
 		CHECK(root->label == NodeLabel::TOP);
+		// reset tree, this time label ch4 as good and ch5 as bad.
+		resetTreeLabels();
+		// set child labels
+		root->label                           = NodeLabel::UNLABELED;
+		root->children[0]->label              = NodeLabel::UNLABELED;
+		root->children[1]->label              = NodeLabel::BOTTOM;
+		root->children[2]->label              = NodeLabel::BOTTOM;
+		root->children[0]->children[0]->label = NodeLabel::TOP;
+		root->children[0]->children[1]->label = NodeLabel::BOTTOM;
+		// call to propagate on any child ch4, ch4 should assign a label TOP to ch1 and root should be
+		// labelled TOP as well
+		root->children[0]->children[0]->label_propagate(controller_actions, environment_actions);
+		CHECK(root->children[0]->label == NodeLabel::TOP);
+		CHECK(root->label == NodeLabel::TOP);
 		// reset tree, this time label ch4 and 5 as bad.
 		resetTreeLabels();
 		root->label                           = NodeLabel::UNLABELED;

--- a/test/test_search.cpp
+++ b/test/test_search.cpp
@@ -249,12 +249,21 @@ TEST_CASE("Invoke incremental labelling on a trivial example", "[search]")
 
 	logic::MTLFormula f   = c.until(e1, logic::TimeInterval(2, BoundType::WEAK, 2, BoundType::INFTY));
 	auto              ata = mtl_ata_translation::translate(f);
-	// TODO Call to incremenal labeling
-	TreeSearch search(&ta, &ata, {"c"}, {"e0", "e1"}, 2, true);
+	TreeSearch        search_incremental(&ta, &ata, {"c"}, {"e0", "e1"}, 2, true);
+	TreeSearch        search(&ta, &ata, {"c"}, {"e0", "e1"}, 2, false);
 	while (search.step()) {};
-	// search.label();
+	search.label();
+	while (search_incremental.step()) {};
 	INFO("Tree:\n" << *search.get_root());
-	CHECK(search.get_root()->label == NodeLabel::TOP);
+	// check trees for equivalence
+	CHECK(search.get_root()->label == search_incremental.get_root()->label);
+	auto searchTreeIt            = search.get_root()->begin();
+	auto searchTreeIncrementalIt = search_incremental.get_root()->begin();
+	while (searchTreeIt != search.get_root()->end()) {
+		CHECK(*searchTreeIt == *searchTreeIncrementalIt);
+		++searchTreeIt;
+		++searchTreeIncrementalIt;
+	}
 	// CHECK(false);
 }
 

--- a/test/test_tree_iteration.cpp
+++ b/test/test_tree_iteration.cpp
@@ -1,5 +1,5 @@
 /***************************************************************************
- *  test_search.cpp - Test the tree preorder iteration
+ *  test_tree_iteration.cpp - Test the tree preorder iteration
  *
  *  Created:   Fri  12 Mar 14:17:00 CET 2021
  *  Copyright  2021  Stefan Schupp <stefan.schupp@cs.rwth-aachen.de>

--- a/test/test_tree_iteration.cpp
+++ b/test/test_tree_iteration.cpp
@@ -1,0 +1,131 @@
+/***************************************************************************
+ *  test_search.cpp - Test the tree preorder iteration
+ *
+ *  Created:   Fri  12 Mar 14:17:00 CET 2021
+ *  Copyright  2021  Stefan Schupp <stefan.schupp@cs.rwth-aachen.de>
+ ****************************************************************************/
+/*  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Library General Public License for more details.
+ *
+ *  Read the full text in the LICENSE.md file.
+ */
+
+#include "synchronous_product/preorder_traversal.h"
+#include "synchronous_product/search_tree.h"
+
+#include <spdlog/details/synchronous_factory.h>
+#include <spdlog/spdlog.h>
+
+#include <catch2/catch_test_macros.hpp>
+#include <memory>
+#include <ostream>
+
+namespace {
+
+struct TestNode
+{
+	TestNode(int d, TestNode *parent = nullptr) : data(d), parent(parent)
+	{
+	}
+	int                                    data;
+	TestNode *                             parent   = nullptr;
+	std::vector<std::unique_ptr<TestNode>> children = {};
+
+	bool
+	operator==(const TestNode &rhs) const
+	{
+		return data == rhs.data;
+	}
+};
+
+std::ostream &
+operator<<(std::ostream &out, const TestNode &n)
+{
+	out << n.data;
+	if (n.parent != nullptr) {
+		out << " parent: " << n.parent->data;
+	} else {
+		out << " parent: NULL";
+	}
+	return out;
+}
+
+TEST_CASE("Simple Tree traversal", "[search]")
+{
+	spdlog::set_level(spdlog::level::trace);
+	TestNode *root = new TestNode(0);
+	root->children.emplace_back(std::make_unique<TestNode>(1, root));
+	root->children.emplace_back(std::make_unique<TestNode>(2, root));
+	root->children.emplace_back(std::make_unique<TestNode>(3, root));
+	root->children.emplace_back(std::make_unique<TestNode>(4, root));
+	synchronous_product::preorder_iterator<TestNode> it = synchronous_product::begin(root);
+
+	CHECK(*it == *root);
+	CHECK((++it)->data == 1);
+	CHECK((++it)->data == 2);
+	CHECK((++it)->data == 3);
+	CHECK((++it)->data == 4);
+	CHECK((++it) == synchronous_product::end(root));
+}
+
+TEST_CASE("Multilevel Tree traversal", "[search]")
+{
+	spdlog::set_level(spdlog::level::trace);
+	TestNode *root = new TestNode(0);
+	root->children.emplace_back(std::make_unique<TestNode>(1, root));
+	root->children.emplace_back(std::make_unique<TestNode>(2, root));
+	root->children.emplace_back(std::make_unique<TestNode>(3, root));
+	root->children.emplace_back(std::make_unique<TestNode>(4, root));
+	root->children[0]->children.emplace_back(std::make_unique<TestNode>(5, root->children[0].get()));
+	root->children[0]->children.emplace_back(std::make_unique<TestNode>(6, root->children[0].get()));
+	root->children[3]->children.emplace_back(std::make_unique<TestNode>(7, root->children[3].get()));
+	root->children[3]->children.emplace_back(std::make_unique<TestNode>(8, root->children[3].get()));
+	synchronous_product::preorder_iterator<TestNode> it = synchronous_product::begin(root);
+
+	CHECK(*it == *root);
+	CHECK((++it)->data == 1);
+	CHECK((++it)->data == 5);
+	CHECK((++it)->data == 6);
+	CHECK((++it)->data == 2);
+	CHECK((++it)->data == 3);
+	CHECK((++it)->data == 4);
+	CHECK((++it)->data == 7);
+	CHECK((++it)->data == 8);
+	CHECK((++it) == synchronous_product::end(root));
+}
+
+TEST_CASE("Multilevel Subtree traversal", "[search]")
+{
+	spdlog::set_level(spdlog::level::trace);
+	TestNode *root = new TestNode(0);
+	root->children.emplace_back(std::make_unique<TestNode>(1, root));
+	root->children.emplace_back(std::make_unique<TestNode>(2, root));
+	root->children.emplace_back(std::make_unique<TestNode>(3, root));
+	root->children.emplace_back(std::make_unique<TestNode>(4, root));
+	root->children[0]->children.emplace_back(std::make_unique<TestNode>(5, root->children[0].get()));
+	root->children[0]->children.emplace_back(std::make_unique<TestNode>(6, root->children[0].get()));
+	root->children[0]->children[1]->children.emplace_back(
+	  std::make_unique<TestNode>(9, root->children[0]->children[1].get()));
+	root->children[0]->children[1]->children.emplace_back(
+	  std::make_unique<TestNode>(10, root->children[0]->children[1].get()));
+	root->children[3]->children.emplace_back(std::make_unique<TestNode>(7, root->children[3].get()));
+	root->children[3]->children.emplace_back(std::make_unique<TestNode>(8, root->children[3].get()));
+	synchronous_product::preorder_iterator<TestNode> it =
+	  synchronous_product::begin(root->children[0].get());
+
+	CHECK(*it == *root->children[0].get());
+	CHECK((++it)->data == 5);
+	CHECK((++it)->data == 6);
+	CHECK((++it)->data == 9);
+	CHECK((++it)->data == 10);
+	CHECK((++it) == synchronous_product::end(root));
+}
+
+} // namespace


### PR DESCRIPTION
Add incremental labeling to the search, this includes:

- A labeling approach which labels bottom-up as soon as a label can be determined. This is the case analogous to the top-down approach: Leaves can directly be labelled, intermediate nodes are labelled as soon as their label can be determined by the labeling of child nodes. In contrast to the recursive approach, incremental-labeling calls are propagated to the parent nodes and terminate as soon as the label of the current node cannot be determined.
- A pre-order tree iterator: This was required to allow comparison of trees and sub-trees. The iterator traverses a tree induced by the starting node in pre-order (root-left-right) and ends once the starting node is reached again. The implementation relies on the tree being built from unique_ptr for child nodes.