### PR TITLE
Add base support for heuristics

### DIFF
--- a/src/synchronous_product/include/synchronous_product/heuristics.h
+++ b/src/synchronous_product/include/synchronous_product/heuristics.h
@@ -1,0 +1,62 @@
+/***************************************************************************
+ *  heuristics.h - Heuristics to evaluate search tree nodes
+ *
+ *  Created:   Tue 23 Mar 09:05:55 CET 2021
+ *  Copyright  2021  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ ****************************************************************************/
+/*  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Library General Public License for more details.
+ *
+ *  Read the full text in the LICENSE.md file.
+ */
+
+#ifndef SRC_SYNCHRONOUS_PRODUCT_INCLUDE_SYNCHRONOUS_PRODUCT_HEURISTICS_H
+#define SRC_SYNCHRONOUS_PRODUCT_INCLUDE_SYNCHRONOUS_PRODUCT_HEURISTICS_H
+
+#include "search_tree.h"
+
+namespace synchronous_product {
+
+/** The heuristics interface.
+ * @tparam ValueT The value type of the heuristic function
+ * @tparam LocationT The type of the location of an automaton
+ * @tparam ActionT The type of an action of an automaton
+ */
+template <typename ValueT, typename LocationT, typename ActionT>
+class Heuristic
+{
+public:
+	virtual ValueT rank(SearchTreeNode<LocationT, ActionT> *node) = 0;
+};
+
+/** The BFS heuristic.
+ * The BFS heuristic simply decrements the priority with every evaluated node and therefore
+ * processes them just like a FIFO queue, resulting in breadth-first sarch.
+ * @tparam ValueT The value type of the heuristic function
+ * @tparam LocationT The type of the location of an automaton
+ * @tparam ActionT The type of an action of an automaton
+ */
+template <typename ValueT, typename LocationT, typename ActionT>
+class BfsHeuristic : public Heuristic<ValueT, LocationT, ActionT>
+{
+public:
+	ValueT
+	rank(SearchTreeNode<LocationT, ActionT> *) override
+	{
+		return -(++node_counter);
+	}
+
+private:
+	std::atomic_size_t node_counter{0};
+};
+
+} // namespace synchronous_product
+
+#endif /* ifndef SRC_SYNCHRONOUS_PRODUCT_INCLUDE_SYNCHRONOUS_PRODUCT_HEURISTICS_H */

--- a/src/synchronous_product/include/synchronous_product/heuristics.h
+++ b/src/synchronous_product/include/synchronous_product/heuristics.h
@@ -33,7 +33,12 @@ template <typename ValueT, typename LocationT, typename ActionT>
 class Heuristic
 {
 public:
-	virtual ValueT rank(SearchTreeNode<LocationT, ActionT> *node) = 0;
+	/** @brief Compute the cost of the given node.
+	 * The higher the cost, the lower the priority.
+	 * @param node The node to compute the cost for
+	 * @return The cost of the node
+	 */
+	virtual ValueT compute_cost(SearchTreeNode<LocationT, ActionT> *node) = 0;
 };
 
 /** The BFS heuristic.
@@ -47,8 +52,13 @@ template <typename ValueT, typename LocationT, typename ActionT>
 class BfsHeuristic : public Heuristic<ValueT, LocationT, ActionT>
 {
 public:
+	/** @brief Compute the cost of the given node.
+	 * The cost will strictly monotonically increase for each node, thereby emulating breadth-first
+	 * search.
+	 * @return The cost of the node
+	 */
 	ValueT
-	rank(SearchTreeNode<LocationT, ActionT> *) override
+	compute_cost(SearchTreeNode<LocationT, ActionT> *) override
 	{
 		return -(++node_counter);
 	}

--- a/src/synchronous_product/include/synchronous_product/heuristics.h
+++ b/src/synchronous_product/include/synchronous_product/heuristics.h
@@ -39,6 +39,10 @@ public:
 	 * @return The cost of the node
 	 */
 	virtual ValueT compute_cost(SearchTreeNode<LocationT, ActionT> *node) = 0;
+	/** Virtual destructor. */
+	virtual ~Heuristic()
+	{
+	}
 };
 
 /** The BFS heuristic.

--- a/src/synchronous_product/include/synchronous_product/search.h
+++ b/src/synchronous_product/include/synchronous_product/search.h
@@ -129,7 +129,7 @@ public:
 	void
 	add_node_to_queue(Node *node)
 	{
-		pool_.add_job([this, node] { expand_node(node); }, heuristic->rank(node));
+		pool_.add_job([this, node] { expand_node(node); }, heuristic->compute_cost(node));
 	}
 
 	/** Build the complete search tree by expanding nodes recursively. */

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -70,6 +70,10 @@ add_executable(test_tree_iteration test_tree_iteration.cpp)
 target_link_libraries(test_tree_iteration PRIVATE  synchronous_product Catch2::Catch2WithMain)
 catch_discover_tests(test_tree_iteration)
 
+add_executable(test_heuristics test_heuristics.cpp)
+target_link_libraries(test_heuristics PRIVATE synchronous_product Catch2::Catch2WithMain)
+catch_discover_tests(test_heuristics)
+
 if (COVERAGE)
   # Depend on all targets in the current directory.
   get_property(test_targets DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}

--- a/test/test_heuristics.cpp
+++ b/test/test_heuristics.cpp
@@ -29,9 +29,9 @@ TEST_CASE("Test BFS heuristic", "[search][heuristics]")
 {
 	Bfs bfs{};
 	// The heuristic does not care about the actual node, we can just give it nullptrs.
-	long h1 = bfs.rank(nullptr);
-	long h2 = bfs.rank(nullptr);
-	long h3 = bfs.rank(nullptr);
+	long h1 = bfs.compute_cost(nullptr);
+	long h2 = bfs.compute_cost(nullptr);
+	long h3 = bfs.compute_cost(nullptr);
 	CHECK(h1 > h2);
 	CHECK(h2 > h3);
 }

--- a/test/test_heuristics.cpp
+++ b/test/test_heuristics.cpp
@@ -1,0 +1,39 @@
+/***************************************************************************
+ *  test_heuristics.cpp - Test search tree heuristic functions
+ *
+ *  Created:   Tue 23 Mar 09:08:56 CET 2021
+ *  Copyright  2021  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ ****************************************************************************/
+/*  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Library General Public License for more details.
+ *
+ *  Read the full text in the LICENSE.md file.
+ */
+
+#include "synchronous_product/heuristics.h"
+
+#include <catch2/catch_test_macros.hpp>
+
+namespace {
+
+using Bfs = synchronous_product::BfsHeuristic<long, std::string, std::string>;
+
+TEST_CASE("Test BFS heuristic", "[search][heuristics]")
+{
+	Bfs bfs{};
+	// The heuristic does not care about the actual node, we can just give it nullptrs.
+	long h1 = bfs.rank(nullptr);
+	long h2 = bfs.rank(nullptr);
+	long h3 = bfs.rank(nullptr);
+	CHECK(h1 > h2);
+	CHECK(h2 > h3);
+}
+
+} // namespace


### PR DESCRIPTION
Add an abstract class `Heuristic` and re-implement BFS as heuristic.

This does not add new heuristics yet, but serves as baseline for additional heuristics.