### PR TITLE
Also consider intervals when comparing MTL formulas

### DIFF
--- a/src/mtl/include/mtl/MTLFormula.h
+++ b/src/mtl/include/mtl/MTLFormula.h
@@ -215,6 +215,12 @@ public:
 	bool
 	operator==(const MTLFormula &rhs) const
 	{
+		// Intervals may be unequal even though !(I1 < I2) and !(I2 < I1), thus check them separately.
+		if (((operator_ == LOP::LUNTIL && rhs.operator_ == LOP::LUNTIL)
+		     || (operator_ == LOP::LDUNTIL && rhs.operator_ == LOP::LDUNTIL))
+		    && duration_ != rhs.duration_) {
+			return false;
+		}
 		return !(*this < rhs) && !(rhs < *this);
 	}
 	/// not-equal operator

--- a/src/mtl/include/mtl/MTLFormula.h
+++ b/src/mtl/include/mtl/MTLFormula.h
@@ -215,12 +215,6 @@ public:
 	bool
 	operator==(const MTLFormula &rhs) const
 	{
-		// Intervals may be unequal even though !(I1 < I2) and !(I2 < I1), thus check them separately.
-		if (((operator_ == LOP::LUNTIL && rhs.operator_ == LOP::LUNTIL)
-		     || (operator_ == LOP::LDUNTIL && rhs.operator_ == LOP::LDUNTIL))
-		    && duration_ != rhs.duration_) {
-			return false;
-		}
 		return !(*this < rhs) && !(rhs < *this);
 	}
 	/// not-equal operator

--- a/src/mtl/include/mtl/MTLFormula.hpp
+++ b/src/mtl/include/mtl/MTLFormula.hpp
@@ -46,10 +46,12 @@ operator<<(std::ostream &out, const logic::MTLFormula<APType> &f)
 		break;
 	case LOP::LNEG: out << "!(" << f.get_operands().front() << ")"; break;
 	case LOP::LUNTIL:
-		out << "(" << f.get_operands().front() << " U " << f.get_operands().back() << ")";
+		out << "(" << f.get_operands().front() << " U" << f.get_interval() << " "
+		    << f.get_operands().back() << ")";
 		break;
 	case LOP::LDUNTIL:
-		out << "(" << f.get_operands().front() << " ~U " << f.get_operands().back() << ")";
+		out << "(" << f.get_operands().front() << " ~U" << f.get_interval() << " "
+		    << f.get_operands().back() << ")";
 		break;
 	}
 	return out;

--- a/src/mtl/include/mtl/MTLFormula.hpp
+++ b/src/mtl/include/mtl/MTLFormula.hpp
@@ -216,6 +216,16 @@ MTLFormula<APType>::operator<(const MTLFormula &rhs) const
 	// Note: since the operators are the same, the size of operands needs to be the same
 	assert(this->get_operands().size() == rhs.get_operands().size());
 
+	// Compare intervals before operands.
+	if (operator_ == LOP::LUNTIL || operator_ == LOP::LDUNTIL) {
+		if (duration_ < rhs.duration_) {
+			return true;
+		}
+		if (rhs.duration_ < duration_) {
+			return false;
+		}
+	}
+
 	return std::lexicographical_compare(this->get_operands().begin(),
 	                                    this->get_operands().end(),
 	                                    rhs.get_operands().begin(),

--- a/src/mtl/include/mtl/MTLFormula.hpp
+++ b/src/mtl/include/mtl/MTLFormula.hpp
@@ -40,6 +40,8 @@ operator<<(std::ostream &out, const logic::MTLFormula<APType> &f)
 	  [](std::ostream &out, const logic::MTLFormula<APType> &f, std::string_view op_symbol) {
 		  out << "(" << f.get_operands().front() << " " << op_symbol;
 		  const auto &interval = f.get_interval();
+		  // Only print interval if it is not (INFTY, INFTY), this corresponds to the usual short
+		  // notation used in the literature.
 		  if (interval.lowerBoundType() != BoundType::INFTY
 		      || interval.upperBoundType() != BoundType::INFTY) {
 			  out << interval;

--- a/src/mtl/include/mtl/MTLFormula.hpp
+++ b/src/mtl/include/mtl/MTLFormula.hpp
@@ -20,6 +20,7 @@
 #pragma once
 
 #include "MTLFormula.h"
+#include "utilities/Interval.h"
 
 template <typename APType>
 std::ostream &
@@ -34,6 +35,17 @@ std::ostream &
 operator<<(std::ostream &out, const logic::MTLFormula<APType> &f)
 {
 	using logic::LOP;
+	using utilities::arithmetic::BoundType;
+	const auto print_until =
+	  [](std::ostream &out, const logic::MTLFormula<APType> &f, std::string_view op_symbol) {
+		  out << "(" << f.get_operands().front() << " " << op_symbol;
+		  const auto &interval = f.get_interval();
+		  if (interval.lowerBoundType() != BoundType::INFTY
+		      || interval.upperBoundType() != BoundType::INFTY) {
+			  out << interval;
+		  }
+		  out << " " << f.get_operands().back() << ")";
+	  };
 	switch (f.get_operator()) {
 	case LOP::TRUE: out << u8"⊤"; break;
 	case LOP::FALSE: out << u8"⊥"; break;
@@ -45,14 +57,8 @@ operator<<(std::ostream &out, const logic::MTLFormula<APType> &f)
 		out << "(" << f.get_operands().front() << " || " << f.get_operands().back() << ")";
 		break;
 	case LOP::LNEG: out << "!(" << f.get_operands().front() << ")"; break;
-	case LOP::LUNTIL:
-		out << "(" << f.get_operands().front() << " U" << f.get_interval() << " "
-		    << f.get_operands().back() << ")";
-		break;
-	case LOP::LDUNTIL:
-		out << "(" << f.get_operands().front() << " ~U" << f.get_interval() << " "
-		    << f.get_operands().back() << ")";
-		break;
+	case LOP::LUNTIL: print_until(out, f, "U"); break;
+	case LOP::LDUNTIL: print_until(out, f, "~U"); break;
 	}
 	return out;
 }

--- a/src/utilities/include/utilities/Interval.h
+++ b/src/utilities/include/utilities/Interval.h
@@ -126,11 +126,6 @@ public:
 	friend std::ostream &
 	operator<<(std::ostream &os, const Interval &interval)
 	{
-		if (interval.lowerBoundType_ == BoundType::INFTY
-		    && interval.upperBoundType_ == BoundType::INFTY) {
-			// Do not print anything.
-			return os;
-		}
 		switch (interval.lowerBoundType_) {
 		case BoundType::WEAK:
 		case BoundType::INFTY: os << "("; break;

--- a/src/utilities/include/utilities/Interval.h
+++ b/src/utilities/include/utilities/Interval.h
@@ -68,6 +68,14 @@ public:
 	friend bool
 	operator<(const Interval &first, const Interval &second)
 	{
+		assert(first.lowerBoundType_ != BoundType::INFTY
+		       || first.lower_ == std::numeric_limits<N>::min());
+		assert(first.upperBoundType_ != BoundType::INFTY
+		       || first.upper_ == std::numeric_limits<N>::max());
+		assert(second.lowerBoundType_ != BoundType::INFTY
+		       || second.lower_ == std::numeric_limits<N>::min());
+		assert(second.upperBoundType_ != BoundType::INFTY
+		       || second.upper_ == std::numeric_limits<N>::max());
 		auto to_tuple = [](const Interval &interval) {
 			return std::tie(interval.lower_,
 			                interval.lowerBoundType_,

--- a/src/utilities/include/utilities/Interval.h
+++ b/src/utilities/include/utilities/Interval.h
@@ -2,6 +2,8 @@
 
 #include "assert.h"
 
+#include <ostream>
+
 namespace utilities {
 namespace arithmetic {
 
@@ -124,6 +126,43 @@ public:
 	operator!=(const Interval &first, const Interval &second)
 	{
 		return !(first == second);
+	}
+
+	/// Print an interval to an ostream.
+	/** @param os The ostream to print to.
+	 * @param interval The interval to print.
+	 * @return A reference to the ostream.
+	 */
+	friend std::ostream &
+	operator<<(std::ostream &os, const Interval &interval)
+	{
+		if (interval.lowerBoundType_ == BoundType::INFTY
+		    && interval.upperBoundType_ == BoundType::INFTY) {
+			// Do not print anything.
+			return os;
+		}
+		switch (interval.lowerBoundType_) {
+		case BoundType::WEAK:
+		case BoundType::INFTY: os << "("; break;
+		case BoundType::STRICT: os << "["; break;
+		}
+		if (interval.lowerBoundType_ == BoundType::INFTY) {
+			os << u8"∞";
+		} else {
+			os << interval.lower_;
+		}
+		os << ", ";
+		if (interval.upperBoundType_ == BoundType::INFTY) {
+			os << u8"∞";
+		} else {
+			os << interval.upper_;
+		}
+		switch (interval.upperBoundType_) {
+		case BoundType::WEAK:
+		case BoundType::INFTY: os << ")"; break;
+		case BoundType::STRICT: os << "]"; break;
+		}
+		return os;
 	}
 
 	/**

--- a/src/utilities/include/utilities/Interval.h
+++ b/src/utilities/include/utilities/Interval.h
@@ -2,6 +2,7 @@
 
 #include "assert.h"
 
+#include <limits>
 #include <ostream>
 
 namespace utilities {
@@ -37,14 +38,20 @@ public:
 	/**
 	 * @brief Construct a new Interval object from bounds and bound types
 	 *
-	 * @param lb
-	 * @param lbType
-	 * @param up
-	 * @param upType
+	 * @param lb The value of the lower bound (ignored if lbType == INFTY)
+	 * @param lbType The type of the lower bound
+	 * @param ub The value of the higher bound (ignored if ubType == INFTY)
+	 * @param ubType The type of the higher bound
 	 */
-	Interval(N lb, BoundType lbType, N up, BoundType upType)
-	: lower_(lb), upper_(up), lowerBoundType_(lbType), upperBoundType_(upType)
+	Interval(N lb, BoundType lbType, N ub, BoundType ubType)
+	: lower_(lb), upper_(ub), lowerBoundType_(lbType), upperBoundType_(ubType)
 	{
+		if (lbType == BoundType::INFTY) {
+			lower_ = std::numeric_limits<N>::min();
+		}
+		if (ubType == BoundType::INFTY) {
+			upper_ = std::numeric_limits<N>::max();
+		}
 	}
 
 	/// Check if the first interval is smaller than the second.
@@ -236,8 +243,8 @@ private:
 		       || (upperBoundType_ == BoundType::WEAK && value <= upper_);
 	}
 
-	N         lower_          = 0;
-	N         upper_          = 0;
+	N         lower_          = std::numeric_limits<N>::min();
+	N         upper_          = std::numeric_limits<N>::max();
 	BoundType lowerBoundType_ = BoundType::INFTY;
 	BoundType upperBoundType_ = BoundType::INFTY;
 };

--- a/test/test_interval.cpp
+++ b/test/test_interval.cpp
@@ -130,7 +130,7 @@ TEST_CASE("Print an interval", "[libmtl][print]")
 	SECTION("No bounds")
 	{
 		str << Interval();
-		CHECK(str.str() == "");
+		CHECK(str.str() == "(∞, ∞)");
 	}
 	SECTION("weak lower bound")
 	{

--- a/test/test_interval.cpp
+++ b/test/test_interval.cpp
@@ -34,6 +34,36 @@ TEST_CASE("Construction of intervals", "[libmtl]")
 	REQUIRE(Interval().upperBoundType() == BoundType::INFTY);
 }
 
+TEST_CASE("Interval comparison", "[libmtl]")
+{
+	// Less than
+	CHECK(Interval(1, BoundType::WEAK, 0, BoundType::INFTY) < Interval());
+	CHECK(Interval(1, BoundType::WEAK, 0, BoundType::INFTY)
+	      < Interval(2, BoundType::WEAK, 0, BoundType::INFTY));
+	CHECK(Interval(1, BoundType::STRICT, 0, BoundType::INFTY)
+	      < Interval(2, BoundType::WEAK, 0, BoundType::INFTY));
+	CHECK(Interval(1, BoundType::WEAK, 0, BoundType::INFTY)
+	      < Interval(1, BoundType::STRICT, 0, BoundType::INFTY));
+	CHECK(Interval(0, BoundType::INFTY, 2, BoundType::WEAK)
+	      < Interval(0, BoundType::INFTY, 3, BoundType::WEAK));
+	CHECK(Interval(0, BoundType::INFTY, 2, BoundType::STRICT)
+	      < Interval(0, BoundType::INFTY, 3, BoundType::STRICT));
+	CHECK(Interval(0, BoundType::INFTY, 1, BoundType::WEAK)
+	      < Interval(0, BoundType::INFTY, 1, BoundType::STRICT));
+	// Value is ignored if bound type is INFTY.
+	CHECK(Interval(6, BoundType::INFTY, 2, BoundType::WEAK)
+	      < Interval(0, BoundType::INFTY, 3, BoundType::WEAK));
+
+	CHECK(Interval() > Interval(1, BoundType::WEAK, 0, BoundType::INFTY));
+
+	// Equality
+	CHECK(Interval() == Interval());
+	CHECK(Interval(1, BoundType::WEAK, 0, BoundType::INFTY) != Interval());
+	CHECK(Interval(1, BoundType::WEAK, 0, BoundType::INFTY)
+	      != Interval(1, BoundType::STRICT, 0, BoundType::INFTY));
+	CHECK(Interval(1, BoundType::INFTY, 0, BoundType::INFTY) == Interval());
+}
+
 TEST_CASE("Emptiness", "[libmtl]")
 {
 	REQUIRE(!Interval(2, 3).is_empty());

--- a/test/test_interval.cpp
+++ b/test/test_interval.cpp
@@ -39,14 +39,14 @@ TEST_CASE("Interval comparison", "[libmtl]")
 {
 	// Less than
 	CHECK(!(Interval() < Interval()));
-	CHECK(!(Interval(0, BoundType::INFTY, 2, BoundType::WEAK) < Interval()));
+	CHECK(Interval(0, BoundType::INFTY, 2, BoundType::WEAK) < Interval());
 	CHECK(!(Interval(1, BoundType::WEAK, 2, BoundType::WEAK) < Interval()));
 	CHECK(!(Interval(1, BoundType::WEAK, 2, BoundType::WEAK)
 	        < Interval(0, BoundType::INFTY, 1, BoundType::WEAK)));
 	CHECK(!(Interval(1, BoundType::WEAK, 2, BoundType::WEAK)
 	        < Interval(1, BoundType::WEAK, 2, BoundType::WEAK)));
-	CHECK(!(Interval(1, BoundType::WEAK, 2, BoundType::WEAK)
-	        < Interval(2, BoundType::WEAK, 3, BoundType::WEAK)));
+	CHECK(Interval(1, BoundType::WEAK, 2, BoundType::WEAK)
+	      < Interval(2, BoundType::WEAK, 3, BoundType::WEAK));
 	CHECK(Interval(1, BoundType::WEAK, 2, BoundType::WEAK)
 	      < Interval(3, BoundType::WEAK, 4, BoundType::WEAK));
 	CHECK(Interval(1, BoundType::WEAK, 2, BoundType::WEAK)
@@ -56,14 +56,14 @@ TEST_CASE("Interval comparison", "[libmtl]")
 
 	// Bigger than
 	CHECK(!(Interval() < Interval()));
-	CHECK(!(Interval() > Interval(0, BoundType::INFTY, 2, BoundType::WEAK)));
+	CHECK(Interval() > Interval(0, BoundType::INFTY, 2, BoundType::WEAK));
 	CHECK(!(Interval() > Interval(1, BoundType::WEAK, 2, BoundType::WEAK)));
 	CHECK(!(Interval(0, BoundType::INFTY, 1, BoundType::WEAK)
 	        > Interval(1, BoundType::WEAK, 2, BoundType::WEAK)));
 	CHECK(!(Interval(1, BoundType::WEAK, 2, BoundType::WEAK)
 	        > Interval(1, BoundType::WEAK, 2, BoundType::WEAK)));
-	CHECK(!(Interval(2, BoundType::WEAK, 3, BoundType::WEAK)
-	        > Interval(1, BoundType::WEAK, 2, BoundType::WEAK)));
+	CHECK(Interval(2, BoundType::WEAK, 3, BoundType::WEAK)
+	      > Interval(1, BoundType::WEAK, 2, BoundType::WEAK));
 	CHECK(Interval(3, BoundType::WEAK, 4, BoundType::WEAK)
 	      > Interval(1, BoundType::WEAK, 2, BoundType::WEAK));
 	CHECK(Interval(2, BoundType::STRICT, 3, BoundType::WEAK)

--- a/test/test_interval.cpp
+++ b/test/test_interval.cpp
@@ -21,6 +21,7 @@
 #include "utilities/Interval.h"
 
 #include <catch2/catch_test_macros.hpp>
+#include <sstream>
 
 namespace {
 using Interval = utilities::arithmetic::Interval<int>;
@@ -98,4 +99,38 @@ TEST_CASE("Containment of values", "[libmtl]")
 	REQUIRE(!Interval(2, BoundType::STRICT, 2, BoundType::STRICT).contains(2));
 }
 
+TEST_CASE("Print an interval", "[libmtl][print]")
+{
+	std::stringstream str;
+	SECTION("No bounds")
+	{
+		str << Interval();
+		CHECK(str.str() == "");
+	}
+	SECTION("weak lower bound")
+	{
+		str << Interval(1, BoundType::WEAK, 0, BoundType::INFTY);
+		CHECK(str.str() == u8"(1, ∞)");
+	}
+	SECTION("strict lower bound")
+	{
+		str << Interval(2, BoundType::STRICT, 0, BoundType::INFTY);
+		CHECK(str.str() == u8"[2, ∞)");
+	}
+	SECTION("weak upper bound")
+	{
+		str << Interval(0, BoundType::INFTY, 1, BoundType::WEAK);
+		CHECK(str.str() == u8"(∞, 1)");
+	}
+	SECTION("strict upper bound")
+	{
+		str << Interval(0, BoundType::INFTY, 1, BoundType::STRICT);
+		CHECK(str.str() == u8"(∞, 1]");
+	}
+	SECTION("weak lower and strict upper bound")
+	{
+		str << Interval(4, BoundType::WEAK, 5, BoundType::STRICT);
+		CHECK(str.str() == "(4, 5]");
+	}
+}
 } // namespace

--- a/test/test_interval.cpp
+++ b/test/test_interval.cpp
@@ -38,31 +38,56 @@ TEST_CASE("Construction of intervals", "[libmtl]")
 TEST_CASE("Interval comparison", "[libmtl]")
 {
 	// Less than
-	CHECK(Interval(1, BoundType::WEAK, 0, BoundType::INFTY) < Interval());
-	CHECK(Interval(1, BoundType::WEAK, 0, BoundType::INFTY)
-	      < Interval(2, BoundType::WEAK, 0, BoundType::INFTY));
-	CHECK(Interval(1, BoundType::STRICT, 0, BoundType::INFTY)
-	      < Interval(2, BoundType::WEAK, 0, BoundType::INFTY));
-	CHECK(Interval(1, BoundType::WEAK, 0, BoundType::INFTY)
-	      < Interval(1, BoundType::STRICT, 0, BoundType::INFTY));
-	CHECK(Interval(0, BoundType::INFTY, 2, BoundType::WEAK)
-	      < Interval(0, BoundType::INFTY, 3, BoundType::WEAK));
-	CHECK(Interval(0, BoundType::INFTY, 2, BoundType::STRICT)
-	      < Interval(0, BoundType::INFTY, 3, BoundType::STRICT));
-	CHECK(Interval(0, BoundType::INFTY, 1, BoundType::WEAK)
-	      < Interval(0, BoundType::INFTY, 1, BoundType::STRICT));
-	// Value is ignored if bound type is INFTY.
-	CHECK(Interval(6, BoundType::INFTY, 2, BoundType::WEAK)
-	      < Interval(0, BoundType::INFTY, 3, BoundType::WEAK));
+	CHECK(!(Interval() < Interval()));
+	CHECK(!(Interval(0, BoundType::INFTY, 2, BoundType::WEAK) < Interval()));
+	CHECK(!(Interval(1, BoundType::WEAK, 2, BoundType::WEAK) < Interval()));
+	CHECK(!(Interval(1, BoundType::WEAK, 2, BoundType::WEAK)
+	        < Interval(0, BoundType::INFTY, 1, BoundType::WEAK)));
+	CHECK(!(Interval(1, BoundType::WEAK, 2, BoundType::WEAK)
+	        < Interval(1, BoundType::WEAK, 2, BoundType::WEAK)));
+	CHECK(!(Interval(1, BoundType::WEAK, 2, BoundType::WEAK)
+	        < Interval(2, BoundType::WEAK, 3, BoundType::WEAK)));
+	CHECK(Interval(1, BoundType::WEAK, 2, BoundType::WEAK)
+	      < Interval(3, BoundType::WEAK, 4, BoundType::WEAK));
+	CHECK(Interval(1, BoundType::WEAK, 2, BoundType::WEAK)
+	      < Interval(2, BoundType::STRICT, 3, BoundType::WEAK));
+	CHECK(Interval(1, BoundType::WEAK, 2, BoundType::STRICT)
+	      < Interval(2, BoundType::WEAK, 3, BoundType::WEAK));
 
-	CHECK(Interval() > Interval(1, BoundType::WEAK, 0, BoundType::INFTY));
+	// Bigger than
+	CHECK(!(Interval() < Interval()));
+	CHECK(!(Interval() > Interval(0, BoundType::INFTY, 2, BoundType::WEAK)));
+	CHECK(!(Interval() > Interval(1, BoundType::WEAK, 2, BoundType::WEAK)));
+	CHECK(!(Interval(0, BoundType::INFTY, 1, BoundType::WEAK)
+	        > Interval(1, BoundType::WEAK, 2, BoundType::WEAK)));
+	CHECK(!(Interval(1, BoundType::WEAK, 2, BoundType::WEAK)
+	        > Interval(1, BoundType::WEAK, 2, BoundType::WEAK)));
+	CHECK(!(Interval(2, BoundType::WEAK, 3, BoundType::WEAK)
+	        > Interval(1, BoundType::WEAK, 2, BoundType::WEAK)));
+	CHECK(Interval(3, BoundType::WEAK, 4, BoundType::WEAK)
+	      > Interval(1, BoundType::WEAK, 2, BoundType::WEAK));
+	CHECK(Interval(2, BoundType::STRICT, 3, BoundType::WEAK)
+	      > Interval(1, BoundType::WEAK, 2, BoundType::WEAK));
+	CHECK(Interval(2, BoundType::WEAK, 3, BoundType::WEAK)
+	      > Interval(1, BoundType::WEAK, 2, BoundType::STRICT));
 
 	// Equality
 	CHECK(Interval() == Interval());
 	CHECK(Interval(1, BoundType::WEAK, 0, BoundType::INFTY) != Interval());
+	CHECK(Interval(1, BoundType::INFTY, 1, BoundType::INFTY) == Interval());
+	CHECK(Interval() == Interval(1, BoundType::INFTY, 1, BoundType::INFTY));
 	CHECK(Interval(1, BoundType::WEAK, 0, BoundType::INFTY)
 	      != Interval(1, BoundType::STRICT, 0, BoundType::INFTY));
-	CHECK(Interval(1, BoundType::INFTY, 0, BoundType::INFTY) == Interval());
+	CHECK(Interval(1, BoundType::WEAK, 2, BoundType::WEAK)
+	      != Interval(1, BoundType::WEAK, 2, BoundType::STRICT));
+	CHECK(Interval(1, BoundType::STRICT, 2, BoundType::STRICT)
+	      != Interval(1, BoundType::WEAK, 2, BoundType::STRICT));
+	CHECK(Interval(1, BoundType::STRICT, 2, BoundType::STRICT)
+	      == Interval(1, BoundType::STRICT, 2, BoundType::STRICT));
+	CHECK(Interval(2, BoundType::WEAK, 3, BoundType::STRICT)
+	      == Interval(2, BoundType::WEAK, 3, BoundType::STRICT));
+	CHECK(Interval(2, BoundType::WEAK, 4, BoundType::WEAK)
+	      == Interval(2, BoundType::WEAK, 4, BoundType::WEAK));
 }
 
 TEST_CASE("Emptiness", "[libmtl]")

--- a/test/test_mtlFormula.cpp
+++ b/test/test_mtlFormula.cpp
@@ -19,6 +19,7 @@
  */
 
 #include "mtl/MTLFormula.h"
+#include "utilities/Interval.h"
 
 #include <catch2/catch_test_macros.hpp>
 #include <iostream>
@@ -152,7 +153,7 @@ TEST_CASE("To positive normal form", "[libmtl]")
 	REQUIRE(((!dual_until).to_positive_normal_form()) == na.until(nb));
 }
 
-TEST_CASE("Comparison operators", "[libmtl]")
+TEST_CASE("MTL Formula comparison operators", "[libmtl]")
 {
 	logic::AtomicProposition a{std::string("a")};
 	logic::AtomicProposition b{std::string("b")};
@@ -178,6 +179,12 @@ TEST_CASE("Comparison operators", "[libmtl]")
 	CHECK(phi4 != phi1);
 	CHECK(phi1 > phi4);
 	CHECK(phi3 < (phi1 && phi5));
+
+	CHECK(phi1.until(phi2)
+	      != phi1.until(phi2, utilities::arithmetic::Interval<logic::TimePoint>{0, 1}));
+
+	CHECK(phi1.dual_until(phi2)
+	      != phi1.dual_until(phi2, utilities::arithmetic::Interval<logic::TimePoint>{1, 2}));
 }
 
 TEST_CASE("Get subformulas of type", "[libmtl]")

--- a/test/test_print_mtl_formula.cpp
+++ b/test/test_print_mtl_formula.cpp
@@ -57,9 +57,8 @@ TEST_CASE("Print MTL formulas", "[print][mtl]")
 	}
 	{
 		std::stringstream s;
-		// TODO we should actually print the interval
 		s << (Formula(AP{"a"}).until(Formula{AP{"b"}}, TimeInterval(1, 2)));
-		CHECK(s.str() == "(a U b)");
+		CHECK(s.str() == "(a U(1, 2) b)");
 	}
 	{
 		std::stringstream s;
@@ -68,9 +67,8 @@ TEST_CASE("Print MTL formulas", "[print][mtl]")
 	}
 	{
 		std::stringstream s;
-		// TODO we should actually print the interval
 		s << (Formula(AP{"a"}).dual_until(Formula{AP{"b"}}, TimeInterval(1, 2)));
-		CHECK(s.str() == "(a ~U b)");
+		CHECK(s.str() == "(a ~U(1, 2) b)");
 	}
 }
 

--- a/test/test_search.cpp
+++ b/test/test_search.cpp
@@ -64,8 +64,8 @@ TEST_CASE("Search in an ABConfiguration tree", "[search]")
 	logic::MTLFormula<std::string> a{AP("a")};
 	logic::MTLFormula<std::string> b{AP("b")};
 
-	logic::MTLFormula f   = a.until(b, logic::TimeInterval(2, BoundType::WEAK, 2, BoundType::INFTY));
-	auto              ata = mtl_ata_translation::translate(f);
+	logic::MTLFormula spec = a.until(b, logic::TimeInterval{2, BoundType::WEAK, 2, BoundType::INFTY});
+	auto              ata  = mtl_ata_translation::translate(spec);
 	TreeSearch        search(&ta, &ata, {"a"}, {"b", "c"}, 2);
 	TreeSearch        search_incremental_labeling(&ta, &ata, {"a"}, {"b", "c"}, 2, true);
 
@@ -87,19 +87,16 @@ TEST_CASE("Search in an ABConfiguration tree", "[search]")
 		INFO("Children of the root node:\n" << children);
 		REQUIRE(children.size() == 3);
 		CHECK(children[0]->words
-		      == std::set{
-		        CanonicalABWord({{TARegionState{"l0", "x", 0}}, {ATARegionState{a.until(b), 3}}}),
-		        CanonicalABWord({{TARegionState{"l0", "x", 0}, ATARegionState{a.until(b), 4}}}),
-		        CanonicalABWord({{TARegionState{"l0", "x", 0}}, {ATARegionState{a.until(b), 5}}})});
+		      == std::set{CanonicalABWord({{TARegionState{"l0", "x", 0}}, {ATARegionState{spec, 3}}}),
+		                  CanonicalABWord({{TARegionState{"l0", "x", 0}, ATARegionState{spec, 4}}}),
+		                  CanonicalABWord({{TARegionState{"l0", "x", 0}}, {ATARegionState{spec, 5}}})});
 		CHECK(children[0]->incoming_actions
 		      == std::set<std::pair<RegionIndex, std::string>>{{3, "a"}, {4, "a"}, {5, "a"}});
-		CHECK(
-		  children[1]->words
-		  == std::set{CanonicalABWord({{TARegionState{"l1", "x", 0}, ATARegionState{a.until(b), 0}}})});
+		CHECK(children[1]->words
+		      == std::set{CanonicalABWord({{TARegionState{"l1", "x", 0}, ATARegionState{spec, 0}}})});
 		CHECK(children[1]->incoming_actions == std::set<std::pair<RegionIndex, std::string>>{{0, "b"}});
-		CHECK(
-		  children[2]->words
-		  == std::set{CanonicalABWord({{TARegionState{"l1", "x", 1}, ATARegionState{a.until(b), 1}}})});
+		CHECK(children[2]->words
+		      == std::set{CanonicalABWord({{TARegionState{"l1", "x", 1}, ATARegionState{spec, 1}}})});
 		CHECK(children[2]->incoming_actions == std::set<std::pair<RegionIndex, std::string>>{{1, "b"}});
 	}
 
@@ -117,9 +114,9 @@ TEST_CASE("Search in an ABConfiguration tree", "[search]")
 			// starts with [{(l0, x, 0), ((a U b), 3)}]
 			const auto &children = root_children[0]->children;
 			REQUIRE(children.size() == std::size_t(3));
-			CHECK(children[0]->words
-			      == std::set{
-			        CanonicalABWord({{TARegionState{"l0", "x", 0}}, {ATARegionState{a.until(b), 5}}})});
+			CHECK(
+			  children[0]->words
+			  == std::set{CanonicalABWord({{TARegionState{"l0", "x", 0}}, {ATARegionState{spec, 5}}})});
 			CHECK(children[0]->incoming_actions
 			      == std::set<std::pair<RegionIndex, std::string>>{{3, "a"}, {4, "a"}, {5, "a"}});
 			CHECK(children[1]->words == std::set{CanonicalABWord({{TARegionState{"l1", "x", 0}}})});


### PR DESCRIPTION
When comparing two MTL Formulas of type until or dual until, we also need to compare the intervals. To do this, define comparison operators for Intervals and then compare the intervals when comparing MTL formulas.

For debugging purposes, also define an ostream operator for Intervals and print the interval when printing an MTL Formula.

Also adapt some tests that made wrong assumptions about intervals.