### PR TITLE
Terminate search in a sub-branch if node is labeled

### DIFF
--- a/src/synchronous_product/include/synchronous_product/search.h
+++ b/src/synchronous_product/include/synchronous_product/search.h
@@ -220,10 +220,18 @@ public:
 			                 std::make_unique<Node>(std::move(map_entry.second),
 			                                        node,
 			                                        std::move(outgoing_actions[map_entry.first]));
-			               add_node_to_queue(child.get());
 			               return child;
 		               });
+		// Check if the node has been canceled in the meantime.
+		if (node->label == NodeLabel::CANCELED) {
+			node->children.clear();
+			node->is_expanded = true;
+			return;
+		}
 		node->is_expanded = true;
+		for (const auto &child : node->children) {
+			add_node_to_queue(child.get());
+		}
 		if (node->children.empty()) {
 			node->state = NodeState::DEAD;
 			if (incremental_labeling_) {

--- a/src/synchronous_product/include/synchronous_product/search_tree.h
+++ b/src/synchronous_product/include/synchronous_product/search_tree.h
@@ -81,9 +81,7 @@ struct SearchTreeNode
 	void
 	set_label(NodeLabel new_label, bool cancel_children = false)
 	{
-		if (label != NodeLabel::UNLABELED) {
-			return;
-		}
+		assert(new_label != NodeLabel::UNLABELED);
 		label = new_label;
 		if (cancel_children && is_expanded && new_label != NodeLabel::UNLABELED) {
 			for (const auto &child : children) {

--- a/src/synchronous_product/include/synchronous_product/search_tree.h
+++ b/src/synchronous_product/include/synchronous_product/search_tree.h
@@ -250,7 +250,8 @@ template <typename Location, typename ActionType>
 void
 print_to_ostream(std::ostream &                                                   os,
                  const synchronous_product::SearchTreeNode<Location, ActionType> &node,
-                 unsigned int                                                     indent = 0)
+                 bool         print_children = false,
+                 unsigned int indent         = 0)
 {
 	for (unsigned int i = 0; i < indent; i++) {
 		os << "  ";
@@ -261,9 +262,11 @@ print_to_ostream(std::ostream &                                                 
 		os << "(" << action.first << ", " << action.second << ") ";
 	}
 	os << "} -> " << node.words << ": " << node.state << " " << node.label;
-	os << '\n';
-	for (const auto &child : node.children) {
-		print_to_ostream(os, *child, indent + 1);
+	if (print_children) {
+		os << '\n';
+		for (const auto &child : node.children) {
+			print_to_ostream(os, *child, true, indent + 1);
+		}
 	}
 }
 

--- a/src/synchronous_product/include/synchronous_product/search_tree.h
+++ b/src/synchronous_product/include/synchronous_product/search_tree.h
@@ -30,6 +30,7 @@
 #include <iostream>
 #include <limits>
 #include <memory>
+#include <mutex>
 
 namespace synchronous_product {
 
@@ -89,6 +90,7 @@ struct SearchTreeNode
 	label_propagate(const std::set<ActionType> &controller_actions,
 	                const std::set<ActionType> &environment_actions)
 	{
+		std::lock_guard lock{node_mutex};
 		SPDLOG_TRACE("Call propagate on node \n{}", *this);
 		// leaf-nodes should always be labelled directly
 		assert(!children.empty() || label != NodeLabel::UNLABELED);
@@ -200,6 +202,8 @@ struct SearchTreeNode
 		       && this->incoming_actions == other.incoming_actions;
 	}
 
+	/** A mutex to protect node access. */
+	std::recursive_mutex node_mutex;
 	/** The words of the node */
 	std::set<CanonicalABWord<Location, ActionType>> words;
 	/** The state of the node */

--- a/src/synchronous_product/include/synchronous_product/search_tree.h
+++ b/src/synchronous_product/include/synchronous_product/search_tree.h
@@ -47,6 +47,7 @@ enum class NodeLabel {
 	UNLABELED,
 	BOTTOM,
 	TOP,
+	CANCELED,
 };
 
 /** A node in the search tree

--- a/src/synchronous_product/search_tree.cpp
+++ b/src/synchronous_product/search_tree.cpp
@@ -28,6 +28,7 @@ operator<<(std::ostream &os, const synchronous_product::NodeLabel &node_label)
 	case NodeLabel::TOP: os << u8"⊤"; break;
 	case NodeLabel::BOTTOM: os << u8"⊥"; break;
 	case NodeLabel::UNLABELED: os << u8"?"; break;
+	case NodeLabel::CANCELED: os << "CANCELED"; break;
 	}
 	return os;
 }

--- a/test/test_railroad.cpp
+++ b/test/test_railroad.cpp
@@ -92,7 +92,9 @@ TEST_CASE("A single railroad crossing", "[.][railroad]")
 	INFO("TA: " << product);
 	INFO("ATA: " << ata);
 	search.build_tree();
-	INFO("Tree:\n" << *search.get_root());
+	std::stringstream str;
+	print_to_ostream(str, *search.get_root(), true);
+	INFO("Tree:\n" << str.rdbuf());
 	search.label();
 	CHECK(false);
 }

--- a/test/test_search.cpp
+++ b/test/test_search.cpp
@@ -331,18 +331,21 @@ TEST_CASE("Incremental labeling on constructed cases", "[search]")
 	std::set<ActionType> controller_actions{"a", "b", "c"};
 	std::set<ActionType> environment_actions{"x", "y", "z"};
 
+	auto create_test_node = [](const std::set<CanonicalABWord> &words, Node *parent = nullptr) {
+		auto node         = std::make_unique<Node>(words);
+		node->parent      = parent;
+		node->is_expanded = true;
+		return node;
+	};
+
 	SECTION("Label tree: single-step propagate")
 	{
 		// root node
-		auto root = std::make_unique<Node>(dummyWords);
+		auto root = create_test_node(dummyWords);
 		// create children
-		auto ch1 = std::make_unique<Node>(dummyWords);
-		auto ch2 = std::make_unique<Node>(dummyWords);
-		auto ch3 = std::make_unique<Node>(dummyWords);
-		// set child-node properties
-		ch1->parent = root.get();
-		ch2->parent = root.get();
-		ch3->parent = root.get();
+		auto ch1 = create_test_node(dummyWords, root.get());
+		auto ch2 = create_test_node(dummyWords, root.get());
+		auto ch3 = create_test_node(dummyWords, root.get());
 		// set incoming actions
 		ch1->incoming_actions.emplace(std::make_pair(0, *controller_actions.begin()));
 		ch2->incoming_actions.emplace(std::make_pair(1, *environment_actions.begin()));
@@ -414,7 +417,7 @@ TEST_CASE("Incremental labeling on constructed cases", "[search]")
 	SECTION("Label tree: multi-step propagate")
 	{
 		// root node
-		auto root = std::make_unique<Node>(dummyWords);
+		auto root = create_test_node(dummyWords);
 		// utility functions
 		auto resetTreeLabels = [&root] {
 			auto it = root->begin();
@@ -424,13 +427,9 @@ TEST_CASE("Incremental labeling on constructed cases", "[search]")
 			}
 		};
 		// create children
-		auto ch1 = std::make_unique<Node>(dummyWords);
-		auto ch2 = std::make_unique<Node>(dummyWords);
-		auto ch3 = std::make_unique<Node>(dummyWords);
-		// set child-node properties
-		ch1->parent = root.get();
-		ch2->parent = root.get();
-		ch3->parent = root.get();
+		auto ch1 = create_test_node(dummyWords, root.get());
+		auto ch2 = create_test_node(dummyWords, root.get());
+		auto ch3 = create_test_node(dummyWords, root.get());
 		// set incoming actions
 		ch1->incoming_actions.emplace(std::make_pair(0, *controller_actions.begin()));
 		ch2->incoming_actions.emplace(std::make_pair(1, *environment_actions.begin()));
@@ -444,12 +443,10 @@ TEST_CASE("Incremental labeling on constructed cases", "[search]")
 		root->children.emplace_back(std::move(ch2));
 		root->children.emplace_back(std::move(ch3));
 		// add second layer of children to make the first child ch1 an intermediate node
-		auto ch4    = std::make_unique<Node>(dummyWords);
-		auto ch5    = std::make_unique<Node>(dummyWords);
-		ch4->parent = root->children[0].get();
-		ch5->parent = root->children[0].get();
-		ch4->label  = NodeLabel::BOTTOM;
-		ch5->label  = NodeLabel::TOP;
+		auto ch4   = create_test_node(dummyWords, root->children[0].get());
+		auto ch5   = create_test_node(dummyWords, root->children[0].get());
+		ch4->label = NodeLabel::BOTTOM;
+		ch5->label = NodeLabel::TOP;
 		ch4->incoming_actions.emplace(std::make_pair(0, *controller_actions.begin()));
 		ch5->incoming_actions.emplace(std::make_pair(1, *environment_actions.begin()));
 		root->children[0]->children.emplace_back(std::move(ch4));
@@ -494,8 +491,7 @@ TEST_CASE("Incremental labeling on constructed cases", "[search]")
 		root->children[2]->label              = NodeLabel::TOP;
 		root->children[0]->children[0]->label = NodeLabel::BOTTOM;
 		root->children[0]->children[1]->label = NodeLabel::BOTTOM;
-		auto ch6                              = std::make_unique<Node>(dummyWords);
-		ch6->parent                           = root->children[1].get();
+		auto ch6                              = create_test_node(dummyWords, root->children[1].get());
 		ch6->label                            = NodeLabel::TOP;
 		ch6->incoming_actions.emplace(std::make_pair(0, *environment_actions.begin()));
 		root->children[1]->children.emplace_back(std::move(ch6));


### PR DESCRIPTION
If we have already labeled a node by means of incremental labeling, we know that the label will not change, no matter what the search on remaining children returns. Thus, we can also safely cancel the search in that sub-tree.

This require some careful multi-threading coordination. Until now, a thread always operated on a single node with a guarantee that no other thread would work on that node simultaneously. With incremental labeling, we may move up in the tree, but never down. With node canceling, we may now move up (by means of incremental labeling) and down (by means of node cancelation), causing possible conflicts. Rather than protecting the complete node with a mutex, make the node label atomic, and also add an atomic bool `is_expanded` that is true if the node has been expanded already and thus accessing the children is safe. This makes sure that we only access the children after they have been created, while also avoiding a mutex for the vector.