### PR TITLE
ta: do not allow inequality in transition guards

### DIFF
--- a/src/automata/include/automata/ta.h
+++ b/src/automata/include/automata/ta.h
@@ -24,6 +24,7 @@
 #include "automata.h"
 
 #include <algorithm>
+#include <functional>
 #include <map>
 #include <set>
 #include <string>
@@ -244,6 +245,9 @@ public:
 			for (const auto &[clock, constraint] : transition.clock_constraints_) {
 				if (clocks.find(clock) == end(clocks)) {
 					throw std::invalid_argument("Clock constraint uses unknown clock");
+				}
+				if (std::holds_alternative<AtomicClockConstraintT<std::not_equal_to<Time>>>(constraint)) {
+					throw std::invalid_argument("Inequality is not allowed in a TA guard");
 				}
 			}
 			add_transition(transition);

--- a/src/automata/ta.proto
+++ b/src/automata/ta.proto
@@ -27,7 +27,6 @@ message TimedAutomaton {
         LESS = 0;
         LESS_EQUAL = 1;
         EQUAL_TO = 2;
-        NOT_EQUAL_TO = 3;
         GREATER_EQUAL = 4;
         GREATER = 5;
       }

--- a/src/automata/ta_proto.cpp
+++ b/src/automata/ta_proto.cpp
@@ -53,11 +53,6 @@ parse_transition(const proto::TimedAutomaton::Transition &transition_proto)
 			  {clock_constraint.clock(),
 			   AtomicClockConstraintT<std::equal_to<Time>>{clock_constraint.comparand()}});
 			break;
-		case ProtoClockConstraint::NOT_EQUAL_TO:
-			clock_constraints.insert(
-			  {clock_constraint.clock(),
-			   AtomicClockConstraintT<std::not_equal_to<Time>>{clock_constraint.comparand()}});
-			break;
 		case ProtoClockConstraint::GREATER_EQUAL:
 			clock_constraints.insert(
 			  {clock_constraint.clock(),

--- a/test/test_ta.cpp
+++ b/test/test_ta.cpp
@@ -32,6 +32,8 @@ using namespace automata;
 using namespace automata::ta;
 using Configuration = automata::ta::Configuration<std::string>;
 using Catch::Matchers::Contains;
+using TimedAutomaton = automata::ta::TimedAutomaton<std::string, std::string>;
+using Transition     = automata::ta::Transition<std::string, std::string>;
 
 TEST_CASE("Clock constraints with integers", "[ta]")
 {
@@ -59,8 +61,8 @@ TEST_CASE("Clock constraints with integers", "[ta]")
 
 TEST_CASE("Simple TA", "[ta]")
 {
-	TimedAutomaton<std::string, std::string> ta{{"a", "b"}, "s0", {"s0"}};
-	ta.add_transition(Transition<std::string, std::string>("s0", "a", "s0"));
+	TimedAutomaton ta{{"a", "b"}, "s0", {"s0"}};
+	ta.add_transition(Transition("s0", "a", "s0"));
 
 	CHECK(ta.get_initial_configuration() == Configuration{"s0", {}});
 
@@ -77,9 +79,9 @@ TEST_CASE("Simple TA", "[ta]")
 
 TEST_CASE("Simple TA with two locations", "[ta]")
 {
-	TimedAutomaton<std::string, std::string> ta{{"a", "b"}, "s0", {"s1"}};
-	ta.add_transition(Transition<std::string, std::string>("s0", "a", "s0"));
-	ta.add_transition(Transition<std::string, std::string>("s0", "b", "s1"));
+	TimedAutomaton ta{{"a", "b"}, "s0", {"s1"}};
+	ta.add_transition(Transition("s0", "a", "s0"));
+	ta.add_transition(Transition("s0", "b", "s1"));
 	// We must be in a final location.
 	CHECK(!ta.accepts_word({{"a", 0}}));
 	CHECK(ta.accepts_word({{"b", 0}}));
@@ -87,10 +89,10 @@ TEST_CASE("Simple TA with two locations", "[ta]")
 
 TEST_CASE("TA with a simple guard", "[ta]")
 {
-	TimedAutomaton<std::string, std::string> ta{{"a"}, "s0", {"s0"}};
-	ClockConstraint                          c = AtomicClockConstraintT<std::less<Time>>(1);
+	TimedAutomaton  ta{{"a"}, "s0", {"s0"}};
+	ClockConstraint c = AtomicClockConstraintT<std::less<Time>>(1);
 	ta.add_clock("x");
-	ta.add_transition(Transition<std::string, std::string>("s0", "a", "s0", {{"x", c}}));
+	ta.add_transition(Transition("s0", "a", "s0", {{"x", c}}));
 
 	CHECK(ta.get_initial_configuration() == Configuration{"s0", {{"x", 0}}});
 
@@ -106,10 +108,10 @@ TEST_CASE("TA with clock reset", "[ta]")
 {
 	SECTION("Build TA step by step")
 	{
-		TimedAutomaton<std::string, std::string> ta{{"a"}, "s0", {"s0"}};
-		ClockConstraint                          c = AtomicClockConstraintT<std::less<Time>>(2);
+		TimedAutomaton  ta{{"a"}, "s0", {"s0"}};
+		ClockConstraint c = AtomicClockConstraintT<std::less<Time>>(2);
 		ta.add_clock("x");
-		ta.add_transition(Transition<std::string, std::string>("s0", "a", "s0", {{"x", c}}, {"x"}));
+		ta.add_transition(Transition("s0", "a", "s0", {{"x", c}}, {"x"}));
 		CHECK(ta.get_initial_configuration() == Configuration{"s0", {{"x", 0}}});
 
 		CHECK(ta.make_symbol_step({"s0", {{"x", 1}}}, "a")
@@ -120,14 +122,13 @@ TEST_CASE("TA with clock reset", "[ta]")
 	}
 	SECTION("Build TA with a single constructor call")
 	{
-		TimedAutomaton<std::string, std::string> ta{
+		TimedAutomaton ta{
 		  {"s0"},
 		  {"a"},
 		  "s0",
 		  {"s0"},
 		  {"x"},
-		  {Transition<std::string, std::string>{
-		    "s0", "a", "s0", {{"x", AtomicClockConstraintT<std::less<Time>>(2)}}, {"x"}}}};
+		  {Transition{"s0", "a", "s0", {{"x", AtomicClockConstraintT<std::less<Time>>(2)}}, {"x"}}}};
 		CHECK(ta.get_initial_configuration() == Configuration{"s0", {{"x", 0}}});
 
 		CHECK(ta.make_symbol_step({"s0", {{"x", 1}}}, "a")
@@ -140,12 +141,12 @@ TEST_CASE("TA with clock reset", "[ta]")
 
 TEST_CASE("Simple non-deterministic TA", "[ta]")
 {
-	TimedAutomaton<std::string, std::string> ta{{"a", "b"}, "s0", {"s2"}};
+	TimedAutomaton ta{{"a", "b"}, "s0", {"s2"}};
 	ta.add_location("s1");
-	ta.add_transition(Transition<std::string, std::string>("s0", "a", "s1"));
-	ta.add_transition(Transition<std::string, std::string>("s0", "a", "s2"));
-	ta.add_transition(Transition<std::string, std::string>("s1", "b", "s1"));
-	ta.add_transition(Transition<std::string, std::string>("s2", "b", "s2"));
+	ta.add_transition(Transition("s0", "a", "s1"));
+	ta.add_transition(Transition("s0", "a", "s2"));
+	ta.add_transition(Transition("s1", "b", "s1"));
+	ta.add_transition(Transition("s2", "b", "s2"));
 
 	CHECK(ta.make_symbol_step({"s0", {}}, "a")
 	      == std::set{Configuration{"s1", {}}, Configuration{"s2", {}}});
@@ -155,19 +156,19 @@ TEST_CASE("Simple non-deterministic TA", "[ta]")
 
 TEST_CASE("Non-determinstic TA with clocks", "[ta]")
 {
-	TimedAutomaton<std::string, std::string> ta{{"a", "b"}, "s0", {"s1", "s2"}};
+	TimedAutomaton ta{{"a", "b"}, "s0", {"s1", "s2"}};
 	ta.add_location("s1");
 	ta.add_clock("x");
 	ClockConstraint c1 = AtomicClockConstraintT<std::less<Time>>(2);
-	ta.add_transition(Transition<std::string, std::string>("s0", "a", "s1"));
-	ta.add_transition(Transition<std::string, std::string>("s0", "a", "s2"));
-	ta.add_transition(Transition<std::string, std::string>("s1", "b", "s1", {{"x", c1}}));
+	ta.add_transition(Transition("s0", "a", "s1"));
+	ta.add_transition(Transition("s0", "a", "s2"));
+	ta.add_transition(Transition("s1", "b", "s1", {{"x", c1}}));
 
 	CHECK(ta.accepts_word({{"a", 1}, {"b", 1}}));
 	CHECK(!ta.accepts_word({{"a", 1}, {"b", 3}}));
 
 	ClockConstraint c2 = AtomicClockConstraintT<std::greater<Time>>(2);
-	ta.add_transition(Transition<std::string, std::string>("s2", "b", "s2", {{"x", c2}}));
+	ta.add_transition(Transition("s2", "b", "s2", {{"x", c2}}));
 
 	CHECK(ta.accepts_word({{"a", 1}, {"b", 1}}));
 	CHECK(ta.accepts_word({{"a", 1}, {"b", 3}}));
@@ -175,31 +176,27 @@ TEST_CASE("Non-determinstic TA with clocks", "[ta]")
 
 TEST_CASE("Transitions must use the TA's alphabet, locations and clocks", "[ta]")
 {
-	TimedAutomaton<std::string, std::string> ta{{"a", "b"}, "s0", {"s0"}};
+	TimedAutomaton ta{{"a", "b"}, "s0", {"s0"}};
 	ta.add_location("s1");
 	ta.add_clock("x");
 
 	ClockConstraint c = AtomicClockConstraintT<std::less<Time>>(2);
-	CHECK_THROWS_AS(ta.add_transition(Transition<std::string, std::string>("s0", "a", "s2")),
+	CHECK_THROWS_AS(ta.add_transition(Transition("s0", "a", "s2")),
 	                InvalidLocationException<std::string>);
-	CHECK_THROWS_AS(ta.add_transition(Transition<std::string, std::string>("s2", "a", "s0")),
+	CHECK_THROWS_AS(ta.add_transition(Transition("s2", "a", "s0")),
 	                InvalidLocationException<std::string>);
-	CHECK_THROWS_AS(ta.add_transition(
-	                  Transition<std::string, std::string>("s0", "a", "s1", {{"y", c}})),
+	CHECK_THROWS_AS(ta.add_transition(Transition("s0", "a", "s1", {{"y", c}})),
 	                InvalidClockException);
-	CHECK_THROWS_AS(ta.add_transition(
-	                  Transition<std::string, std::string>("s0", "a", "s1", {}, {"y"})),
-	                InvalidClockException);
-	CHECK_THROWS_AS(ta.add_transition(Transition<std::string, std::string>("s0", "c", "s0")),
-	                InvalidSymbolException);
+	CHECK_THROWS_AS(ta.add_transition(Transition("s0", "a", "s1", {}, {"y"})), InvalidClockException);
+	CHECK_THROWS_AS(ta.add_transition(Transition("s0", "c", "s0")), InvalidSymbolException);
 }
 
 TEST_CASE("Create a TA with non-string location types", "[ta]")
 {
-	TimedAutomaton<unsigned int, std::string> ta{{"a"}, 0, {0}};
-	ClockConstraint                           c = AtomicClockConstraintT<std::less<Time>>(1);
+	automata::ta::TimedAutomaton<unsigned int, std::string> ta{{"a"}, 0, {0}};
+	ClockConstraint c = AtomicClockConstraintT<std::less<Time>>(1);
 	ta.add_clock("x");
-	ta.add_transition(Transition<unsigned int, std::string>(0, "a", 0, {{"x", c}}));
+	ta.add_transition(automata::ta::Transition<unsigned int, std::string>(0, "a", 0, {{"x", c}}));
 	CHECK(!ta.accepts_word({{"a", 2}}));
 	CHECK(ta.accepts_word({{"a", 0.5}}));
 	CHECK(!ta.accepts_word({{"a", 1}}));
@@ -207,66 +204,52 @@ TEST_CASE("Create a TA with non-string location types", "[ta]")
 
 TEST_CASE("Get enabled transitions", "[ta]")
 {
-	TimedAutomaton<std::string, std::string> ta{{"a", "b"}, "s0", {"s1"}};
-	Transition<std::string, std::string>     t1{"s0", "a", "s1"};
+	TimedAutomaton ta{{"a", "b"}, "s0", {"s1"}};
+	Transition     t1{"s0", "a", "s1"};
 	ta.add_transition(t1);
-	CHECK(ta.get_enabled_transitions({"s0", {}})
-	      == std::vector<Transition<std::string, std::string>>{{t1}});
-	Transition<std::string, std::string> t2{"s1", "a", "s1"};
+	CHECK(ta.get_enabled_transitions({"s0", {}}) == std::vector<Transition>{{t1}});
+	Transition t2{"s1", "a", "s1"};
 	ta.add_transition(t2);
 	// t2 should not be enabled
-	CHECK(ta.get_enabled_transitions({"s0", {}})
-	      == std::vector<Transition<std::string, std::string>>{{t1}});
-	Transition<std::string, std::string> t3{"s0", "b", "s0"};
+	CHECK(ta.get_enabled_transitions({"s0", {}}) == std::vector<Transition>{{t1}});
+	Transition t3{"s0", "b", "s0"};
 	ta.add_transition(t3);
 	// t3 should be enabled
-	CHECK(ta.get_enabled_transitions({"s0", {{"c0", 0}}})
-	      == std::vector<Transition<std::string, std::string>>{{t1, t3}});
+	CHECK(ta.get_enabled_transitions({"s0", {{"c0", 0}}}) == std::vector<Transition>{{t1, t3}});
 	ta.add_clock("c0");
-	Transition<std::string, std::string> t4{"s0",
-	                                        "b",
-	                                        "s0",
-	                                        {{"c0", AtomicClockConstraintT<std::greater<Time>>(1)}}};
+	Transition t4{"s0", "b", "s0", {{"c0", AtomicClockConstraintT<std::greater<Time>>(1)}}};
 	// t4 should not be enabled
-	CHECK(ta.get_enabled_transitions({"s0", {}})
-	      == std::vector<Transition<std::string, std::string>>{{t1, t3}});
-	Transition<std::string, std::string> t5{"s0",
-	                                        "b",
-	                                        "s0",
-	                                        {{"c0", AtomicClockConstraintT<std::less<Time>>(1)}}};
+	CHECK(ta.get_enabled_transitions({"s0", {}}) == std::vector<Transition>{{t1, t3}});
+	Transition t5{"s0", "b", "s0", {{"c0", AtomicClockConstraintT<std::less<Time>>(1)}}};
 	ta.add_transition(t5);
 	// t5 should be enabled
-	CHECK(ta.get_enabled_transitions({"s0", {{"c0", 0}}})
-	      == std::vector<Transition<std::string, std::string>>{{t1, t3, t5}});
+	CHECK(ta.get_enabled_transitions({"s0", {{"c0", 0}}}) == std::vector<Transition>{{t1, t3, t5}});
 }
 
 TEST_CASE("Constructing invalid TAs throws exceptions", "[ta]")
 {
-	CHECK_THROWS_WITH((TimedAutomaton<std::string, std::string>(
-	                    {"l0"}, {"a"}, "non_existent_initial_location", {}, {}, {})),
+	CHECK_THROWS_WITH(TimedAutomaton({"l0"}, {"a"}, "non_existent_initial_location", {}, {}, {}),
 	                  Contains("Initial location"));
-	CHECK_THROWS_WITH((TimedAutomaton<std::string, std::string>(
-	                    {"l0"}, {"a"}, "l0", {"non_existent_final_location"}, {}, {})),
+	CHECK_THROWS_WITH(TimedAutomaton({"l0"}, {"a"}, "l0", {"non_existent_final_location"}, {}, {}),
 	                  Contains("Final location"));
 	CHECK_THROWS_WITH(
-	  (TimedAutomaton<std::string, std::string>(
+	  TimedAutomaton(
 	    {"l0"},
 	    {"a"},
 	    "l0",
 	    {"l0"},
 	    {"x"},
-	    {Transition<std::string, std::string>{
-	      "s0", "a", "s0", {{"y", AtomicClockConstraintT<std::less<Time>>(2)}}, {"x"}}})),
+	    {Transition{"l0", "a", "l0", {{"y", AtomicClockConstraintT<std::less<Time>>(2)}}, {"x"}}}),
 	  Contains("unknown clock"));
 	CHECK_THROWS_WITH(
-	  (TimedAutomaton<std::string, std::string>(
+	  TimedAutomaton(
 	    {"l0"},
 	    {"a"},
 	    "l0",
 	    {"l0"},
 	    {"x"},
-	    {Transition<std::string, std::string>{
-	      "s0", "a", "s0", {{"x", AtomicClockConstraintT<std::not_equal_to<Time>>(2)}}, {"x"}}})),
+	    {Transition{
+	      "l0", "a", "l0", {{"x", AtomicClockConstraintT<std::not_equal_to<Time>>(2)}}, {"x"}}}),
 	  Contains("Inequality"));
 }
 

--- a/test/test_ta.cpp
+++ b/test/test_ta.cpp
@@ -251,6 +251,14 @@ TEST_CASE("Constructing invalid TAs throws exceptions", "[ta]")
 	  {"x"},
 	  {Transition<std::string, std::string>{
 	    "s0", "a", "s0", {{"y", AtomicClockConstraintT<std::less<Time>>(2)}}, {"x"}}}));
+	CHECK_THROWS(TimedAutomaton<std::string, std::string>(
+	  {"l0"},
+	  {"a"},
+	  "l0",
+	  {"l0"},
+	  {"x"},
+	  {Transition<std::string, std::string>{
+	    "s0", "a", "s0", {{"x", AtomicClockConstraintT<std::not_equal_to<Time>>(2)}}, {"x"}}}));
 }
 
 // TODO Test case with multiple clocks

--- a/test/test_ta.cpp
+++ b/test/test_ta.cpp
@@ -22,6 +22,8 @@
 #include "automata/ta.h"
 
 #include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers.hpp>
+#include <catch2/matchers/catch_matchers_string.hpp>
 #include <functional>
 
 namespace {
@@ -29,6 +31,7 @@ namespace {
 using namespace automata;
 using namespace automata::ta;
 using Configuration = automata::ta::Configuration<std::string>;
+using Catch::Matchers::Contains;
 
 TEST_CASE("Clock constraints with integers", "[ta]")
 {
@@ -239,26 +242,32 @@ TEST_CASE("Get enabled transitions", "[ta]")
 
 TEST_CASE("Constructing invalid TAs throws exceptions", "[ta]")
 {
-	CHECK_THROWS(TimedAutomaton<std::string, std::string>(
-	  {"l0"}, {"a"}, "non_existent_initial_location", {}, {}, {}));
-	CHECK_THROWS(TimedAutomaton<std::string, std::string>(
-	  {"l0"}, {"a"}, "l0", {"non_existent_final_location"}, {}, {}));
-	CHECK_THROWS(TimedAutomaton<std::string, std::string>(
-	  {"l0"},
-	  {"a"},
-	  "l0",
-	  {"l0"},
-	  {"x"},
-	  {Transition<std::string, std::string>{
-	    "s0", "a", "s0", {{"y", AtomicClockConstraintT<std::less<Time>>(2)}}, {"x"}}}));
-	CHECK_THROWS(TimedAutomaton<std::string, std::string>(
-	  {"l0"},
-	  {"a"},
-	  "l0",
-	  {"l0"},
-	  {"x"},
-	  {Transition<std::string, std::string>{
-	    "s0", "a", "s0", {{"x", AtomicClockConstraintT<std::not_equal_to<Time>>(2)}}, {"x"}}}));
+	CHECK_THROWS_WITH((TimedAutomaton<std::string, std::string>(
+	                    {"l0"}, {"a"}, "non_existent_initial_location", {}, {}, {})),
+	                  Contains("Initial location"));
+	CHECK_THROWS_WITH((TimedAutomaton<std::string, std::string>(
+	                    {"l0"}, {"a"}, "l0", {"non_existent_final_location"}, {}, {})),
+	                  Contains("Final location"));
+	CHECK_THROWS_WITH(
+	  (TimedAutomaton<std::string, std::string>(
+	    {"l0"},
+	    {"a"},
+	    "l0",
+	    {"l0"},
+	    {"x"},
+	    {Transition<std::string, std::string>{
+	      "s0", "a", "s0", {{"y", AtomicClockConstraintT<std::less<Time>>(2)}}, {"x"}}})),
+	  Contains("unknown clock"));
+	CHECK_THROWS_WITH(
+	  (TimedAutomaton<std::string, std::string>(
+	    {"l0"},
+	    {"a"},
+	    "l0",
+	    {"l0"},
+	    {"x"},
+	    {Transition<std::string, std::string>{
+	      "s0", "a", "s0", {{"x", AtomicClockConstraintT<std::not_equal_to<Time>>(2)}}, {"x"}}})),
+	  Contains("Inequality"));
 }
 
 // TODO Test case with multiple clocks

--- a/test/test_ta_proto.cpp
+++ b/test/test_ta_proto.cpp
@@ -63,7 +63,6 @@ TEST_CASE("Parse a TA from a proto", "[proto][ta]")
         source: "s1"
         target: "s2"
         symbol: "b"
-        clock_constraints { clock: "c4" operand: NOT_EQUAL_TO comparand: 4 }
         clock_constraints { clock: "c5" operand: GREATER_EQUAL comparand: 5 }
         clock_constraints { clock: "c6" operand: GREATER comparand: 6 }
         clock_resets: "c6"
@@ -89,8 +88,7 @@ TEST_CASE("Parse a TA from a proto", "[proto][ta]")
 	     Transition{"s1",
 	                "b",
 	                "s2",
-	                {{"c4", automata::AtomicClockConstraintT<std::not_equal_to<automata::Time>>{4}},
-	                 {"c5", automata::AtomicClockConstraintT<std::greater_equal<automata::Time>>{5}},
+	                {{"c5", automata::AtomicClockConstraintT<std::greater_equal<automata::Time>>{5}},
 	                 {"c6", automata::AtomicClockConstraintT<std::greater<automata::Time>>{6}}},
 	                {"c6"}}}});
 }


### PR DESCRIPTION
While ATAs allow inequality in clock constraints, TAs do not. To avoid
having two classes for clock constraints, throw an exception on
construction of a TA with an inequality constraint.