### PR TITLE
Use strong typing for TA Locations, configurations, TARegionStates, ATARegionStates

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,7 @@ if (COVERAGE)
 endif()
 
 add_subdirectory(src)
+add_subdirectory(third_party)
 
 find_package(Boost REQUIRED)
 

--- a/src/automata/CMakeLists.txt
+++ b/src/automata/CMakeLists.txt
@@ -1,7 +1,7 @@
 find_package(range-v3 REQUIRED)
 
 add_library(ta SHARED ta.cpp automata.cpp ata.cpp ta_regions.cpp)
-target_link_libraries(ta PRIVATE range-v3::range-v3 PUBLIC utilities)
+target_link_libraries(ta PRIVATE range-v3::range-v3 PUBLIC utilities NamedType)
 target_include_directories(ta PUBLIC include ${Boost_INCLUDE_DIR})
 
 find_package(Protobuf QUIET)

--- a/src/automata/automata.cpp
+++ b/src/automata/automata.cpp
@@ -28,8 +28,6 @@ is_satisfied(const ClockConstraint &constraint, const Time &valuation)
 	return std::visit([&](auto &&c) { return c.is_satisfied(valuation); }, constraint);
 }
 
-} // namespace automata
-
 std::ostream &
 operator<<(std::ostream &os, const automata::ClockConstraint &constraint)
 {
@@ -56,3 +54,5 @@ operator<<(std::ostream &                                               os,
 	}
 	return os;
 }
+
+} // namespace automata

--- a/src/automata/include/automata/ata.h
+++ b/src/automata/include/automata/ata.h
@@ -62,7 +62,6 @@ class AlternatingTimedAutomaton;
 
 template <typename LocationT, typename SymbolT>
 class Transition;
-} // namespace automata::ata
 
 template <typename LocationT, typename SymbolT>
 std::ostream &operator<<(std::ostream &                                       os,
@@ -88,8 +87,6 @@ std::ostream &operator<<(std::ostream &                                 os,
  */
 template <typename LocationT, typename SymbolT>
 std::ostream &operator<<(std::ostream &os, const automata::ata::Run<LocationT, SymbolT> &run);
-
-namespace automata::ata {
 
 template <typename LocationT, typename SymbolT>
 bool operator<(const Transition<LocationT, SymbolT> &first,

--- a/src/automata/include/automata/ata.hpp
+++ b/src/automata/include/automata/ata.hpp
@@ -21,6 +21,8 @@
 
 #include "ata.h"
 
+namespace automata::ata {
+
 template <typename LocationT, typename SymbolT>
 std::ostream &
 operator<<(std::ostream &os, const automata::ata::Transition<LocationT, SymbolT> &transition)
@@ -101,8 +103,6 @@ operator<<(std::ostream &os, const automata::ata::Run<LocationT, SymbolT> &run)
 	}
 	return os;
 }
-
-namespace automata::ata {
 
 template <typename LocationT, typename SymbolT>
 bool

--- a/src/automata/include/automata/ata.hpp
+++ b/src/automata/include/automata/ata.hpp
@@ -142,7 +142,7 @@ template <typename LocationT, typename SymbolT>
 [[nodiscard]] Configuration<LocationT>
 AlternatingTimedAutomaton<LocationT, SymbolT>::get_initial_configuration() const
 {
-	return {std::make_pair(initial_location_, 0)};
+	return {State<LocationT>{initial_location_, 0}};
 }
 
 template <typename LocationT, typename SymbolT>
@@ -161,12 +161,12 @@ AlternatingTimedAutomaton<LocationT, SymbolT>::make_symbol_step(
 	}
 	for (const auto &state : start_states) {
 		auto t = std::find_if(transitions_.cbegin(), transitions_.cend(), [&](const auto &t) {
-			return t.source_ == state.first && t.symbol_ == symbol;
+			return t.source_ == state.location && t.symbol_ == symbol;
 		});
 		if (t == transitions_.end()) {
 			continue;
 		}
-		const auto new_states = get_minimal_models(t->formula_.get(), state.second);
+		const auto new_states = get_minimal_models(t->formula_.get(), state.clock_valuation);
 		models.push_back(new_states);
 	}
 	// We were not able to make any transition.
@@ -240,7 +240,9 @@ AlternatingTimedAutomaton<LocationT, SymbolT>::make_time_step(const Configuratio
 	std::transform(start.cbegin(),
 	               start.cend(),
 	               std::inserter(res, res.begin()),
-	               [&time](const auto &s) { return std::make_pair(s.first, s.second + time); });
+	               [&time](const auto &s) {
+		               return State<LocationT>{s.location, s.clock_valuation + time};
+	               });
 	return res;
 }
 
@@ -273,7 +275,7 @@ AlternatingTimedAutomaton<LocationT, SymbolT>::is_accepting_configuration(
   const Configuration<LocationT> &configuration) const
 {
 	return std::all_of(configuration.begin(), configuration.end(), [this](auto const &state) {
-		return final_locations_.count(state.first) > 0;
+		return final_locations_.count(state.location) > 0;
 	});
 }
 

--- a/src/automata/include/automata/ata_formula.h
+++ b/src/automata/include/automata/ata_formula.h
@@ -55,10 +55,7 @@ template <typename LocationT>
 bool
 operator<(const State<LocationT> &s1, const State<LocationT> &s2)
 {
-	if (s1.location != s2.location) {
-		return s1.location < s2.location;
-	}
-	return s1.clock_valuation < s2.clock_valuation;
+	return std::tie(s1.location, s1.clock_valuation) < std::tie(s2.location, s2.clock_valuation);
 }
 
 /** Check two states for equality

--- a/src/automata/include/automata/ata_formula.h
+++ b/src/automata/include/automata/ata_formula.h
@@ -78,8 +78,6 @@ operator==(const State<LocationT> &s1, const State<LocationT> &s2)
 template <typename LocationT>
 class Formula;
 
-} // namespace automata::ata
-
 /** Print a Formula to an ostream.
  * @param os The ostream to print to
  * @param formula The formula to print
@@ -96,7 +94,6 @@ std::ostream &operator<<(std::ostream &os, const automata::ata::Formula<Location
 template <typename LocationT>
 std::ostream &operator<<(std::ostream &os, const automata::ata::State<LocationT> &state);
 
-namespace automata::ata {
 /// An abstract ATA formula.
 template <typename LocationT>
 class Formula

--- a/src/automata/include/automata/ata_formula.h
+++ b/src/automata/include/automata/ata_formula.h
@@ -31,8 +31,49 @@
 
 namespace automata::ata {
 
+/** A state of an ATA.
+ * An ATAState is always a pair (location, clock valuation).
+ * @tparam The location type
+ */
 template <typename LocationT>
-using State = std::pair<LocationT, ClockValuation>;
+struct State
+{
+	/** The location of the state */
+	LocationT location;
+	/** The clock valuation of the state */
+	ClockValuation clock_valuation;
+};
+
+/** Compare two States.
+ * @param s1 The first state
+ * @param s2 The second state
+ * @return true if s1 is lexicographically smaller than s2, i.e., true if s1's location is smaller
+ * than s2's location, or if the locations are the same and s1's clock valuation is smaller than
+ * s2's clock valuation
+ */
+template <typename LocationT>
+bool
+operator<(const State<LocationT> &s1, const State<LocationT> &s2)
+{
+	if (s1.location != s2.location) {
+		return s1.location < s2.location;
+	}
+	return s1.clock_valuation < s2.clock_valuation;
+}
+
+/** Check two states for equality
+ * @param s1 The first state
+ * @param s2 The second state
+ * @return true if both states are identical
+ */
+template <typename LocationT>
+bool
+operator==(const State<LocationT> &s1, const State<LocationT> &s2)
+{
+	return !(s1 < s2) && !(s2 < s1);
+}
+
+// using State = std::pair<LocationT, ClockValuation>;
 
 template <typename LocationT>
 class Formula;

--- a/src/automata/include/automata/ata_formula.hpp
+++ b/src/automata/include/automata/ata_formula.hpp
@@ -36,7 +36,7 @@ template <typename LocationT>
 std::ostream &
 operator<<(std::ostream &os, const automata::ata::State<LocationT> &state)
 {
-	os << "(" << state.first << ", " << state.second << std::string(")");
+	os << "(" << state.location << ", " << state.clock_valuation << std::string(")");
 	return os;
 }
 
@@ -91,14 +91,14 @@ bool
 LocationFormula<LocationT>::is_satisfied(const std::set<State<LocationT>> &states,
                                          const ClockValuation &            v) const
 {
-	return states.count(std::make_pair(location_, v));
+	return states.count(State<LocationT>{location_, v});
 }
 
 template <typename LocationT>
 std::set<std::set<State<LocationT>>>
 LocationFormula<LocationT>::get_minimal_models(const ClockValuation &v) const
 {
-	return {{std::make_pair(location_, v)}};
+	return {{State<LocationT>{location_, v}}};
 }
 
 template <typename LocationT>

--- a/src/automata/include/automata/ata_formula.hpp
+++ b/src/automata/include/automata/ata_formula.hpp
@@ -24,6 +24,8 @@
 #include <experimental/set>
 #include <set>
 
+namespace automata::ata {
+
 template <typename LocationT>
 std::ostream &
 operator<<(std::ostream &os, const automata::ata::Formula<LocationT> &formula)
@@ -39,8 +41,6 @@ operator<<(std::ostream &os, const automata::ata::State<LocationT> &state)
 	os << "(" << state.location << ", " << state.clock_valuation << std::string(")");
 	return os;
 }
-
-namespace automata::ata {
 
 template <typename LocationT>
 bool

--- a/src/automata/include/automata/automata.h
+++ b/src/automata/include/automata/automata.h
@@ -130,21 +130,6 @@ private:
 	Time valuation_;
 };
 
-/// Invalid location encountered
-/*** This exception is thrown when some location (e.g., as part of a transition) is not  part of a
- * timed automaton.
- */
-template <typename Location>
-class InvalidLocationException : public std::invalid_argument
-{
-public:
-	/** Constructor
-	 */
-	explicit InvalidLocationException(const Location &) : std::invalid_argument("Invalid location")
-	{
-	}
-};
-
 /// Invalid clock encountered
 /*** This exception is thrown when some clock (e.g., as part of a transition) is not  part of a
  * timed automaton.

--- a/src/automata/include/automata/automata.h
+++ b/src/automata/include/automata/automata.h
@@ -53,8 +53,6 @@ using ClockConstraint = std::variant<AtomicClockConstraintT<std::less<Time>>,
                                      AtomicClockConstraintT<std::greater_equal<Time>>,
                                      AtomicClockConstraintT<std::greater<Time>>>;
 
-} // namespace automata
-
 template <class Comp>
 std::ostream &operator<<(std::ostream &                                os,
                          const automata::AtomicClockConstraintT<Comp> &constraint);
@@ -73,8 +71,6 @@ std::ostream &operator<<(std::ostream &os, const automata::ClockConstraint &cons
  */
 std::ostream &operator<<(std::ostream &                                               os,
                          const std::multimap<std::string, automata::ClockConstraint> &constraints);
-
-namespace automata {
 
 /// Invalid timed word, e.g., first time is not initialized at 0.
 class InvalidTimedWordException : public std::invalid_argument

--- a/src/automata/include/automata/automata.hpp
+++ b/src/automata/include/automata/automata.hpp
@@ -21,6 +21,8 @@
 
 #include "automata.h"
 
+namespace automata {
+
 template <class Comp>
 std::ostream &
 operator<<(std::ostream &os, const automata::AtomicClockConstraintT<Comp> &constraint)
@@ -46,3 +48,5 @@ operator<<(std::ostream &os, const automata::AtomicClockConstraintT<Comp> &const
 	os << " " << constraint.comparand_;
 	return os;
 }
+
+} // namespace automata

--- a/src/automata/include/automata/ta.h
+++ b/src/automata/include/automata/ta.h
@@ -69,25 +69,23 @@ struct Configuration
 	Location<LocationT> location;
 	/** The current clock valuations of the TA */
 	ClockSetValuation clock_valuations;
+
 	/** Check if one configuration is lexicographically smaller than the other.
-	 * @return true if this configuration has a smaller location or the same location and smaller
-	 * clock valuations than the other configuration
+	 * @return true if the first configuration is smaler than the second
 	 */
-	[[nodiscard]] bool
-	operator<(const Configuration<LocationT> &other) const
+	[[nodiscard]] friend bool
+	operator<(const Configuration<LocationT> &first, const Configuration<LocationT> &second)
 	{
-		if (location != other.location) {
-			return location < other.location;
-		}
-		return clock_valuations < other.clock_valuations;
+		return std::tie(first.location, first.clock_valuations)
+		       < std::tie(second.location, second.clock_valuations);
 	}
 	/** Check if two configurations are identical.
 	 * @return true if both configurations have the same location and clock valuations.
 	 */
-	[[nodiscard]] bool
-	operator==(const Configuration<LocationT> &other) const
+	[[nodiscard]] friend bool
+	operator==(const Configuration<LocationT> &first, const Configuration<LocationT> &second)
 	{
-		return !(*this < other) && !(other < *this);
+		return !(first < second) && !(second < first);
 	}
 };
 

--- a/src/automata/include/automata/ta.h
+++ b/src/automata/include/automata/ta.h
@@ -71,7 +71,6 @@ class TimedAutomaton;
 
 template <typename LocationT, typename AP>
 class Transition;
-} // namespace automata::ta
 
 /** Print a transition
  * @param os The ostream to print to
@@ -84,11 +83,6 @@ std::ostream &operator<<(std::ostream &                                 os,
 
 template <typename LocationT, typename AP>
 std::ostream &operator<<(std::ostream &os, const automata::ta::TimedAutomaton<LocationT, AP> &ta);
-
-template <typename T1, typename T2>
-std::ostream &operator<<(std::ostream &os, const std::tuple<T1, T2> &t);
-
-namespace automata::ta {
 
 /// Compare two transitions.
 /** Two transitions are equal if they use the same source, target, read the
@@ -426,8 +420,6 @@ private:
 	std::multimap<LocationT, Transition<LocationT, AP>> transitions_;
 };
 
-} // namespace automata::ta
-
 /** Print a multimap of transitions. */
 template <typename LocationT, typename AP>
 std::ostream &
@@ -443,6 +435,8 @@ std::ostream &operator<<(std::ostream &os, const std::set<T> &strings);
 template <typename Location>
 std::ostream &operator<<(std::ostream &                               os,
                          const automata::ta::Configuration<Location> &configuration);
+
+} // namespace automata::ta
 
 #include "ta.hpp"
 

--- a/src/automata/include/automata/ta.h
+++ b/src/automata/include/automata/ta.h
@@ -34,8 +34,37 @@
 
 namespace automata::ta {
 
+/** A TA Configuration, consisting of a location and a set of clock valuations.
+ * @tparam LocationT The location type
+ */
 template <typename LocationT>
-using Configuration = std::pair<LocationT, ClockSetValuation>;
+struct Configuration
+{
+	/** The current location of the TA */
+	LocationT location;
+	/** The current clock valuations of the TA */
+	ClockSetValuation clock_valuations;
+	/** Check if one configuration is lexicographically smaller than the other.
+	 * @return true if this configuration has a smaller location or the same location and smaller
+	 * clock valuations than the other configuration
+	 */
+	[[nodiscard]] bool
+	operator<(const Configuration<LocationT> &other) const
+	{
+		if (location != other.location) {
+			return location < other.location;
+		}
+		return clock_valuations < other.clock_valuations;
+	}
+	/** Check if two configurations are identical.
+	 * @return true if both configurations have the same location and clock valuations.
+	 */
+	[[nodiscard]] bool
+	operator==(const Configuration<LocationT> &other) const
+	{
+		return !(*this < other) && !(other < *this);
+	}
+};
 
 template <typename LocationT, typename AP>
 class TimedAutomaton;
@@ -165,7 +194,7 @@ public:
 	Configuration<LocationT>
 	get_current_configuration() const
 	{
-		return std::make_pair(current_location_, clock_valuations_);
+		return {current_location_, clock_valuations_};
 	}
 
 private:

--- a/src/automata/include/automata/ta.hpp
+++ b/src/automata/include/automata/ta.hpp
@@ -21,33 +21,38 @@
 
 #include "ta.h"
 
-template <typename T1>
+namespace automata::ta {
+
+template <typename LocationT, typename AP>
 std::ostream &
-operator<<(std::ostream &os, const std::pair<T1, std::vector<std::string>> &pair)
+operator<<(std::ostream &os, const std::multimap<LocationT, Transition<LocationT, AP>> &transitions)
 {
-	os << "(" << pair.first << ", " << pair.second << ")";
+	for (const auto &[source, transition] : transitions) {
+		os << transition << '\n';
+	}
 	return os;
 }
 
-template <typename T>
+template <typename Location>
 std::ostream &
-operator<<(std::ostream &os, const std::vector<T> &elements)
+operator<<(std::ostream &os, const Configuration<Location> &configuration)
 {
-	if (elements.empty()) {
-		os << "[]";
+	os << "(" << configuration.location << ", ";
+	if (configuration.clock_valuations.empty()) {
+		os << "{})";
 		return os;
 	}
+	os << "{ ";
 	bool first = true;
-	os << "[ ";
-	for (const auto &element : elements) {
+	for (const auto &[clock, value] : configuration.clock_valuations) {
 		if (first) {
 			first = false;
 		} else {
 			os << ", ";
 		}
-		os << element;
+		os << clock << ": " << value;
 	}
-	os << " ]";
+	os << " } )";
 	return os;
 }
 
@@ -75,41 +80,7 @@ operator<<(std::ostream &os, const std::set<T> &elements)
 
 template <typename LocationT, typename AP>
 std::ostream &
-operator<<(std::ostream &                                                           os,
-           const std::multimap<LocationT, automata::ta::Transition<LocationT, AP>> &transitions)
-{
-	for (const auto &[source, transition] : transitions) {
-		os << transition << '\n';
-	}
-	return os;
-}
-
-template <typename Location>
-std::ostream &
-operator<<(std::ostream &os, const automata::ta::Configuration<Location> &configuration)
-{
-	os << "(" << configuration.location << ", ";
-	if (configuration.clock_valuations.empty()) {
-		os << "{})";
-		return os;
-	}
-	os << "{ ";
-	bool first = true;
-	for (const auto &[clock, value] : configuration.clock_valuations) {
-		if (first) {
-			first = false;
-		} else {
-			os << ", ";
-		}
-		os << clock << ": " << value;
-	}
-	os << " } )";
-	return os;
-}
-
-template <typename LocationT, typename AP>
-std::ostream &
-operator<<(std::ostream &os, const automata::ta::Transition<LocationT, AP> &transition)
+operator<<(std::ostream &os, const Transition<LocationT, AP> &transition)
 {
 	os << transition.source_ << u8" → " << transition.symbol_ << " / "
 	   << transition.clock_constraints_ << " / " << transition.clock_resets_ << u8" → "
@@ -119,7 +90,7 @@ operator<<(std::ostream &os, const automata::ta::Transition<LocationT, AP> &tran
 
 template <typename LocationT, typename AP>
 std::ostream &
-operator<<(std::ostream &os, const automata::ta::TimedAutomaton<LocationT, AP> &ta)
+operator<<(std::ostream &os, const TimedAutomaton<LocationT, AP> &ta)
 {
 	os << "Alphabet: " << ta.alphabet_ << ", initial location: " << ta.initial_location_
 	   << ", final locations: " << ta.final_locations_ << ", transitions:\n"
@@ -127,15 +98,6 @@ operator<<(std::ostream &os, const automata::ta::TimedAutomaton<LocationT, AP> &
 	return os;
 }
 
-template <typename T1, typename T2>
-std::ostream &
-operator<<(std::ostream &os, const std::tuple<T1, T2> &t)
-{
-	os << "(" << std::get<0>(t) << ", " << std::get<1>(t) << ")";
-	return os;
-}
-
-namespace automata::ta {
 template <typename LocationT, typename AP>
 bool
 Transition<LocationT, AP>::is_enabled(const AP &symbol, const ClockSetValuation &clock_vals) const

--- a/src/automata/include/automata/ta.hpp
+++ b/src/automata/include/automata/ta.hpp
@@ -25,7 +25,8 @@ namespace automata::ta {
 
 template <typename LocationT, typename AP>
 std::ostream &
-operator<<(std::ostream &os, const std::multimap<LocationT, Transition<LocationT, AP>> &transitions)
+operator<<(std::ostream &                                                       os,
+           const std::multimap<Location<LocationT>, Transition<LocationT, AP>> &transitions)
 {
 	for (const auto &[source, transition] : transitions) {
 		os << transition << '\n';

--- a/src/automata/include/automata/ta_product.h
+++ b/src/automata/include/automata/ta_product.h
@@ -32,6 +32,15 @@ class NotImplementedException : public std::logic_error
 	using std::logic_error::logic_error;
 };
 
+/** Print a product location. */
+template <typename LocationT1, typename LocationT2>
+std::ostream &
+operator<<(std::ostream &os, const Location<std::tuple<LocationT1, LocationT2>> &location)
+{
+	os << "(" << std::get<0>(location.get()) << ", " << std::get<1>(location.get()) << ")";
+	return os;
+}
+
 /** Compute the product automaton of two timed automata.
  * The resulting automaton's location set is the cartesian product of the
  * input automata's locations.
@@ -57,16 +66,6 @@ get_product(const TimedAutomaton<LocationT1, ActionT> &ta1,
             const std::set<ActionT> &                  synchronized_actions = {});
 
 } // namespace automata::ta
-
-namespace std {
-template <typename LocationT1, typename LocationT2>
-std::ostream &
-operator<<(std::ostream &os, const std::tuple<LocationT1, LocationT2> &t)
-{
-	os << "(" << std::get<0>(t) << ", " << std::get<1>(t) << ")";
-	return os;
-}
-} // namespace std
 
 #include "ta_product.hpp"
 

--- a/src/automata/include/automata/ta_product.h
+++ b/src/automata/include/automata/ta_product.h
@@ -58,6 +58,16 @@ get_product(const TimedAutomaton<LocationT1, ActionT> &ta1,
 
 } // namespace automata::ta
 
+namespace std {
+template <typename LocationT1, typename LocationT2>
+std::ostream &
+operator<<(std::ostream &os, const std::tuple<LocationT1, LocationT2> &t)
+{
+	os << "(" << std::get<0>(t) << ", " << std::get<1>(t) << ")";
+	return os;
+}
+} // namespace std
+
 #include "ta_product.hpp"
 
 #endif /* ifndef SRC_AUTOMATA_INCLUDE_AUTOMATA_TA_PRODUCT_H_ */

--- a/src/automata/include/automata/ta_regions.h
+++ b/src/automata/include/automata/ta_regions.h
@@ -31,7 +31,7 @@ namespace automata::ta {
 using RegionIndex        = size_t;
 using RegionSetValuation = std::map<std::string, RegionIndex>;
 template <typename LocationT>
-using RegionalizedConfiguration = std::pair<LocationT, RegionSetValuation>;
+using RegionalizedConfiguration = std::pair<Location<LocationT>, RegionSetValuation>;
 using Integer                   = unsigned; ///< fix integer type
 
 /// A set of one-dimensional regions

--- a/src/automata/include/automata/ta_regions.hpp
+++ b/src/automata/include/automata/ta_regions.hpp
@@ -28,10 +28,10 @@ Configuration<LocationT>
 get_region_candidate(const RegionalizedConfiguration<LocationT> &regionalized_configuration)
 {
 	Configuration<LocationT> res;
-	res.first = regionalized_configuration.first;
+	res.location = regionalized_configuration.first;
 	std::transform(std::begin(regionalized_configuration.second),
 	               std::end(regionalized_configuration.second),
-	               std::inserter(res.second, res.second.end()),
+	               std::inserter(res.clock_valuations, res.clock_valuations.end()),
 	               [&](const std::pair<std::string, RegionIndex> &clock_region) {
 		               const std::string &clock_name = clock_region.first;
 		               const RegionIndex &region     = clock_region.second;

--- a/src/automata/ta_proto.cpp
+++ b/src/automata/ta_proto.cpp
@@ -69,9 +69,9 @@ parse_transition(const proto::TimedAutomaton::Transition &transition_proto)
 		}
 	}
 	return Transition<std::string, std::string>{
-	  transition_proto.source(),
+	  Location<std::string>{transition_proto.source()},
 	  transition_proto.symbol(),
-	  transition_proto.target(),
+	  Location<std::string>{transition_proto.target()},
 	  clock_constraints,
 	  std::set<std::string>{begin(transition_proto.clock_resets()),
 	                        end(transition_proto.clock_resets())}};
@@ -82,10 +82,14 @@ TimedAutomaton<std::string, std::string>
 parse_proto(const proto::TimedAutomaton &ta_proto)
 {
 	return TimedAutomaton<std::string, std::string>{
-	  std::set<std::string>{begin(ta_proto.locations()), end(ta_proto.locations())},
+	  ranges::subrange(std::begin(ta_proto.locations()), std::end(ta_proto.locations()))
+	    | ranges::views::transform([](const auto &name) { return Location<std::string>{name}; })
+	    | ranges::to<std::set>,
 	  std::set<std::string>{begin(ta_proto.alphabet()), end(ta_proto.alphabet())},
-	  ta_proto.initial_location(),
-	  std::set<std::string>{begin(ta_proto.final_locations()), end(ta_proto.final_locations())},
+	  Location<std::string>{ta_proto.initial_location()},
+	  ranges::subrange(std::begin(ta_proto.final_locations()), std::end(ta_proto.final_locations()))
+	    | ranges::views::transform([](const auto &name) { return Location<std::string>{name}; })
+	    | ranges::to<std::set>,
 	  std::set<std::string>{begin(ta_proto.clocks()), end(ta_proto.clocks())},
 	  // Construct a Transition for each transition in the proto.
 	  ranges::subrange(std::begin(ta_proto.transitions()), std::end(ta_proto.transitions()))

--- a/src/mtl/include/mtl/MTLFormula.h
+++ b/src/mtl/include/mtl/MTLFormula.h
@@ -345,8 +345,6 @@ operator!(const AtomicProposition<APType> &ap)
 	return !MTLFormula<APType>(ap);
 }
 
-} // namespace logic
-
 /// outstream operator
 template <typename APType>
 std::ostream &operator<<(std::ostream &out, const logic::AtomicProposition<APType> &a);
@@ -354,6 +352,8 @@ std::ostream &operator<<(std::ostream &out, const logic::AtomicProposition<APTyp
 /// outstream operator
 template <typename APType>
 std::ostream &operator<<(std::ostream &out, const logic::MTLFormula<APType> &f);
+
+} // namespace logic
 
 #include "MTLFormula.hpp"
 

--- a/src/mtl/include/mtl/MTLFormula.hpp
+++ b/src/mtl/include/mtl/MTLFormula.hpp
@@ -22,6 +22,8 @@
 #include "MTLFormula.h"
 #include "utilities/Interval.h"
 
+namespace logic {
+
 template <typename APType>
 std::ostream &
 operator<<(std::ostream &out, const logic::AtomicProposition<APType> &a)
@@ -64,8 +66,6 @@ operator<<(std::ostream &out, const logic::MTLFormula<APType> &f)
 	}
 	return out;
 }
-
-namespace logic {
 
 template <typename APType>
 bool

--- a/src/mtl_ata_translation/include/mtl_ata_translation/translator.h
+++ b/src/mtl_ata_translation/include/mtl_ata_translation/translator.h
@@ -20,9 +20,8 @@
 
 #pragma once
 
-#include "mtl/MTLFormula.h"
-// MTL needs to be included first to have operator<< available for MTLFormula.
 #include "automata/ata.h"
+#include "mtl/MTLFormula.h"
 
 /// Translate an MTL formula into an ATA.
 namespace mtl_ata_translation {

--- a/src/synchronous_product/include/synchronous_product/canonical_word.h
+++ b/src/synchronous_product/include/synchronous_product/canonical_word.h
@@ -32,19 +32,19 @@ namespace synchronous_product {
 using automata::ClockValuation;
 using automata::Time;
 using automata::ta::RegionIndex;
-template <typename Location>
+template <typename LocationT>
 /** Short-hand type alias for a configuration of a TA */
-using TAConfiguration = automata::ta::Configuration<Location>;
+using TAConfiguration = automata::ta::Configuration<LocationT>;
 /** Always use ATA configurations over MTLFormulas */
 template <typename ActionType>
 using ATAConfiguration = automata::ata::Configuration<logic::MTLFormula<ActionType>>;
 
 /** An expanded state (location, clock_name, clock_valuation) of a TimedAutomaton */
-template <typename Location>
+template <typename LocationT>
 struct TAState
 {
 	/** The location part of this state */
-	Location location;
+	automata::ta::Location<LocationT> location;
 	/** The clock name of this state */
 	std::string clock;
 	/** The clock valuation of the clock in this state */
@@ -56,9 +56,9 @@ struct TAState
  * @param s2 The second state
  * @return true if s1 is lexicographically smaller than s2
  */
-template <typename Location>
+template <typename LocationT>
 bool
-operator<(const TAState<Location> &s1, const TAState<Location> &s2)
+operator<(const TAState<LocationT> &s1, const TAState<LocationT> &s2)
 {
 	if (s1.location != s2.location) {
 		return s1.location < s2.location;
@@ -73,15 +73,15 @@ operator<(const TAState<Location> &s1, const TAState<Location> &s2)
 template <typename ActionType>
 using ATAState = automata::ata::State<logic::MTLFormula<ActionType>>;
 /** An ABSymbol is either a TAState or an ATAState */
-template <typename Location, typename ActionType>
-using ABSymbol = std::variant<TAState<Location>, ATAState<ActionType>>;
+template <typename LocationT, typename ActionType>
+using ABSymbol = std::variant<TAState<LocationT>, ATAState<ActionType>>;
 
 /** A TARegionState is a tuple (location, clock_name, clock_region) */
-template <typename Location>
+template <typename LocationT>
 struct TARegionState
 {
 	/** The location of the TA region state */
-	Location location;
+	automata::ta::Location<LocationT> location;
 	/** The clock name of this region state */
 	std::string clock;
 	/** The region index (regionalized clock valuation) of the clock in this state */
@@ -93,9 +93,9 @@ struct TARegionState
  * @param s2 The second state
  * @return true if s1 is lexicographically smaller than s2
  */
-template <typename Location>
+template <typename LocationT>
 bool
-operator<(const TARegionState<Location> &s1, const TARegionState<Location> &s2)
+operator<(const TARegionState<LocationT> &s1, const TARegionState<LocationT> &s2)
 {
 	if (s1.location != s2.location) {
 		return s1.location < s2.location;
@@ -113,9 +113,9 @@ operator<(const TARegionState<Location> &s1, const TARegionState<Location> &s2)
  * @param s2 The second state
  * @return true if s1 is equal to s2
  */
-template <typename Location>
+template <typename LocationT>
 bool
-operator==(const TARegionState<Location> &s1, const TARegionState<Location> &s2)
+operator==(const TARegionState<LocationT> &s1, const TARegionState<LocationT> &s2)
 {
 	return !(s1 < s2) && !(s2 < s1);
 }
@@ -135,9 +135,9 @@ struct ATARegionState
  * @param s2 The second state
  * @return true if s1 is lexicographically smaller than s2
  */
-template <typename Location>
+template <typename LocationT>
 bool
-operator<(const ATARegionState<Location> &s1, const ATARegionState<Location> &s2)
+operator<(const ATARegionState<LocationT> &s1, const ATARegionState<LocationT> &s2)
 {
 	if (s1.formula != s2.formula) {
 		return s1.formula < s2.formula;
@@ -152,26 +152,26 @@ operator<(const ATARegionState<Location> &s1, const ATARegionState<Location> &s2
  * @param s2 The second state
  * @return true if s1 is equal to s2
  */
-template <typename Location>
+template <typename LocationT>
 bool
-operator==(const ATARegionState<Location> &s1, const ATARegionState<Location> &s2)
+operator==(const ATARegionState<LocationT> &s1, const ATARegionState<LocationT> &s2)
 {
 	return !(s1 < s2) && !(s2 < s1);
 }
 
 /** An ABRegionSymbol is either a TARegionState or an ATARegionState */
-template <typename Location, typename ActionType>
-using ABRegionSymbol = std::variant<TARegionState<Location>, ATARegionState<ActionType>>;
+template <typename LocationT, typename ActionType>
+using ABRegionSymbol = std::variant<TARegionState<LocationT>, ATARegionState<ActionType>>;
 
 /** A canonical word H(s) for a regionalized A/B configuration */
-template <typename Location, typename ActionType>
-using CanonicalABWord = std::vector<std::set<ABRegionSymbol<Location, ActionType>>>;
+template <typename LocationT, typename ActionType>
+using CanonicalABWord = std::vector<std::set<ABRegionSymbol<LocationT, ActionType>>>;
 
 } // namespace synchronous_product
 
-template <typename Location>
+template <typename LocationT>
 std::ostream &
-operator<<(std::ostream &os, const synchronous_product::TARegionState<Location> &state)
+operator<<(std::ostream &os, const synchronous_product::TARegionState<LocationT> &state)
 {
 	os << "(" << state.location << ", " << state.clock << ", " << state.region_index << ")";
 	return os;
@@ -185,19 +185,19 @@ operator<<(std::ostream &os, const synchronous_product::ATARegionState<ActionTyp
 	return os;
 }
 
-template <typename Location, typename ActionType>
+template <typename LocationT, typename ActionType>
 std::ostream &
-operator<<(std::ostream &                                                   os,
-           const synchronous_product::ABRegionSymbol<Location, ActionType> &symbol)
+operator<<(std::ostream &                                                    os,
+           const synchronous_product::ABRegionSymbol<LocationT, ActionType> &symbol)
 {
 	std::visit([&os](const auto &v) { os << v; }, symbol);
 	return os;
 }
 
-template <typename Location, typename ActionType>
+template <typename LocationT, typename ActionType>
 std::ostream &
-operator<<(std::ostream &                                                             os,
-           const std::set<synchronous_product::ABRegionSymbol<Location, ActionType>> &word)
+operator<<(std::ostream &                                                              os,
+           const std::set<synchronous_product::ABRegionSymbol<LocationT, ActionType>> &word)
 {
 	if (word.empty()) {
 		os << "{}";
@@ -217,11 +217,11 @@ operator<<(std::ostream &                                                       
 	return os;
 }
 
-template <typename Location, typename ActionType>
+template <typename LocationT, typename ActionType>
 std::ostream &
 operator<<(
-  std::ostream &                                                                          os,
-  const std::vector<std::set<synchronous_product::ABRegionSymbol<Location, ActionType>>> &word)
+  std::ostream &                                                                           os,
+  const std::vector<std::set<synchronous_product::ABRegionSymbol<LocationT, ActionType>>> &word)
 {
 	if (word.empty()) {
 		os << "[]";
@@ -241,10 +241,10 @@ operator<<(
 	return os;
 }
 
-template <typename Location, typename ActionType>
+template <typename LocationT, typename ActionType>
 std::ostream &
-operator<<(std::ostream &                                                                 os,
-           const std::vector<synchronous_product::CanonicalABWord<Location, ActionType>> &ab_words)
+operator<<(std::ostream &                                                                  os,
+           const std::vector<synchronous_product::CanonicalABWord<LocationT, ActionType>> &ab_words)
 {
 	if (ab_words.empty()) {
 		os << "{}";
@@ -264,25 +264,26 @@ operator<<(std::ostream &                                                       
 	return os;
 }
 
-template <typename Location, typename ActionType>
+template <typename LocationT, typename ActionType>
 std::ostream &
-operator<<(std::ostream &                                                                os,
+operator<<(std::ostream &                                                                 os,
            const std::tuple<synchronous_product::RegionIndex,
                             ActionType,
-                            synchronous_product::CanonicalABWord<Location, ActionType>> &ab_word)
+                            synchronous_product::CanonicalABWord<LocationT, ActionType>> &ab_word)
 {
 	os << "(" << std::get<0>(ab_word) << ", " << std::get<1>(ab_word) << ", " << std::get<2>(ab_word)
 	   << ")";
 	return os;
 }
 
-template <typename Location, typename ActionType>
+template <typename LocationT, typename ActionType>
 std::ostream &
-operator<<(std::ostream &os,
-           const std::vector<std::tuple<synchronous_product::RegionIndex,
-                                        ActionType,
-                                        synchronous_product::CanonicalABWord<Location, ActionType>>>
-             &ab_words)
+operator<<(
+  std::ostream &os,
+  const std::vector<std::tuple<synchronous_product::RegionIndex,
+                               ActionType,
+                               synchronous_product::CanonicalABWord<LocationT, ActionType>>>
+    &ab_words)
 {
 	if (ab_words.empty()) {
 		os << "{}";
@@ -302,10 +303,10 @@ operator<<(std::ostream &os,
 	return os;
 }
 
-template <typename Location, typename ActionType>
+template <typename LocationT, typename ActionType>
 std::ostream &
-operator<<(std::ostream &                                                              os,
-           const std::set<synchronous_product::CanonicalABWord<Location, ActionType>> &ab_words)
+operator<<(std::ostream &                                                               os,
+           const std::set<synchronous_product::CanonicalABWord<LocationT, ActionType>> &ab_words)
 {
 	if (ab_words.empty()) {
 		os << "{}";

--- a/src/synchronous_product/include/synchronous_product/canonical_word.h
+++ b/src/synchronous_product/include/synchronous_product/canonical_word.h
@@ -122,7 +122,43 @@ operator==(const TARegionState<Location> &s1, const TARegionState<Location> &s2)
 
 /** An ATARegionState is a pair (formula, clock_region) */
 template <typename ActionType>
-using ATARegionState = std::pair<logic::MTLFormula<ActionType>, RegionIndex>;
+struct ATARegionState
+{
+	/** The ATA formula in the regionalized ATA state */
+	logic::MTLFormula<ActionType> formula;
+	/** The region index of the state */
+	RegionIndex region_index;
+};
+
+/** Compare two ATA region states.
+ * @param s1 The first state
+ * @param s2 The second state
+ * @return true if s1 is lexicographically smaller than s2
+ */
+template <typename Location>
+bool
+operator<(const ATARegionState<Location> &s1, const ATARegionState<Location> &s2)
+{
+	if (s1.formula != s2.formula) {
+		return s1.formula < s2.formula;
+	}
+	return s1.region_index < s2.region_index;
+}
+
+/** Check two ATA region states for equality.
+ * Two ATA region states are considered equal if they have the same location and region
+ * index.
+ * @param s1 The first state
+ * @param s2 The second state
+ * @return true if s1 is equal to s2
+ */
+template <typename Location>
+bool
+operator==(const ATARegionState<Location> &s1, const ATARegionState<Location> &s2)
+{
+	return !(s1 < s2) && !(s2 < s1);
+}
+
 /** An ABRegionSymbol is either a TARegionState or an ATARegionState */
 template <typename Location, typename ActionType>
 using ABRegionSymbol = std::variant<TARegionState<Location>, ATARegionState<ActionType>>;
@@ -145,7 +181,7 @@ template <typename ActionType>
 std::ostream &
 operator<<(std::ostream &os, const synchronous_product::ATARegionState<ActionType> &state)
 {
-	os << "(" << state.first << ", " << state.second << ")";
+	os << "(" << state.formula << ", " << state.region_index << ")";
 	return os;
 }
 

--- a/src/synchronous_product/include/synchronous_product/canonical_word.h
+++ b/src/synchronous_product/include/synchronous_product/canonical_word.h
@@ -38,9 +38,37 @@ using TAConfiguration = automata::ta::Configuration<Location>;
 /** Always use ATA configurations over MTLFormulas */
 template <typename ActionType>
 using ATAConfiguration = automata::ata::Configuration<logic::MTLFormula<ActionType>>;
+
 /** An expanded state (location, clock_name, clock_valuation) of a TimedAutomaton */
 template <typename Location>
-using TAState = std::tuple<Location, std::string, ClockValuation>;
+struct TAState
+{
+	/** The location part of this state */
+	Location location;
+	/** The clock name of this state */
+	std::string clock;
+	/** The clock valuation of the clock in this state */
+	ClockValuation clock_valuation;
+};
+
+/** Compare two TAStates
+ * @param s1 The first state
+ * @param s2 The second state
+ * @return true if s1 is lexicographically smaller than s2
+ */
+template <typename Location>
+bool
+operator<(const TAState<Location> &s1, const TAState<Location> &s2)
+{
+	if (s1.location != s2.location) {
+		return s1.location < s2.location;
+	}
+	if (s1.clock != s2.clock) {
+		return s1.clock < s2.clock;
+	}
+	return s1.clock_valuation < s2.clock_valuation;
+}
+
 /** Always use ATA states over MTLFormulas */
 template <typename ActionType>
 using ATAState = automata::ata::State<logic::MTLFormula<ActionType>>;

--- a/src/synchronous_product/include/synchronous_product/canonical_word.h
+++ b/src/synchronous_product/include/synchronous_product/canonical_word.h
@@ -60,13 +60,8 @@ template <typename LocationT>
 bool
 operator<(const TAState<LocationT> &s1, const TAState<LocationT> &s2)
 {
-	if (s1.location != s2.location) {
-		return s1.location < s2.location;
-	}
-	if (s1.clock != s2.clock) {
-		return s1.clock < s2.clock;
-	}
-	return s1.clock_valuation < s2.clock_valuation;
+	return std::tie(s1.location, s1.clock, s1.clock_valuation)
+	       < std::tie(s2.location, s2.clock, s2.clock_valuation);
 }
 
 /** Always use ATA states over MTLFormulas */

--- a/src/synchronous_product/include/synchronous_product/canonical_word.h
+++ b/src/synchronous_product/include/synchronous_product/canonical_word.h
@@ -92,13 +92,8 @@ template <typename LocationT>
 bool
 operator<(const TARegionState<LocationT> &s1, const TARegionState<LocationT> &s2)
 {
-	if (s1.location != s2.location) {
-		return s1.location < s2.location;
-	}
-	if (s1.clock != s2.clock) {
-		return s1.clock < s2.clock;
-	}
-	return s1.region_index < s2.region_index;
+	return std::tie(s1.location, s1.clock, s1.region_index)
+	       < std::tie(s2.location, s2.clock, s2.region_index);
 }
 
 /** Check two TA region states for equality.

--- a/src/synchronous_product/include/synchronous_product/canonical_word.h
+++ b/src/synchronous_product/include/synchronous_product/canonical_word.h
@@ -75,9 +75,51 @@ using ATAState = automata::ata::State<logic::MTLFormula<ActionType>>;
 /** An ABSymbol is either a TAState or an ATAState */
 template <typename Location, typename ActionType>
 using ABSymbol = std::variant<TAState<Location>, ATAState<ActionType>>;
+
 /** A TARegionState is a tuple (location, clock_name, clock_region) */
 template <typename Location>
-using TARegionState = std::tuple<Location, std::string, RegionIndex>;
+struct TARegionState
+{
+	/** The location of the TA region state */
+	Location location;
+	/** The clock name of this region state */
+	std::string clock;
+	/** The region index (regionalized clock valuation) of the clock in this state */
+	RegionIndex region_index;
+};
+
+/** Compare two TA region states.
+ * @param s1 The first state
+ * @param s2 The second state
+ * @return true if s1 is lexicographically smaller than s2
+ */
+template <typename Location>
+bool
+operator<(const TARegionState<Location> &s1, const TARegionState<Location> &s2)
+{
+	if (s1.location != s2.location) {
+		return s1.location < s2.location;
+	}
+	if (s1.clock != s2.clock) {
+		return s1.clock < s2.clock;
+	}
+	return s1.region_index < s2.region_index;
+}
+
+/** Check two TA region states for equality.
+ * Two TA region states are considered equal if they have the same location, clock name, and region
+ * index.
+ * @param s1 The first state
+ * @param s2 The second state
+ * @return true if s1 is equal to s2
+ */
+template <typename Location>
+bool
+operator==(const TARegionState<Location> &s1, const TARegionState<Location> &s2)
+{
+	return !(s1 < s2) && !(s2 < s1);
+}
+
 /** An ATARegionState is a pair (formula, clock_region) */
 template <typename ActionType>
 using ATARegionState = std::pair<logic::MTLFormula<ActionType>, RegionIndex>;
@@ -95,8 +137,7 @@ template <typename Location>
 std::ostream &
 operator<<(std::ostream &os, const synchronous_product::TARegionState<Location> &state)
 {
-	os << "(" << std::get<0>(state) << ", " << std::get<1>(state) << ", " << std::get<2>(state)
-	   << ")";
+	os << "(" << state.location << ", " << state.clock << ", " << state.region_index << ")";
 	return os;
 }
 

--- a/src/synchronous_product/include/synchronous_product/canonical_word.h
+++ b/src/synchronous_product/include/synchronous_product/canonical_word.h
@@ -167,8 +167,7 @@ using ABRegionSymbol = std::variant<TARegionState<LocationT>, ATARegionState<Act
 template <typename LocationT, typename ActionType>
 using CanonicalABWord = std::vector<std::set<ABRegionSymbol<LocationT, ActionType>>>;
 
-} // namespace synchronous_product
-
+/** Print a TARegionState. */
 template <typename LocationT>
 std::ostream &
 operator<<(std::ostream &os, const synchronous_product::TARegionState<LocationT> &state)
@@ -177,6 +176,7 @@ operator<<(std::ostream &os, const synchronous_product::TARegionState<LocationT>
 	return os;
 }
 
+/** Print an ATARegionState. */
 template <typename ActionType>
 std::ostream &
 operator<<(std::ostream &os, const synchronous_product::ATARegionState<ActionType> &state)
@@ -185,6 +185,7 @@ operator<<(std::ostream &os, const synchronous_product::ATARegionState<ActionTyp
 	return os;
 }
 
+/** Print an ABRegionSymbol. */
 template <typename LocationT, typename ActionType>
 std::ostream &
 operator<<(std::ostream &                                                    os,
@@ -194,6 +195,7 @@ operator<<(std::ostream &                                                    os,
 	return os;
 }
 
+/** Print a set of ABRegionSymbols (a letter of a CanonicalABWord). */
 template <typename LocationT, typename ActionType>
 std::ostream &
 operator<<(std::ostream &                                                              os,
@@ -217,6 +219,7 @@ operator<<(std::ostream &                                                       
 	return os;
 }
 
+/** Print a CanonicalABWord. */
 template <typename LocationT, typename ActionType>
 std::ostream &
 operator<<(
@@ -241,6 +244,7 @@ operator<<(
 	return os;
 }
 
+/** Print a vector of CanonicalABWords. */
 template <typename LocationT, typename ActionType>
 std::ostream &
 operator<<(std::ostream &                                                                  os,
@@ -264,6 +268,7 @@ operator<<(std::ostream &                                                       
 	return os;
 }
 
+/** Print a next canonical word along with its region index and action. */
 template <typename LocationT, typename ActionType>
 std::ostream &
 operator<<(std::ostream &                                                                 os,
@@ -276,6 +281,7 @@ operator<<(std::ostream &                                                       
 	return os;
 }
 
+/** Print a vector of next canonical words. */
 template <typename LocationT, typename ActionType>
 std::ostream &
 operator<<(
@@ -303,6 +309,7 @@ operator<<(
 	return os;
 }
 
+/** Print a set of CanonicalABWords. */
 template <typename LocationT, typename ActionType>
 std::ostream &
 operator<<(std::ostream &                                                               os,
@@ -326,24 +333,4 @@ operator<<(std::ostream &                                                       
 	return os;
 }
 
-template <typename T1, typename T2>
-std::ostream &
-operator<<(std::ostream &os, const std::set<std::pair<T1, T2>> &set)
-{
-	if (set.empty()) {
-		os << "{}";
-		return os;
-	}
-	os << "{ ";
-	bool first = true;
-	for (const auto &element : set) {
-		if (first) {
-			first = false;
-		} else {
-			os << ", ";
-		}
-		os << "(" << element.first << ", " << element.second << ")";
-	}
-	os << " }";
-	return os;
-}
+} // namespace synchronous_product

--- a/src/synchronous_product/include/synchronous_product/canonical_word.h
+++ b/src/synchronous_product/include/synchronous_product/canonical_word.h
@@ -129,10 +129,7 @@ template <typename LocationT>
 bool
 operator<(const ATARegionState<LocationT> &s1, const ATARegionState<LocationT> &s2)
 {
-	if (s1.formula != s2.formula) {
-		return s1.formula < s2.formula;
-	}
-	return s1.region_index < s2.region_index;
+	return std::tie(s1.formula, s1.region_index) < std::tie(s2.formula, s2.region_index);
 }
 
 /** Check two ATA region states for equality.

--- a/src/synchronous_product/include/synchronous_product/search_tree.h
+++ b/src/synchronous_product/include/synchronous_product/search_tree.h
@@ -241,11 +241,19 @@ struct SearchTreeNode
 	std::set<std::pair<RegionIndex, ActionType>> incoming_actions;
 };
 
-} // namespace synchronous_product
-
+/** Print a node state. */
 std::ostream &operator<<(std::ostream &os, const synchronous_product::NodeState &node_state);
+/** Print a node label. */
 std::ostream &operator<<(std::ostream &os, const synchronous_product::NodeLabel &node_label);
 
+/** @brief Print a SearchTreeNode, optionally the whole tree.
+ * By default, just print information about the node itself on a single line. Optionally, also print
+ * all its children, effectively printing the whole sub-tree.
+ * @param os The stream to print to
+ * @param node The node to print
+ * @param print_children If true, also print the node's children
+ * @param indent The indentation to insert before this node, should be the distance to the root node
+ */
 template <typename Location, typename ActionType>
 void
 print_to_ostream(std::ostream &                                                   os,
@@ -300,3 +308,5 @@ operator<<(
 	}
 	return os;
 }
+
+} // namespace synchronous_product

--- a/src/synchronous_product/include/synchronous_product/synchronous_product.h
+++ b/src/synchronous_product/include/synchronous_product/synchronous_product.h
@@ -307,15 +307,15 @@ get_canonical_word(const automata::ta::Configuration<Location> &ta_configuration
                    const unsigned int                           K)
 {
 	// TODO Also accept a TA that does not have any clocks.
-	if (ta_configuration.second.empty()) {
+	if (ta_configuration.clock_valuations.empty()) {
 		throw std::invalid_argument("TA without clocks are not supported");
 	}
 	std::set<ABSymbol<Location, ActionType>> g;
 	// Insert ATA configurations into g.
 	std::copy(ata_configuration.begin(), ata_configuration.end(), std::inserter(g, g.end()));
 	// Insert TA configurations into g.
-	for (const auto &[clock_name, clock_value] : ta_configuration.second) {
-		g.insert(TAState<Location>{ta_configuration.first, clock_name, clock_value});
+	for (const auto &[clock_name, clock_value] : ta_configuration.clock_valuations) {
+		g.insert(TAState<Location>{ta_configuration.location, clock_name, clock_value});
 	}
 	// Sort into partitions by the fractional parts.
 	std::map<ClockValuation, std::set<ABSymbol<Location, ActionType>>> partitioned_g;
@@ -378,8 +378,8 @@ get_candidate(const CanonicalABWord<Location, ActionType> &word)
 				const Time        integral_part   = static_cast<RegionIndex>(region_index / 2);
 				const auto &      clock_name      = ta_region_state.clock;
 				// update ta_configuration
-				ta_configuration.first              = ta_region_state.location;
-				ta_configuration.second[clock_name] = integral_part + fractional_part;
+				ta_configuration.location                     = ta_region_state.location;
+				ta_configuration.clock_valuations[clock_name] = integral_part + fractional_part;
 			} else { // ATARegionState<ActionType>
 				const auto &      ata_region_state = std::get<ATARegionState<ActionType>>(symbol);
 				const RegionIndex region_index     = ata_region_state.region_index;

--- a/src/synchronous_product/include/synchronous_product/synchronous_product.h
+++ b/src/synchronous_product/include/synchronous_product/synchronous_product.h
@@ -65,7 +65,7 @@ get_region_index(const ABRegionSymbol<Location, ActionType> &w)
 	if (std::holds_alternative<TARegionState<Location>>(w)) {
 		return std::get<TARegionState<Location>>(w).region_index;
 	} else {
-		return std::get<ATARegionState<ActionType>>(w).second;
+		return std::get<ATARegionState<ActionType>>(w).region_index;
 	}
 }
 
@@ -192,7 +192,7 @@ increment_region_indexes(const std::set<ABRegionSymbol<Location, ActionType>> &c
 			               }
 		               } else {
 			               auto &ata_configuration = std::get<ATARegionState<ActionType>>(configuration);
-			               RegionIndex &region_index = std::get<1>(ata_configuration);
+			               RegionIndex &region_index = ata_configuration.region_index;
 			               // Increment if the region index is less than the max_region_index and if the
 			               // region index is even or if we increment all region indexes.
 			               if (region_index < max_region_index) {
@@ -340,8 +340,8 @@ get_canonical_word(const automata::ta::Configuration<Location> &ta_configuration
 				                                 regionSet.getRegionIndex(s.clock_valuation)};
 			  } else {
 				  const ATAState<ActionType> &s = std::get<ATAState<ActionType>>(w);
-				  return ATARegionState<ActionType>(s.location,
-				                                    regionSet.getRegionIndex(s.clock_valuation));
+				  return ATARegionState<ActionType>{s.location,
+				                                    regionSet.getRegionIndex(s.clock_valuation)};
 			  }
 		  });
 		abs.push_back(abs_i);
@@ -382,14 +382,14 @@ get_candidate(const CanonicalABWord<Location, ActionType> &word)
 				ta_configuration.second[clock_name] = integral_part + fractional_part;
 			} else { // ATARegionState<ActionType>
 				const auto &      ata_region_state = std::get<ATARegionState<ActionType>>(symbol);
-				const RegionIndex region_index     = std::get<1>(ata_region_state);
+				const RegionIndex region_index     = ata_region_state.region_index;
 				const Time        fractional_part  = region_index % 2 == 0 ? 0 : time_delta * (i + 1);
 				const Time        integral_part    = static_cast<RegionIndex>(region_index / 2);
 				// update configuration
 				// TODO check: the formula (aka ActionType) encodes the location, the clock valuation is
 				// separate and a configuration is a set of such pairs. Is this already sufficient?
 				ata_configuration.insert(
-				  ATAState<ActionType>{std::get<0>(ata_region_state), fractional_part + integral_part});
+				  ATAState<ActionType>{ata_region_state.formula, fractional_part + integral_part});
 			}
 		}
 	}

--- a/src/synchronous_product/include/synchronous_product/synchronous_product.h
+++ b/src/synchronous_product/include/synchronous_product/synchronous_product.h
@@ -63,7 +63,7 @@ RegionIndex
 get_region_index(const ABRegionSymbol<Location, ActionType> &w)
 {
 	if (std::holds_alternative<TARegionState<Location>>(w)) {
-		return std::get<2>(std::get<TARegionState<Location>>(w));
+		return std::get<TARegionState<Location>>(w).region_index;
 	} else {
 		return std::get<ATARegionState<ActionType>>(w).second;
 	}
@@ -184,7 +184,7 @@ increment_region_indexes(const std::set<ABRegionSymbol<Location, ActionType>> &c
 	               [max_region_index](auto configuration) {
 		               if (std::holds_alternative<TARegionState<Location>>(configuration)) {
 			               auto &ta_configuration    = std::get<TARegionState<Location>>(configuration);
-			               RegionIndex &region_index = std::get<2>(ta_configuration);
+			               RegionIndex &region_index = ta_configuration.region_index;
 			               // Increment if the region index is less than the max_region_index and if the
 			               // region index is even or if we increment all region indexes.
 			               if (region_index < max_region_index) {
@@ -335,9 +335,9 @@ get_canonical_word(const automata::ta::Configuration<Location> &ta_configuration
 		  [&](const ABSymbol<Location, ActionType> &w) -> ABRegionSymbol<Location, ActionType> {
 			  if (std::holds_alternative<TAState<Location>>(w)) {
 				  const TAState<Location> &s = std::get<TAState<Location>>(w);
-				  return TARegionState<Location>(s.location,
+				  return TARegionState<Location>{s.location,
 				                                 s.clock,
-				                                 regionSet.getRegionIndex(s.clock_valuation));
+				                                 regionSet.getRegionIndex(s.clock_valuation)};
 			  } else {
 				  const ATAState<ActionType> &s = std::get<ATAState<ActionType>>(w);
 				  return ATARegionState<ActionType>(s.location,
@@ -373,12 +373,12 @@ get_candidate(const CanonicalABWord<Location, ActionType> &word)
 			// TODO Refactor, fractional/integral outside of if
 			if (std::holds_alternative<TARegionState<Location>>(symbol)) {
 				const auto &      ta_region_state = std::get<TARegionState<Location>>(symbol);
-				const RegionIndex region_index    = std::get<2>(ta_region_state);
+				const RegionIndex region_index    = ta_region_state.region_index;
 				const Time        fractional_part = region_index % 2 == 0 ? 0 : time_delta * (i + 1);
 				const Time        integral_part   = static_cast<RegionIndex>(region_index / 2);
-				const auto &      clock_name      = std::get<1>(ta_region_state);
+				const auto &      clock_name      = ta_region_state.clock;
 				// update ta_configuration
-				ta_configuration.first              = std::get<0>(ta_region_state);
+				ta_configuration.first              = ta_region_state.location;
 				ta_configuration.second[clock_name] = integral_part + fractional_part;
 			} else { // ATARegionState<ActionType>
 				const auto &      ata_region_state = std::get<ATARegionState<ActionType>>(symbol);

--- a/src/synchronous_product/include/synchronous_product/synchronous_product.h
+++ b/src/synchronous_product/include/synchronous_product/synchronous_product.h
@@ -47,7 +47,7 @@ ClockValuation
 get_time(const ABSymbol<Location, ActionType> &w)
 {
 	if (std::holds_alternative<TAState<Location>>(w)) {
-		return std::get<2>(std::get<TAState<Location>>(w));
+		return std::get<TAState<Location>>(w).clock_valuation;
 	} else {
 		return std::get<ATAState<ActionType>>(w).second;
 	}
@@ -315,7 +315,7 @@ get_canonical_word(const automata::ta::Configuration<Location> &ta_configuration
 	std::copy(ata_configuration.begin(), ata_configuration.end(), std::inserter(g, g.end()));
 	// Insert TA configurations into g.
 	for (const auto &[clock_name, clock_value] : ta_configuration.second) {
-		g.insert(std::make_tuple(ta_configuration.first, clock_name, clock_value));
+		g.insert(TAState<Location>{ta_configuration.first, clock_name, clock_value});
 	}
 	// Sort into partitions by the fractional parts.
 	std::map<ClockValuation, std::set<ABSymbol<Location, ActionType>>> partitioned_g;
@@ -335,9 +335,9 @@ get_canonical_word(const automata::ta::Configuration<Location> &ta_configuration
 		  [&](const ABSymbol<Location, ActionType> &w) -> ABRegionSymbol<Location, ActionType> {
 			  if (std::holds_alternative<TAState<Location>>(w)) {
 				  const TAState<Location> &s = std::get<TAState<Location>>(w);
-				  return TARegionState<Location>(std::get<0>(s),
-				                                 std::get<1>(s),
-				                                 regionSet.getRegionIndex(std::get<2>(s)));
+				  return TARegionState<Location>(s.location,
+				                                 s.clock,
+				                                 regionSet.getRegionIndex(s.clock_valuation));
 			  } else {
 				  const ATAState<ActionType> &s = std::get<ATAState<ActionType>>(w);
 				  return ATARegionState<ActionType>(s.first, regionSet.getRegionIndex(s.second));

--- a/src/synchronous_product/include/synchronous_product/synchronous_product.h
+++ b/src/synchronous_product/include/synchronous_product/synchronous_product.h
@@ -49,7 +49,7 @@ get_time(const ABSymbol<Location, ActionType> &w)
 	if (std::holds_alternative<TAState<Location>>(w)) {
 		return std::get<TAState<Location>>(w).clock_valuation;
 	} else {
-		return std::get<ATAState<ActionType>>(w).second;
+		return std::get<ATAState<ActionType>>(w).clock_valuation;
 	}
 }
 
@@ -340,7 +340,8 @@ get_canonical_word(const automata::ta::Configuration<Location> &ta_configuration
 				                                 regionSet.getRegionIndex(s.clock_valuation));
 			  } else {
 				  const ATAState<ActionType> &s = std::get<ATAState<ActionType>>(w);
-				  return ATARegionState<ActionType>(s.first, regionSet.getRegionIndex(s.second));
+				  return ATARegionState<ActionType>(s.location,
+				                                    regionSet.getRegionIndex(s.clock_valuation));
 			  }
 		  });
 		abs.push_back(abs_i);
@@ -388,7 +389,7 @@ get_candidate(const CanonicalABWord<Location, ActionType> &word)
 				// TODO check: the formula (aka ActionType) encodes the location, the clock valuation is
 				// separate and a configuration is a set of such pairs. Is this already sufficient?
 				ata_configuration.insert(
-				  std::make_pair(std::get<0>(ata_region_state), fractional_part + integral_part));
+				  ATAState<ActionType>{std::get<0>(ata_region_state), fractional_part + integral_part});
 			}
 		}
 	}

--- a/src/synchronous_product/search_tree.cpp
+++ b/src/synchronous_product/search_tree.cpp
@@ -7,6 +7,7 @@
 
 #include "synchronous_product/search_tree.h"
 
+namespace synchronous_product {
 std::ostream &
 operator<<(std::ostream &os, const synchronous_product::NodeState &node_state)
 {
@@ -32,3 +33,5 @@ operator<<(std::ostream &os, const synchronous_product::NodeLabel &node_label)
 	}
 	return os;
 }
+
+} // namespace synchronous_product

--- a/test/test_ata.cpp
+++ b/test/test_ata.cpp
@@ -201,7 +201,7 @@ TEST_CASE("Simple ATA with a disjunction", "[ta]")
 }
 
 TEST_CASE("ATA accepting no events with a time difference of exactly 1"
-          " (example by Ouaknine & Worrel, 2005)")
+          " (example by Ouaknine & Worrell, 2005)")
 {
 	std::set<Transition<std::string, std::string>> transitions;
 	transitions.insert(Transition<std::string, std::string>(
@@ -255,7 +255,7 @@ TEST_CASE("ATA accepting no events with a time difference of exactly 1"
 	}
 }
 
-TEST_CASE("Time-bounded response two-state ATA (example by Ouaknine & Worrel, 2005)", "[ta]")
+TEST_CASE("Time-bounded response two-state ATA (example by Ouaknine & Worrell, 2005)", "[ta]")
 {
 	std::set<Transition<std::string, std::string>> transitions;
 	transitions.insert(Transition<std::string, std::string>(

--- a/test/test_ata.cpp
+++ b/test/test_ata.cpp
@@ -55,6 +55,20 @@ TEST_CASE("ATA less-than operator for transitions", "[automata][ata]")
 	}
 }
 
+TEST_CASE("Comparison of ATA states", "[automata][ata]")
+{
+	using S = State<std::string>;
+	CHECK(S{"l0", 0} < S{"l1", 0});
+	CHECK(!(S{"l1", 0} < S{"l1", 0}));
+	CHECK(!(S{"l1", 0} < S{"l1", 0}));
+	CHECK(!(S{"l1", 2} < S{"l1", 0}));
+	CHECK(S{"l1", 0} < S{"l1", 1});
+	CHECK(S{"l0", 0} == S{"l0", 0});
+	CHECK(S{"l1", 5} == S{"l1", 5});
+	CHECK(!(S{"l1", 5} == S{"l1", 4}));
+	CHECK(!(S{"l2", 5} == S{"l1", 5}));
+}
+
 TEST_CASE("ATA initial configuration", "[automata][ata]")
 {
 	AlternatingTimedAutomaton<std::string, std::string> ata({"a", "b"}, "s1", {"s0"}, {});

--- a/test/test_ata_formula.cpp
+++ b/test/test_ata_formula.cpp
@@ -29,6 +29,7 @@ namespace {
 
 using namespace automata;
 using namespace automata::ata;
+using State = automata::ata::State<std::string>;
 
 TEST_CASE("Simple ATA formulas", "[ta]")
 {
@@ -133,21 +134,16 @@ TEST_CASE("ATA reset clock formulas", "[ta]")
 
 TEST_CASE("Minimal models of ATA atomic formulas", "[ta]")
 {
-	REQUIRE(TrueFormula<std::string>().get_minimal_models(2)
-	        == std::set<std::set<State<std::string>>>{{}});
-	REQUIRE(FalseFormula<std::string>().get_minimal_models(2)
-	        == std::set<std::set<State<std::string>>>{});
+	REQUIRE(TrueFormula<std::string>().get_minimal_models(2) == std::set<std::set<State>>{{}});
+	REQUIRE(FalseFormula<std::string>().get_minimal_models(2) == std::set<std::set<State>>{});
 	{
 		LocationFormula<std::string> f{"s0"};
-		REQUIRE(f.get_minimal_models(0)
-		        == std::set<std::set<State<std::string>>>{{State<std::string>("s0", 0)}});
-		REQUIRE(f.get_minimal_models(1)
-		        == std::set<std::set<State<std::string>>>{{State<std::string>("s0", 1)}});
+		REQUIRE(f.get_minimal_models(0) == std::set<std::set<State>>{{State{"s0", 0}}});
+		REQUIRE(f.get_minimal_models(1) == std::set<std::set<State>>{{State{"s0", 1}}});
 	}
 	{
 		ResetClockFormula<std::string> f(std::make_unique<LocationFormula<std::string>>("s0"));
-		REQUIRE(f.get_minimal_models(1)
-		        == std::set<std::set<State<std::string>>>{{State<std::string>("s0", 0)}});
+		REQUIRE(f.get_minimal_models(1) == std::set<std::set<State>>{{State{"s0", 0}}});
 	}
 }
 TEST_CASE("Minimal models of ATA conjunction formulas", "[ta]")
@@ -155,39 +151,31 @@ TEST_CASE("Minimal models of ATA conjunction formulas", "[ta]")
 	{
 		ConjunctionFormula<std::string> f(std::make_unique<LocationFormula<std::string>>("s0"),
 		                                  std::make_unique<LocationFormula<std::string>>("s1"));
-		REQUIRE(f.get_minimal_models(0)
-		        == std::set<std::set<State<std::string>>>{
-		          {State<std::string>("s0", 0), State<std::string>("s1", 0)}});
-		REQUIRE(f.get_minimal_models(1)
-		        == std::set<std::set<State<std::string>>>{
-		          {State<std::string>("s0", 1), State<std::string>("s1", 1)}});
+		REQUIRE(f.get_minimal_models(0) == std::set<std::set<State>>{{State{"s0", 0}, State{"s1", 0}}});
+		REQUIRE(f.get_minimal_models(1) == std::set<std::set<State>>{{State{"s0", 1}, State{"s1", 1}}});
 	}
 	{
 		ConjunctionFormula<std::string> f(std::make_unique<TrueFormula<std::string>>(),
 		                                  std::make_unique<FalseFormula<std::string>>());
-		REQUIRE(f.get_minimal_models(0) == std::set<std::set<State<std::string>>>{});
+		REQUIRE(f.get_minimal_models(0) == std::set<std::set<State>>{});
 	}
 	{
 		ConjunctionFormula<std::string> f(std::make_unique<LocationFormula<std::string>>("s0"),
 		                                  std::make_unique<TrueFormula<std::string>>());
-		REQUIRE(f.get_minimal_models(0)
-		        == std::set<std::set<State<std::string>>>{{State<std::string>("s0", 0)}});
-		REQUIRE(f.get_minimal_models(1)
-		        == std::set<std::set<State<std::string>>>{{State<std::string>("s0", 1)}});
+		REQUIRE(f.get_minimal_models(0) == std::set<std::set<State>>{{State{"s0", 0}}});
+		REQUIRE(f.get_minimal_models(1) == std::set<std::set<State>>{{State{"s0", 1}}});
 	}
 	{
 		ConjunctionFormula<std::string> f(std::make_unique<LocationFormula<std::string>>("s0"),
 		                                  std::make_unique<FalseFormula<std::string>>());
-		REQUIRE(f.get_minimal_models(0) == std::set<std::set<State<std::string>>>{});
-		REQUIRE(f.get_minimal_models(1) == std::set<std::set<State<std::string>>>{});
+		REQUIRE(f.get_minimal_models(0) == std::set<std::set<State>>{});
+		REQUIRE(f.get_minimal_models(1) == std::set<std::set<State>>{});
 	}
 	{
 		ConjunctionFormula<std::string> f(std::make_unique<LocationFormula<std::string>>("s0"),
 		                                  std::make_unique<ResetClockFormula<std::string>>(
 		                                    std::make_unique<LocationFormula<std::string>>("s1")));
-		REQUIRE(f.get_minimal_models(1)
-		        == std::set<std::set<State<std::string>>>{
-		          {State<std::string>("s0", 1), State<std::string>("s1", 0)}});
+		REQUIRE(f.get_minimal_models(1) == std::set<std::set<State>>{{State{"s0", 1}, State{"s1", 0}}});
 	}
 }
 TEST_CASE("Minimal models of ATA disjunction formulas", "[ta]")
@@ -196,44 +184,39 @@ TEST_CASE("Minimal models of ATA disjunction formulas", "[ta]")
 		DisjunctionFormula<std::string> f(std::make_unique<LocationFormula<std::string>>("s0"),
 		                                  std::make_unique<LocationFormula<std::string>>("s1"));
 		REQUIRE(f.get_minimal_models(0)
-		        == std::set<std::set<State<std::string>>>{{State<std::string>("s0", 0)},
-		                                                  {State<std::string>("s1", 0)}});
+		        == std::set<std::set<State>>{{State{"s0", 0}}, {State{"s1", 0}}});
 		REQUIRE(f.get_minimal_models(1)
-		        == std::set<std::set<State<std::string>>>{{State<std::string>("s0", 1)},
-		                                                  {State<std::string>("s1", 1)}});
+		        == std::set<std::set<State>>{{State{"s0", 1}}, {State{"s1", 1}}});
 	}
 	{
 		DisjunctionFormula<std::string> f(std::make_unique<TrueFormula<std::string>>(),
 		                                  std::make_unique<FalseFormula<std::string>>());
-		REQUIRE(f.get_minimal_models(0) == std::set<std::set<State<std::string>>>{{}});
+		REQUIRE(f.get_minimal_models(0) == std::set<std::set<State>>{{}});
 	}
 	{
 		DisjunctionFormula<std::string> f(std::make_unique<LocationFormula<std::string>>("s0"),
 		                                  std::make_unique<TrueFormula<std::string>>());
-		REQUIRE(f.get_minimal_models(0) == std::set<std::set<State<std::string>>>{{}});
-		REQUIRE(f.get_minimal_models(1) == std::set<std::set<State<std::string>>>{{}});
+		REQUIRE(f.get_minimal_models(0) == std::set<std::set<State>>{{}});
+		REQUIRE(f.get_minimal_models(1) == std::set<std::set<State>>{{}});
 	}
 	{
 		DisjunctionFormula<std::string> f(std::make_unique<TrueFormula<std::string>>(),
 		                                  std::make_unique<LocationFormula<std::string>>("s0"));
-		REQUIRE(f.get_minimal_models(0) == std::set<std::set<State<std::string>>>{{}});
-		REQUIRE(f.get_minimal_models(1) == std::set<std::set<State<std::string>>>{{}});
+		REQUIRE(f.get_minimal_models(0) == std::set<std::set<State>>{{}});
+		REQUIRE(f.get_minimal_models(1) == std::set<std::set<State>>{{}});
 	}
 	{
 		DisjunctionFormula<std::string> f(std::make_unique<LocationFormula<std::string>>("s0"),
 		                                  std::make_unique<FalseFormula<std::string>>());
-		REQUIRE(f.get_minimal_models(0)
-		        == std::set<std::set<State<std::string>>>{{State<std::string>("s0", 0)}});
-		REQUIRE(f.get_minimal_models(1)
-		        == std::set<std::set<State<std::string>>>{{State<std::string>("s0", 1)}});
+		REQUIRE(f.get_minimal_models(0) == std::set<std::set<State>>{{State{"s0", 0}}});
+		REQUIRE(f.get_minimal_models(1) == std::set<std::set<State>>{{State{"s0", 1}}});
 	}
 	{
 		DisjunctionFormula<std::string> f(std::make_unique<LocationFormula<std::string>>("s0"),
 		                                  std::make_unique<ResetClockFormula<std::string>>(
 		                                    std::make_unique<LocationFormula<std::string>>("s1")));
 		REQUIRE(f.get_minimal_models(1)
-		        == std::set<std::set<State<std::string>>>{{State<std::string>("s0", 1)},
-		                                                  {State<std::string>("s1", 0)}});
+		        == std::set<std::set<State>>{{State{"s0", 1}}, {State{"s1", 0}}});
 	}
 }
 

--- a/test/test_synchronous_product.cpp
+++ b/test/test_synchronous_product.cpp
@@ -235,7 +235,7 @@ TEST_CASE("Get a concrete candidate for a canonical word", "[canonical_word]")
 		// A single ATA state with fractional part in (0, 1)
 		const Candidate cand = get_candidate(CanonicalABWord({{ATARegionState{a, 1}}}));
 		REQUIRE(cand.second.size() == 1);
-		const auto v = cand.second.begin()->second;
+		const auto v = cand.second.begin()->clock_valuation;
 		CHECK(getFractionalPart<Integer>(v) > 0);
 		CHECK(getIntegerPart<Integer>(v) == 0);
 	}
@@ -244,7 +244,7 @@ TEST_CASE("Get a concrete candidate for a canonical word", "[canonical_word]")
 		// A single ATA state with fractional part not in (0, 1)
 		const Candidate cand = get_candidate(CanonicalABWord({{ATARegionState{a, 3}}}));
 		REQUIRE(cand.second.size() == 1);
-		const auto v = cand.second.begin()->second;
+		const auto v = cand.second.begin()->clock_valuation;
 		CHECK(getFractionalPart<Integer>(v) > 0);
 		CHECK(getIntegerPart<Integer>(v) == 1);
 	}

--- a/test/test_synchronous_product.cpp
+++ b/test/test_synchronous_product.cpp
@@ -203,18 +203,16 @@ TEST_CASE("Get a concrete candidate for a canonical word", "[canonical_word]")
 
 	// single state with fractional part 0, clock 0
 	CHECK(get_candidate(CanonicalABWord({{TARegionState{"s0", "c0", 0}}}))
-	      == Candidate(TAConf{std::pair<std::string, automata::ClockSetValuation>("s0", {{"c0", 0}})},
-	                   ATAConf{}));
+	      == Candidate(TAConf{"s0", {{"c0", 0}}}, ATAConf{}));
 	// single state with fractional part 0, clock != 0
 	CHECK(get_candidate(CanonicalABWord({{TARegionState{"s0", "c0", 2}}}))
-	      == Candidate(TAConf{std::pair<std::string, automata::ClockSetValuation>("s0", {{"c0", 1}})},
-	                   ATAConf{}));
+	      == Candidate(TAConf{"s0", {{"c0", 1}}}, ATAConf{}));
 
 	{
 		// single state with non-zero fractional part in (0, 1)
 		const Candidate cand = get_candidate(CanonicalABWord({{TARegionState{"s0", "c0", 1}}}));
-		CHECK(cand.first.second.at("c0") > 0.0);
-		CHECK(cand.first.second.at("c0") < 1.0);
+		CHECK(cand.first.clock_valuations.at("c0") > 0.0);
+		CHECK(cand.first.clock_valuations.at("c0") < 1.0);
 		// The ATA configuration must be empty.
 		CHECK(cand.second.empty());
 	}
@@ -222,8 +220,8 @@ TEST_CASE("Get a concrete candidate for a canonical word", "[canonical_word]")
 	{
 		// single state with non-zero fractional part not in (0, 1)
 		const Candidate cand = get_candidate(CanonicalABWord({{TARegionState{"s0", "c0", 5}}}));
-		CHECK(cand.first.second.at("c0") > 2.0);
-		CHECK(cand.first.second.at("c0") < 3.0);
+		CHECK(cand.first.clock_valuations.at("c0") > 2.0);
+		CHECK(cand.first.clock_valuations.at("c0") < 3.0);
 		// The ATA configuration must be empty.
 		CHECK(cand.second.empty());
 	}
@@ -253,10 +251,10 @@ TEST_CASE("Get a concrete candidate for a canonical word", "[canonical_word]")
 		// two clocks, both non-fractional with same integer parts
 		const Candidate cand = get_candidate(
 		  CanonicalABWord({{TARegionState{"s0", "c0", 2}, TARegionState{"s0", "c1", 2}}}));
-		CHECK(getFractionalPart<Integer>(cand.first.second.at("c0")) == 0);
-		CHECK(getFractionalPart<Integer>(cand.first.second.at("c1")) == 0);
-		CHECK(getIntegerPart<Integer>(cand.first.second.at("c0"))
-		      == getIntegerPart<Integer>(cand.first.second.at("c1")));
+		CHECK(getFractionalPart<Integer>(cand.first.clock_valuations.at("c0")) == 0);
+		CHECK(getFractionalPart<Integer>(cand.first.clock_valuations.at("c1")) == 0);
+		CHECK(getIntegerPart<Integer>(cand.first.clock_valuations.at("c0"))
+		      == getIntegerPart<Integer>(cand.first.clock_valuations.at("c1")));
 		// The ATA configuration must be empty.
 		CHECK(cand.second.empty());
 	}
@@ -265,10 +263,10 @@ TEST_CASE("Get a concrete candidate for a canonical word", "[canonical_word]")
 		// two clocks, both non-fractional but with different integer parts
 		const Candidate cand = get_candidate(
 		  CanonicalABWord({{TARegionState{"s0", "c0", 0}, TARegionState{"s0", "c1", 2}}}));
-		CHECK(getFractionalPart<Integer>(cand.first.second.at("c0")) == 0);
-		CHECK(getFractionalPart<Integer>(cand.first.second.at("c1")) == 0);
-		CHECK(getIntegerPart<Integer>(cand.first.second.at("c0"))
-		      < getIntegerPart<Integer>(cand.first.second.at("c1")));
+		CHECK(getFractionalPart<Integer>(cand.first.clock_valuations.at("c0")) == 0);
+		CHECK(getFractionalPart<Integer>(cand.first.clock_valuations.at("c1")) == 0);
+		CHECK(getIntegerPart<Integer>(cand.first.clock_valuations.at("c0"))
+		      < getIntegerPart<Integer>(cand.first.clock_valuations.at("c1")));
 		// The ATA configuration must be empty.
 		CHECK(cand.second.empty());
 	}
@@ -277,9 +275,9 @@ TEST_CASE("Get a concrete candidate for a canonical word", "[canonical_word]")
 		// two states, one with a clock with fractional part, the other one without
 		const Candidate cand = get_candidate(
 		  CanonicalABWord({{TARegionState{"s0", "c0", 2}}, {TARegionState{"s0", "c1", 1}}}));
-		CHECK(cand.first.second.at("c0") == 1.0);
-		CHECK(cand.first.second.at("c1") > 0.0);
-		CHECK(cand.first.second.at("c1") < 1.0);
+		CHECK(cand.first.clock_valuations.at("c0") == 1.0);
+		CHECK(cand.first.clock_valuations.at("c1") > 0.0);
+		CHECK(cand.first.clock_valuations.at("c1") < 1.0);
 		// The ATA configuration must be empty.
 		CHECK(cand.second.empty());
 	}
@@ -289,7 +287,7 @@ TEST_CASE("Get a concrete candidate for a canonical word", "[canonical_word]")
 		// parts
 		const Candidate cand = get_candidate(
 		  CanonicalABWord({{TARegionState{"s0", "c0", 1}, TARegionState{"s0", "c1", 1}}}));
-		CHECK(cand.first.second.at("c0") == cand.first.second.at("c1"));
+		CHECK(cand.first.clock_valuations.at("c0") == cand.first.clock_valuations.at("c1"));
 	}
 
 	{
@@ -297,10 +295,10 @@ TEST_CASE("Get a concrete candidate for a canonical word", "[canonical_word]")
 		// parts
 		const Candidate cand = get_candidate(
 		  CanonicalABWord({{TARegionState{"s0", "c0", 1}, TARegionState{"s0", "c1", 3}}}));
-		CHECK(getFractionalPart<Integer>(cand.first.second.at("c0"))
-		      == getFractionalPart<Integer>(cand.first.second.at("c1")));
-		CHECK(getIntegerPart<Integer>(cand.first.second.at("c0"))
-		      < getIntegerPart<Integer>(cand.first.second.at("c1")));
+		CHECK(getFractionalPart<Integer>(cand.first.clock_valuations.at("c0"))
+		      == getFractionalPart<Integer>(cand.first.clock_valuations.at("c1")));
+		CHECK(getIntegerPart<Integer>(cand.first.clock_valuations.at("c0"))
+		      < getIntegerPart<Integer>(cand.first.clock_valuations.at("c1")));
 	}
 
 	{
@@ -308,22 +306,22 @@ TEST_CASE("Get a concrete candidate for a canonical word", "[canonical_word]")
 		// parts
 		const Candidate cand = get_candidate(
 		  CanonicalABWord({{TARegionState{"s0", "c0", 1}}, {TARegionState{"s0", "c1", 1}}}));
-		CHECK(cand.first.second.at("c0") < cand.first.second.at("c1"));
-		CHECK(getFractionalPart<Integer>(cand.first.second.at("c0"))
-		      < getFractionalPart<Integer>(cand.first.second.at("c1")));
-		CHECK(getIntegerPart<Integer>(cand.first.second.at("c0"))
-		      == getIntegerPart<Integer>(cand.first.second.at("c1")));
+		CHECK(cand.first.clock_valuations.at("c0") < cand.first.clock_valuations.at("c1"));
+		CHECK(getFractionalPart<Integer>(cand.first.clock_valuations.at("c0"))
+		      < getFractionalPart<Integer>(cand.first.clock_valuations.at("c1")));
+		CHECK(getIntegerPart<Integer>(cand.first.clock_valuations.at("c0"))
+		      == getIntegerPart<Integer>(cand.first.clock_valuations.at("c1")));
 	}
 
 	{
 		// two states, both clocks fractional with different fractional and integer parts
 		const Candidate cand = get_candidate(
 		  CanonicalABWord({{TARegionState{"s0", "c0", 1}}, {TARegionState{"s0", "c1", 3}}}));
-		CHECK(cand.first.second.at("c0") < cand.first.second.at("c1"));
-		CHECK(getFractionalPart<Integer>(cand.first.second.at("c0"))
-		      < getFractionalPart<Integer>(cand.first.second.at("c1")));
-		CHECK(getIntegerPart<Integer>(cand.first.second.at("c0"))
-		      < getIntegerPart<Integer>(cand.first.second.at("c1")));
+		CHECK(cand.first.clock_valuations.at("c0") < cand.first.clock_valuations.at("c1"));
+		CHECK(getFractionalPart<Integer>(cand.first.clock_valuations.at("c0"))
+		      < getFractionalPart<Integer>(cand.first.clock_valuations.at("c1")));
+		CHECK(getIntegerPart<Integer>(cand.first.clock_valuations.at("c0"))
+		      < getIntegerPart<Integer>(cand.first.clock_valuations.at("c1")));
 	}
 
 	{
@@ -332,15 +330,15 @@ TEST_CASE("Get a concrete candidate for a canonical word", "[canonical_word]")
 		  get_candidate(CanonicalABWord({{TARegionState{"s0", "c0", 0}},
 		                                 {TARegionState{"s0", "c1", 1}, TARegionState{"s0", "c2", 3}},
 		                                 {TARegionState{"s0", "c3", 1}}}));
-		CHECK(cand.first.second.at("c0") == 0.0);
-		CHECK(cand.first.second.at("c1") > 0.0);
-		CHECK(cand.first.second.at("c2") > 1.0);
-		CHECK(cand.first.second.at("c3") > 0.0);
-		CHECK(cand.first.second.at("c1") < 1.0);
-		CHECK(cand.first.second.at("c2") < 2.0);
-		CHECK(cand.first.second.at("c3") < 1.0);
-		CHECK(cand.first.second.at("c1") == cand.first.second.at("c2") - 1.0);
-		CHECK(cand.first.second.at("c1") < cand.first.second.at("c3"));
+		CHECK(cand.first.clock_valuations.at("c0") == 0.0);
+		CHECK(cand.first.clock_valuations.at("c1") > 0.0);
+		CHECK(cand.first.clock_valuations.at("c2") > 1.0);
+		CHECK(cand.first.clock_valuations.at("c3") > 0.0);
+		CHECK(cand.first.clock_valuations.at("c1") < 1.0);
+		CHECK(cand.first.clock_valuations.at("c2") < 2.0);
+		CHECK(cand.first.clock_valuations.at("c3") < 1.0);
+		CHECK(cand.first.clock_valuations.at("c1") == cand.first.clock_valuations.at("c2") - 1.0);
+		CHECK(cand.first.clock_valuations.at("c1") < cand.first.clock_valuations.at("c3"));
 	}
 }
 
@@ -367,7 +365,7 @@ TEST_CASE("Get the next canonical word(s)", "[canonical_word]")
 	auto              ata = mtl_ata_translation::translate(f);
 
 	auto initial_word =
-	  get_canonical_word(TAConfiguration("l0", {{"x", 0}}), ata.get_initial_configuration(), 2);
+	  get_canonical_word(TAConfiguration{"l0", {{"x", 0}}}, ata.get_initial_configuration(), 2);
 	INFO("Initial word: " << initial_word);
 	CHECK(initial_word
 	      == CanonicalABWord(

--- a/test/test_synchronous_product.cpp
+++ b/test/test_synchronous_product.cpp
@@ -65,7 +65,7 @@ TEST_CASE("Get a canonical word of a simple state", "[canonical_word]")
 	REQUIRE(abs1.size() == 2);
 	const auto &symbol1 = *abs1.begin();
 	REQUIRE(std::holds_alternative<TARegionState>(symbol1));
-	CHECK(std::get<TARegionState>(symbol1) == TARegionState("s", "c", 0));
+	CHECK(std::get<TARegionState>(symbol1) == TARegionState{"s", "c", 0});
 	const auto &symbol2 = *std::next(abs1.begin());
 	REQUIRE(std::holds_alternative<ATARegionState>(symbol2));
 	CHECK(std::get<ATARegionState>(symbol2) == ATARegionState(f, 0));
@@ -87,14 +87,14 @@ TEST_CASE("Get a canonical word of a more complex state", "[canonical_word]")
 		REQUIRE(abs1.size() == 1);
 		const auto &symbol1 = *abs1.begin();
 		REQUIRE(std::holds_alternative<TARegionState>(symbol1));
-		CHECK(std::get<TARegionState>(symbol1) == TARegionState("s", "c1", 1));
+		CHECK(std::get<TARegionState>(symbol1) == TARegionState{"s", "c1", 1});
 	}
 	{
 		const auto &abs2 = *std::next(w.begin());
 		REQUIRE(abs2.size() == 3);
 		const auto &symbol1 = *abs2.begin();
 		REQUIRE(std::holds_alternative<TARegionState>(symbol1));
-		CHECK(std::get<TARegionState>(symbol1) == TARegionState("s", "c2", 1));
+		CHECK(std::get<TARegionState>(symbol1) == TARegionState{"s", "c2", 1});
 		const auto &symbol2 = *std::next(abs2.begin());
 		REQUIRE(std::holds_alternative<ATARegionState>(symbol2));
 		CHECK(std::get<ATARegionState>(symbol2) == ATARegionState(a, 1));
@@ -330,7 +330,7 @@ TEST_CASE("Get a concrete candidate for a canonical word", "[canonical_word]")
 		// several clocks with different regions
 		const Candidate cand =
 		  get_candidate(CanonicalABWord({{TARegionState{"s0", "c0", 0}},
-		                                 {TARegionState{"s0", "c1", 1}, TARegionState("s0", "c2", 3)},
+		                                 {TARegionState{"s0", "c1", 1}, TARegionState{"s0", "c2", 3}},
 		                                 {TARegionState{"s0", "c3", 1}}}));
 		CHECK(cand.first.second.at("c0") == 0.0);
 		CHECK(cand.first.second.at("c1") > 0.0);

--- a/test/test_synchronous_product.cpp
+++ b/test/test_synchronous_product.cpp
@@ -50,13 +50,14 @@ using synchronous_product::InvalidCanonicalWordException;
 using synchronous_product::is_valid_canonical_word;
 using TARegionState = synchronous_product::TARegionState<std::string>;
 using AP            = logic::AtomicProposition<std::string>;
+using Location      = automata::ta::Location<std::string>;
 
 TEST_CASE("Get a canonical word of a simple state", "[canonical_word]")
 {
 	const logic::MTLFormula                        f{logic::AtomicProposition<std::string>{"a"}};
 	const ATAConfiguration<std::string>            ata_configuration = {{f, 0.0}};
 	const ClockSetValuation                        v{{"c", 0}};
-	const automata::ta::Configuration<std::string> ta_configuration{"s", v};
+	const automata::ta::Configuration<std::string> ta_configuration{Location{"s"}, v};
 	const auto                                     w =
 	  get_canonical_word<std::string, std::string>(ta_configuration, ata_configuration, 5);
 	INFO("Canonical word: " << w);
@@ -65,7 +66,7 @@ TEST_CASE("Get a canonical word of a simple state", "[canonical_word]")
 	REQUIRE(abs1.size() == 2);
 	const auto &symbol1 = *abs1.begin();
 	REQUIRE(std::holds_alternative<TARegionState>(symbol1));
-	CHECK(std::get<TARegionState>(symbol1) == TARegionState{"s", "c", 0});
+	CHECK(std::get<TARegionState>(symbol1) == TARegionState{Location{"s"}, "c", 0});
 	const auto &symbol2 = *std::next(abs1.begin());
 	REQUIRE(std::holds_alternative<ATARegionState>(symbol2));
 	CHECK(std::get<ATARegionState>(symbol2) == ATARegionState{f, 0});
@@ -77,7 +78,7 @@ TEST_CASE("Get a canonical word of a more complex state", "[canonical_word]")
 	const logic::MTLFormula                        b{logic::AtomicProposition<std::string>{"b"}};
 	const ATAConfiguration<std::string>            ata_configuration = {{a, 0.5}, {b, 1.5}};
 	const ClockSetValuation                        v{{"c1", 0.1}, {"c2", 0.5}};
-	const automata::ta::Configuration<std::string> ta_configuration{"s", v};
+	const automata::ta::Configuration<std::string> ta_configuration{Location{"s"}, v};
 	const auto                                     w =
 	  get_canonical_word<std::string, std::string>(ta_configuration, ata_configuration, 3);
 	INFO("Canonical word: " << w);
@@ -87,14 +88,14 @@ TEST_CASE("Get a canonical word of a more complex state", "[canonical_word]")
 		REQUIRE(abs1.size() == 1);
 		const auto &symbol1 = *abs1.begin();
 		REQUIRE(std::holds_alternative<TARegionState>(symbol1));
-		CHECK(std::get<TARegionState>(symbol1) == TARegionState{"s", "c1", 1});
+		CHECK(std::get<TARegionState>(symbol1) == TARegionState{Location{"s"}, "c1", 1});
 	}
 	{
 		const auto &abs2 = *std::next(w.begin());
 		REQUIRE(abs2.size() == 3);
 		const auto &symbol1 = *abs2.begin();
 		REQUIRE(std::holds_alternative<TARegionState>(symbol1));
-		CHECK(std::get<TARegionState>(symbol1) == TARegionState{"s", "c2", 1});
+		CHECK(std::get<TARegionState>(symbol1) == TARegionState{Location{"s"}, "c2", 1});
 		const auto &symbol2 = *std::next(abs2.begin());
 		REQUIRE(std::holds_alternative<ATARegionState>(symbol2));
 		CHECK(std::get<ATARegionState>(symbol2) == ATARegionState{a, 1});
@@ -106,7 +107,7 @@ TEST_CASE("Get a canonical word of a more complex state", "[canonical_word]")
 
 TEST_CASE("Cannot get a canonical word if the TA does not have a clock", "[canonical_word]")
 {
-	CHECK_THROWS_AS(get_canonical_word(automata::ta::Configuration<std::string>{"s", {}},
+	CHECK_THROWS_AS(get_canonical_word(automata::ta::Configuration<std::string>{Location{"s"}, {}},
 	                                   ATAConfiguration<std::string>{},
 	                                   1),
 	                std::invalid_argument);
@@ -116,17 +117,20 @@ TEST_CASE("Validate a canonical word", "[canonical_word]")
 {
 	using CanonicalABWord = synchronous_product::CanonicalABWord<std::string, std::string>;
 	CHECK_THROWS_AS(is_valid_canonical_word(CanonicalABWord{}), InvalidCanonicalWordException);
-	CHECK(is_valid_canonical_word(
-	  CanonicalABWord({{TARegionState{"s0", "c0", 0}}, {TARegionState{"s0", "c1", 1}}})));
+	CHECK(is_valid_canonical_word(CanonicalABWord(
+	  {{TARegionState{Location{"s0"}, "c0", 0}}, {TARegionState{Location{"s0"}, "c1", 1}}})));
 	CHECK_THROWS_AS(is_valid_canonical_word(CanonicalABWord({{}})), InvalidCanonicalWordException);
-	CHECK_THROWS_AS(is_valid_canonical_word(CanonicalABWord(
-	                  {{TARegionState{"s0", "c0", 0}, TARegionState{"s0", "c1", 1}}})),
+	CHECK_THROWS_AS(is_valid_canonical_word(
+	                  CanonicalABWord({{TARegionState{Location{"s0"}, "c0", 0},
+	                                    TARegionState{Location{"s0"}, "c1", 1}}})),
 	                InvalidCanonicalWordException);
-	CHECK_THROWS_AS(is_valid_canonical_word(CanonicalABWord(
-	                  {{TARegionState{"s0", "c0", 0}}, {TARegionState{"s0", "c1", 0}}})),
+	CHECK_THROWS_AS(is_valid_canonical_word(
+	                  CanonicalABWord({{TARegionState{Location{"s0"}, "c0", 0}},
+	                                   {TARegionState{Location{"s0"}, "c1", 0}}})),
 	                InvalidCanonicalWordException);
-	CHECK_THROWS_AS(is_valid_canonical_word(CanonicalABWord(
-	                  {{TARegionState{"s0", "c0", 0}}, {TARegionState{"s0", "c1", 2}}})),
+	CHECK_THROWS_AS(is_valid_canonical_word(
+	                  CanonicalABWord({{TARegionState{Location{"s0"}, "c0", 0}},
+	                                   {TARegionState{Location{"s0"}, "c1", 2}}})),
 	                InvalidCanonicalWordException);
 }
 
@@ -134,24 +138,30 @@ TEST_CASE("Get the time successor for a canonical AB word", "[canonical_word]")
 {
 	// TODO rewrite test cases to only contain valid words
 	using CanonicalABWord = synchronous_product::CanonicalABWord<std::string, std::string>;
-	CHECK(get_time_successor(
-	        CanonicalABWord({{TARegionState{"s0", "c0", 0}}, {TARegionState{"s0", "c1", 1}}}), 3)
-	      == CanonicalABWord({{TARegionState{"s0", "c1", 2}}, {TARegionState{"s0", "c0", 1}}}));
-	CHECK(get_time_successor(CanonicalABWord({{TARegionState{"s0", "c0", 0}}}), 3)
-	      == CanonicalABWord({{TARegionState{"s0", "c0", 1}}}));
-	//	CHECK(get_time_successor(CanonicalABWord({{TARegionState{"s0", "c0", 0}},
-	//	                                          {TARegionState{"s0", "c1", 1}},
-	//	                                          {TARegionState{"s0", "c2", 2}}}),
+	CHECK(get_time_successor(CanonicalABWord({{TARegionState{Location{"s0"}, "c0", 0}},
+	                                          {TARegionState{Location{"s0"}, "c1", 1}}}),
+	                         3)
+	      == CanonicalABWord(
+	        {{TARegionState{Location{"s0"}, "c1", 2}}, {TARegionState{Location{"s0"}, "c0", 1}}}));
+	CHECK(get_time_successor(CanonicalABWord({{TARegionState{Location{"s0"}, "c0", 0}}}), 3)
+	      == CanonicalABWord({{TARegionState{Location{"s0"}, "c0", 1}}}));
+	//	CHECK(get_time_successor(CanonicalABWord({{TARegionState{Location{"s0"}, "c0", 0}},
+	//	                                          {TARegionState{Location{"s0"}, "c1", 1}},
+	//	                                          {TARegionState{Location{"s0"}, "c2", 2}}}),
 	//	                         3)
-	//	      == CanonicalABWord({{TARegionState{"s0", "c2", 3}},
-	//	                          {TARegionState{"s0", "c0", 1}},
-	//	                          {TARegionState{"s0", "c1", 1}}}));
+	//	      == CanonicalABWord({{TARegionState{Location{"s0"}, "c2", 3}},
+	//	                          {TARegionState{Location{"s0"}, "c0", 1}},
+	//	                          {TARegionState{Location{"s0"}, "c1", 1}}}));
 	// CHECK(get_time_successor(
-	//        CanonicalABWord({{TARegionState{"s0", "c0", 1}}, {TARegionState{"s0", "c1", 2}}}), 3)
-	//      == CanonicalABWord({{TARegionState{"s0", "c1", 3}}, {TARegionState{"s0", "c0", 1}}}));
-	CHECK(get_time_successor(
-	        CanonicalABWord({{TARegionState{"s0", "c0", 1}}, {TARegionState{"s0", "c1", 1}}}), 3)
-	      == CanonicalABWord({{TARegionState{"s0", "c1", 2}}, {TARegionState{"s0", "c0", 1}}}));
+	//        CanonicalABWord({{TARegionState{Location{"s0"}, "c0", 1}},
+	//        {TARegionState{Location{"s0"}, "c1", 2}}}), 3)
+	//      == CanonicalABWord({{TARegionState{Location{"s0"}, "c1", 3}},
+	//      {TARegionState{Location{"s0"}, "c0", 1}}}));
+	CHECK(get_time_successor(CanonicalABWord({{TARegionState{Location{"s0"}, "c0", 1}},
+	                                          {TARegionState{Location{"s0"}, "c1", 1}}}),
+	                         3)
+	      == CanonicalABWord(
+	        {{TARegionState{Location{"s0"}, "c1", 2}}, {TARegionState{Location{"s0"}, "c0", 1}}}));
 	const logic::AtomicProposition<std::string> a{"a"};
 	const logic::AtomicProposition<std::string> b{"b"};
 	// CHECK(get_time_successor(CanonicalABWord({{ATARegionState{a, 0}},
@@ -175,17 +185,18 @@ TEST_CASE("Get the time successor for a canonical AB word", "[canonical_word]")
 	//    {{ATARegionState{b, 4}, ATARegionState{a, 7}}}));
 
 	// CHECK(
-	//  get_time_successor(CanonicalABWord({{TARegionState{"s0", "c0", 3}},
+	//  get_time_successor(CanonicalABWord({{TARegionState{Location{"s0"}, "c0", 3}},
 	//                                      {TARegionState{"s1", "c0", 4}},
 	//                                      {ATARegionState{a, 7}}}),
 	//                     3)
 	//  == CanonicalABWord(
-	//    {{TARegionState{"s1", "c0", 5}}, {ATARegionState{a, 7}}, {TARegionState{"s0", "c0", 3}}}));
+	//    {{TARegionState{"s1", "c0", 5}}, {ATARegionState{a, 7}}, {TARegionState{Location{"s0"},
+	//    "c0", 3}}}));
 	CHECK(get_time_successor(CanonicalABWord({{ATARegionState{b, 1}, ATARegionState{a, 3}}}), 3)
 	      == CanonicalABWord({{ATARegionState{b, 2}, ATARegionState{a, 4}}}));
-	CHECK(
-	  get_time_successor(CanonicalABWord({{TARegionState{"l0", "x", 1}, ATARegionState{a, 5}}}), 2)
-	  == CanonicalABWord({{TARegionState{"l0", "x", 2}}, {ATARegionState{a, 5}}}));
+	CHECK(get_time_successor(
+	        CanonicalABWord({{TARegionState{Location{"l0"}, "x", 1}, ATARegionState{a, 5}}}), 2)
+	      == CanonicalABWord({{TARegionState{Location{"l0"}, "x", 2}}, {ATARegionState{a, 5}}}));
 }
 
 TEST_CASE("Get a concrete candidate for a canonical word", "[canonical_word]")
@@ -202,15 +213,16 @@ TEST_CASE("Get a concrete candidate for a canonical word", "[canonical_word]")
 	const logic::AtomicProposition<std::string> b{"b"};
 
 	// single state with fractional part 0, clock 0
-	CHECK(get_candidate(CanonicalABWord({{TARegionState{"s0", "c0", 0}}}))
-	      == Candidate(TAConf{"s0", {{"c0", 0}}}, ATAConf{}));
+	CHECK(get_candidate(CanonicalABWord({{TARegionState{Location{"s0"}, "c0", 0}}}))
+	      == Candidate(TAConf{Location{"s0"}, {{"c0", 0}}}, ATAConf{}));
 	// single state with fractional part 0, clock != 0
-	CHECK(get_candidate(CanonicalABWord({{TARegionState{"s0", "c0", 2}}}))
-	      == Candidate(TAConf{"s0", {{"c0", 1}}}, ATAConf{}));
+	CHECK(get_candidate(CanonicalABWord({{TARegionState{Location{"s0"}, "c0", 2}}}))
+	      == Candidate(TAConf{Location{"s0"}, {{"c0", 1}}}, ATAConf{}));
 
 	{
 		// single state with non-zero fractional part in (0, 1)
-		const Candidate cand = get_candidate(CanonicalABWord({{TARegionState{"s0", "c0", 1}}}));
+		const Candidate cand =
+		  get_candidate(CanonicalABWord({{TARegionState{Location{"s0"}, "c0", 1}}}));
 		CHECK(cand.first.clock_valuations.at("c0") > 0.0);
 		CHECK(cand.first.clock_valuations.at("c0") < 1.0);
 		// The ATA configuration must be empty.
@@ -219,7 +231,8 @@ TEST_CASE("Get a concrete candidate for a canonical word", "[canonical_word]")
 
 	{
 		// single state with non-zero fractional part not in (0, 1)
-		const Candidate cand = get_candidate(CanonicalABWord({{TARegionState{"s0", "c0", 5}}}));
+		const Candidate cand =
+		  get_candidate(CanonicalABWord({{TARegionState{Location{"s0"}, "c0", 5}}}));
 		CHECK(cand.first.clock_valuations.at("c0") > 2.0);
 		CHECK(cand.first.clock_valuations.at("c0") < 3.0);
 		// The ATA configuration must be empty.
@@ -249,8 +262,8 @@ TEST_CASE("Get a concrete candidate for a canonical word", "[canonical_word]")
 
 	{
 		// two clocks, both non-fractional with same integer parts
-		const Candidate cand = get_candidate(
-		  CanonicalABWord({{TARegionState{"s0", "c0", 2}, TARegionState{"s0", "c1", 2}}}));
+		const Candidate cand = get_candidate(CanonicalABWord(
+		  {{TARegionState{Location{"s0"}, "c0", 2}, TARegionState{Location{"s0"}, "c1", 2}}}));
 		CHECK(getFractionalPart<Integer>(cand.first.clock_valuations.at("c0")) == 0);
 		CHECK(getFractionalPart<Integer>(cand.first.clock_valuations.at("c1")) == 0);
 		CHECK(getIntegerPart<Integer>(cand.first.clock_valuations.at("c0"))
@@ -261,8 +274,8 @@ TEST_CASE("Get a concrete candidate for a canonical word", "[canonical_word]")
 
 	{
 		// two clocks, both non-fractional but with different integer parts
-		const Candidate cand = get_candidate(
-		  CanonicalABWord({{TARegionState{"s0", "c0", 0}, TARegionState{"s0", "c1", 2}}}));
+		const Candidate cand = get_candidate(CanonicalABWord(
+		  {{TARegionState{Location{"s0"}, "c0", 0}, TARegionState{Location{"s0"}, "c1", 2}}}));
 		CHECK(getFractionalPart<Integer>(cand.first.clock_valuations.at("c0")) == 0);
 		CHECK(getFractionalPart<Integer>(cand.first.clock_valuations.at("c1")) == 0);
 		CHECK(getIntegerPart<Integer>(cand.first.clock_valuations.at("c0"))
@@ -273,8 +286,8 @@ TEST_CASE("Get a concrete candidate for a canonical word", "[canonical_word]")
 
 	{
 		// two states, one with a clock with fractional part, the other one without
-		const Candidate cand = get_candidate(
-		  CanonicalABWord({{TARegionState{"s0", "c0", 2}}, {TARegionState{"s0", "c1", 1}}}));
+		const Candidate cand = get_candidate(CanonicalABWord(
+		  {{TARegionState{Location{"s0"}, "c0", 2}}, {TARegionState{Location{"s0"}, "c1", 1}}}));
 		CHECK(cand.first.clock_valuations.at("c0") == 1.0);
 		CHECK(cand.first.clock_valuations.at("c1") > 0.0);
 		CHECK(cand.first.clock_valuations.at("c1") < 1.0);
@@ -285,16 +298,16 @@ TEST_CASE("Get a concrete candidate for a canonical word", "[canonical_word]")
 	{
 		// two states, both clocks fractional with equal fractional parts and equal integer
 		// parts
-		const Candidate cand = get_candidate(
-		  CanonicalABWord({{TARegionState{"s0", "c0", 1}, TARegionState{"s0", "c1", 1}}}));
+		const Candidate cand = get_candidate(CanonicalABWord(
+		  {{TARegionState{Location{"s0"}, "c0", 1}, TARegionState{Location{"s0"}, "c1", 1}}}));
 		CHECK(cand.first.clock_valuations.at("c0") == cand.first.clock_valuations.at("c1"));
 	}
 
 	{
 		// two states, both clocks fractional with equal fractional parts but different integer
 		// parts
-		const Candidate cand = get_candidate(
-		  CanonicalABWord({{TARegionState{"s0", "c0", 1}, TARegionState{"s0", "c1", 3}}}));
+		const Candidate cand = get_candidate(CanonicalABWord(
+		  {{TARegionState{Location{"s0"}, "c0", 1}, TARegionState{Location{"s0"}, "c1", 3}}}));
 		CHECK(getFractionalPart<Integer>(cand.first.clock_valuations.at("c0"))
 		      == getFractionalPart<Integer>(cand.first.clock_valuations.at("c1")));
 		CHECK(getIntegerPart<Integer>(cand.first.clock_valuations.at("c0"))
@@ -304,8 +317,8 @@ TEST_CASE("Get a concrete candidate for a canonical word", "[canonical_word]")
 	{
 		// two states, both clocks fractional with different fractional parts but same integer
 		// parts
-		const Candidate cand = get_candidate(
-		  CanonicalABWord({{TARegionState{"s0", "c0", 1}}, {TARegionState{"s0", "c1", 1}}}));
+		const Candidate cand = get_candidate(CanonicalABWord(
+		  {{TARegionState{Location{"s0"}, "c0", 1}}, {TARegionState{Location{"s0"}, "c1", 1}}}));
 		CHECK(cand.first.clock_valuations.at("c0") < cand.first.clock_valuations.at("c1"));
 		CHECK(getFractionalPart<Integer>(cand.first.clock_valuations.at("c0"))
 		      < getFractionalPart<Integer>(cand.first.clock_valuations.at("c1")));
@@ -315,8 +328,8 @@ TEST_CASE("Get a concrete candidate for a canonical word", "[canonical_word]")
 
 	{
 		// two states, both clocks fractional with different fractional and integer parts
-		const Candidate cand = get_candidate(
-		  CanonicalABWord({{TARegionState{"s0", "c0", 1}}, {TARegionState{"s0", "c1", 3}}}));
+		const Candidate cand = get_candidate(CanonicalABWord(
+		  {{TARegionState{Location{"s0"}, "c0", 1}}, {TARegionState{Location{"s0"}, "c1", 3}}}));
 		CHECK(cand.first.clock_valuations.at("c0") < cand.first.clock_valuations.at("c1"));
 		CHECK(getFractionalPart<Integer>(cand.first.clock_valuations.at("c0"))
 		      < getFractionalPart<Integer>(cand.first.clock_valuations.at("c1")));
@@ -326,10 +339,10 @@ TEST_CASE("Get a concrete candidate for a canonical word", "[canonical_word]")
 
 	{
 		// several clocks with different regions
-		const Candidate cand =
-		  get_candidate(CanonicalABWord({{TARegionState{"s0", "c0", 0}},
-		                                 {TARegionState{"s0", "c1", 1}, TARegionState{"s0", "c2", 3}},
-		                                 {TARegionState{"s0", "c3", 1}}}));
+		const Candidate cand = get_candidate(CanonicalABWord(
+		  {{TARegionState{Location{"s0"}, "c0", 0}},
+		   {TARegionState{Location{"s0"}, "c1", 1}, TARegionState{Location{"s0"}, "c2", 3}},
+		   {TARegionState{Location{"s0"}, "c3", 1}}}));
 		CHECK(cand.first.clock_valuations.at("c0") == 0.0);
 		CHECK(cand.first.clock_valuations.at("c1") > 0.0);
 		CHECK(cand.first.clock_valuations.at("c2") > 1.0);
@@ -350,26 +363,32 @@ TEST_CASE("Get the next canonical word(s)", "[canonical_word]")
 	// using ATAConfiguration = automata::ata::Configuration<std::string>;
 	using automata::AtomicClockConstraintT;
 	using utilities::arithmetic::BoundType;
-	TA ta{{"a", "b", "c"}, "l0", {"l0", "l1", "l2"}};
+	TA ta{{"a", "b", "c"}, Location{"l0"}, {Location{"l0"}, Location{"l1"}, Location{"l2"}}};
 	ta.add_clock("x");
-	ta.add_transition(TATransition(
-	  "l0", "a", "l0", {{"x", AtomicClockConstraintT<std::greater<automata::Time>>(1)}}, {"x"}));
-	ta.add_transition(
-	  TATransition("l0", "b", "l1", {{"x", AtomicClockConstraintT<std::less<automata::Time>>(1)}}));
-	ta.add_transition(TATransition("l0", "c", "l2"));
-	ta.add_transition(TATransition("l2", "b", "l1"));
+	ta.add_transition(TATransition(Location{"l0"},
+	                               "a",
+	                               Location{"l0"},
+	                               {{"x", AtomicClockConstraintT<std::greater<automata::Time>>(1)}},
+	                               {"x"}));
+	ta.add_transition(TATransition(Location{"l0"},
+	                               "b",
+	                               Location{"l1"},
+	                               {{"x", AtomicClockConstraintT<std::less<automata::Time>>(1)}}));
+	ta.add_transition(TATransition(Location{"l0"}, "c", Location{"l2"}));
+	ta.add_transition(TATransition(Location{"l2"}, "b", Location{"l1"}));
 	logic::MTLFormula<std::string> a{AP("a")};
 	logic::MTLFormula<std::string> b{AP("b")};
 
 	logic::MTLFormula f   = a.until(b, logic::TimeInterval(2, BoundType::WEAK, 2, BoundType::INFTY));
 	auto              ata = mtl_ata_translation::translate(f);
 
-	auto initial_word =
-	  get_canonical_word(TAConfiguration{"l0", {{"x", 0}}}, ata.get_initial_configuration(), 2);
+	auto initial_word = get_canonical_word(TAConfiguration{Location{"l0"}, {{"x", 0}}},
+	                                       ata.get_initial_configuration(),
+	                                       2);
 	INFO("Initial word: " << initial_word);
 	CHECK(initial_word
-	      == CanonicalABWord(
-	        {{TARegionState{"l0", "x", 0}, ATARegionState{logic::MTLFormula{AP{"phi_i"}}, 0}}}));
+	      == CanonicalABWord({{TARegionState{Location{"l0"}, "x", 0},
+	                           ATARegionState{logic::MTLFormula{AP{"phi_i"}}, 0}}}));
 	auto next_words = synchronous_product::get_next_canonical_words(ta, ata, initial_word, 2);
 	INFO("Next words: " << next_words);
 	// TODO actually test what the word is.
@@ -377,39 +396,47 @@ TEST_CASE("Get the next canonical word(s)", "[canonical_word]")
 
 TEST_CASE("reg_a", "[canonical_word]")
 {
-	CHECK(synchronous_product::reg_a(CanonicalABWord({{TARegionState{"s0", "c0", 0}}}))
-	      == CanonicalABWord({{TARegionState{"s0", "c0", 0}}}));
-	CHECK(synchronous_product::reg_a(CanonicalABWord(
-	        {{TARegionState{"s0", "c0", 0}, ATARegionState{logic::MTLFormula{AP{"a"}}, 0}}}))
-	      == CanonicalABWord({{TARegionState{"s0", "c0", 0}}}));
-	CHECK(synchronous_product::reg_a(CanonicalABWord(
-	        {{TARegionState{"s1", "c0", 0}}, {ATARegionState{logic::MTLFormula{AP{"b"}}, 3}}}))
-	      == CanonicalABWord({{TARegionState{"s1", "c0", 0}}}));
+	CHECK(synchronous_product::reg_a(CanonicalABWord({{TARegionState{Location{"s0"}, "c0", 0}}}))
+	      == CanonicalABWord({{TARegionState{Location{"s0"}, "c0", 0}}}));
+	CHECK(
+	  synchronous_product::reg_a(CanonicalABWord(
+	    {{TARegionState{Location{"s0"}, "c0", 0}, ATARegionState{logic::MTLFormula{AP{"a"}}, 0}}}))
+	  == CanonicalABWord({{TARegionState{Location{"s0"}, "c0", 0}}}));
+	CHECK(
+	  synchronous_product::reg_a(CanonicalABWord(
+	    {{TARegionState{Location{"s1"}, "c0", 0}}, {ATARegionState{logic::MTLFormula{AP{"b"}}, 3}}}))
+	  == CanonicalABWord({{TARegionState{Location{"s1"}, "c0", 0}}}));
 }
 
 TEST_CASE("monotone_domination_order", "[canonical_word]")
 {
 	CHECK(synchronous_product::is_monotonically_dominated(
-	  CanonicalABWord({{TARegionState{"s0", "c0", 0}}}),
-	  CanonicalABWord({{TARegionState{"s0", "c0", 0}}})));
+	  CanonicalABWord({{TARegionState{Location{"s0"}, "c0", 0}}}),
+	  CanonicalABWord({{TARegionState{Location{"s0"}, "c0", 0}}})));
 	CHECK(!synchronous_product::is_monotonically_dominated(
-	  CanonicalABWord({{TARegionState{"s0", "c0", 0}}}),
-	  CanonicalABWord({{TARegionState{"s0", "c0", 1}}})));
+	  CanonicalABWord({{TARegionState{Location{"s0"}, "c0", 0}}}),
+	  CanonicalABWord({{TARegionState{Location{"s0"}, "c0", 1}}})));
 	CHECK(!synchronous_product::is_monotonically_dominated(
 	  CanonicalABWord(
-	    {{TARegionState{"s0", "c0", 0}, ATARegionState{logic::MTLFormula{AP{"a"}}, 0}}}),
-	  CanonicalABWord({{TARegionState{"s0", "c0", 0}}})));
+	    {{TARegionState{Location{"s0"}, "c0", 0}, ATARegionState{logic::MTLFormula{AP{"a"}}, 0}}}),
+	  CanonicalABWord({{TARegionState{Location{"s0"}, "c0", 0}}})));
 	CHECK(synchronous_product::is_monotonically_dominated(
-	  CanonicalABWord({{TARegionState{"s0", "c0", 0}, TARegionState{"s0", "c1", 0}}}),
-	  CanonicalABWord({{TARegionState{"s0", "c0", 0}, TARegionState{"s0", "c1", 0}}})));
+	  CanonicalABWord(
+	    {{TARegionState{Location{"s0"}, "c0", 0}, TARegionState{Location{"s0"}, "c1", 0}}}),
+	  CanonicalABWord(
+	    {{TARegionState{Location{"s0"}, "c0", 0}, TARegionState{Location{"s0"}, "c1", 0}}})));
 	CHECK(!synchronous_product::is_monotonically_dominated(
-	  CanonicalABWord({{TARegionState{"s0", "c0", 0}, TARegionState{"s0", "c1", 1}},
-	                   {ATARegionState{logic::MTLFormula{AP{"a"}}, 0}}}),
-	  CanonicalABWord({{TARegionState{"s0", "c0", 0}, TARegionState{"s0", "c1", 1}}})));
+	  CanonicalABWord(
+	    {{TARegionState{Location{"s0"}, "c0", 0}, TARegionState{Location{"s0"}, "c1", 1}},
+	     {ATARegionState{logic::MTLFormula{AP{"a"}}, 0}}}),
+	  CanonicalABWord(
+	    {{TARegionState{Location{"s0"}, "c0", 0}, TARegionState{Location{"s0"}, "c1", 1}}})));
 	CHECK(synchronous_product::is_monotonically_dominated(
-	  CanonicalABWord({{TARegionState{"s0", "c0", 0}, TARegionState{"s0", "c1", 1}}}),
-	  CanonicalABWord({{TARegionState{"s0", "c0", 0}, TARegionState{"s0", "c1", 1}},
-	                   {ATARegionState{logic::MTLFormula{AP{"a"}}, 0}}})));
+	  CanonicalABWord(
+	    {{TARegionState{Location{"s0"}, "c0", 0}, TARegionState{Location{"s0"}, "c1", 1}}}),
+	  CanonicalABWord(
+	    {{TARegionState{Location{"s0"}, "c0", 0}, TARegionState{Location{"s0"}, "c1", 1}},
+	     {ATARegionState{logic::MTLFormula{AP{"a"}}, 0}}})));
 }
 
 TEST_CASE("monotone_domination_order_sets", "[canonical_word]")
@@ -418,43 +445,45 @@ TEST_CASE("monotone_domination_order_sets", "[canonical_word]")
 	                                                      std::set<CanonicalABWord>{}));
 
 	CHECK(synchronous_product::is_monotonically_dominated(
-	  std::set<CanonicalABWord>{
-	    CanonicalABWord({{TARegionState{"s0", "c0", 0}, TARegionState{"s0", "c1", 1}}})},
-	  std::set<CanonicalABWord>{
-	    CanonicalABWord({{TARegionState{"s0", "c0", 0}, TARegionState{"s0", "c1", 1}}})}));
+	  std::set<CanonicalABWord>{CanonicalABWord(
+	    {{TARegionState{Location{"s0"}, "c0", 0}, TARegionState{Location{"s0"}, "c1", 1}}})},
+	  std::set<CanonicalABWord>{CanonicalABWord(
+	    {{TARegionState{Location{"s0"}, "c0", 0}, TARegionState{Location{"s0"}, "c1", 1}}})}));
 
 	CHECK(!synchronous_product::is_monotonically_dominated(
-	  std::set<CanonicalABWord>{
-	    CanonicalABWord({{TARegionState{"s0", "c0", 0}, TARegionState{"s0", "c1", 1}}})},
+	  std::set<CanonicalABWord>{CanonicalABWord(
+	    {{TARegionState{Location{"s0"}, "c0", 0}, TARegionState{Location{"s0"}, "c1", 1}}})},
 	  std::set<CanonicalABWord>{}));
 
 	CHECK(synchronous_product::is_monotonically_dominated(
 	  std::set<CanonicalABWord>{},
-	  std::set<CanonicalABWord>{
-	    CanonicalABWord({{TARegionState{"s0", "c0", 0}, TARegionState{"s0", "c1", 1}}})}));
+	  std::set<CanonicalABWord>{CanonicalABWord(
+	    {{TARegionState{Location{"s0"}, "c0", 0}, TARegionState{Location{"s0"}, "c1", 1}}})}));
 
 	CHECK(!synchronous_product::is_monotonically_dominated(
-	  std::set<CanonicalABWord>{CanonicalABWord({{TARegionState{"s0", "c0", 0}}})},
-	  std::set<CanonicalABWord>{CanonicalABWord({{TARegionState{"s0", "c0", 2}}})}));
+	  std::set<CanonicalABWord>{CanonicalABWord({{TARegionState{Location{"s0"}, "c0", 0}}})},
+	  std::set<CanonicalABWord>{CanonicalABWord({{TARegionState{Location{"s0"}, "c0", 2}}})}));
 
 	CHECK(!synchronous_product::is_monotonically_dominated(
-	  std::set<CanonicalABWord>{
-	    CanonicalABWord({{TARegionState{"s0", "c0", 0}, TARegionState{"s0", "c1", 1}},
-	                     {ATARegionState{logic::MTLFormula{AP{"a"}}, 0}}}),
-	    CanonicalABWord({{TARegionState{"s0", "c0", 0}, TARegionState{"s0", "c1", 1}},
-	                     {ATARegionState{logic::MTLFormula{AP{"a"}}, 1}}})},
-	  std::set<CanonicalABWord>{
-	    CanonicalABWord({{TARegionState{"s0", "c0", 0}, TARegionState{"s0", "c1", 1}},
-	                     {ATARegionState{logic::MTLFormula{AP{"a"}}, 0}}})}));
+	  std::set<CanonicalABWord>{CanonicalABWord({{TARegionState{Location{"s0"}, "c0", 0},
+	                                              TARegionState{Location{"s0"}, "c1", 1}},
+	                                             {ATARegionState{logic::MTLFormula{AP{"a"}}, 0}}}),
+	                            CanonicalABWord({{TARegionState{Location{"s0"}, "c0", 0},
+	                                              TARegionState{Location{"s0"}, "c1", 1}},
+	                                             {ATARegionState{logic::MTLFormula{AP{"a"}}, 1}}})},
+	  std::set<CanonicalABWord>{CanonicalABWord(
+	    {{TARegionState{Location{"s0"}, "c0", 0}, TARegionState{Location{"s0"}, "c1", 1}},
+	     {ATARegionState{logic::MTLFormula{AP{"a"}}, 0}}})}));
 
 	CHECK(synchronous_product::is_monotonically_dominated(
-	  std::set<CanonicalABWord>{
-	    CanonicalABWord({{TARegionState{"s0", "c0", 0}, TARegionState{"s0", "c1", 1}},
-	                     {ATARegionState{logic::MTLFormula{AP{"a"}}, 0}}})},
-	  std::set<CanonicalABWord>{
-	    CanonicalABWord({{TARegionState{"s0", "c0", 0}, TARegionState{"s0", "c1", 1}},
-	                     {ATARegionState{logic::MTLFormula{AP{"a"}}, 0}}}),
-	    CanonicalABWord({{TARegionState{"s0", "c0", 0}, TARegionState{"s0", "c1", 1}},
-	                     {ATARegionState{logic::MTLFormula{AP{"a"}}, 1}}})}));
+	  std::set<CanonicalABWord>{CanonicalABWord(
+	    {{TARegionState{Location{"s0"}, "c0", 0}, TARegionState{Location{"s0"}, "c1", 1}},
+	     {ATARegionState{logic::MTLFormula{AP{"a"}}, 0}}})},
+	  std::set<CanonicalABWord>{CanonicalABWord({{TARegionState{Location{"s0"}, "c0", 0},
+	                                              TARegionState{Location{"s0"}, "c1", 1}},
+	                                             {ATARegionState{logic::MTLFormula{AP{"a"}}, 0}}}),
+	                            CanonicalABWord({{TARegionState{Location{"s0"}, "c0", 0},
+	                                              TARegionState{Location{"s0"}, "c1", 1}},
+	                                             {ATARegionState{logic::MTLFormula{AP{"a"}}, 1}}})}));
 }
 } // namespace

--- a/test/test_synchronous_product.cpp
+++ b/test/test_synchronous_product.cpp
@@ -24,6 +24,7 @@
 #include "automata/ta_regions.h"
 #include "mtl/MTLFormula.h"
 #include "mtl_ata_translation/translator.h"
+#include "synchronous_product/canonical_word.h"
 #include "synchronous_product/operators.h"
 #include "synchronous_product/reg_a.h"
 #include "synchronous_product/synchronous_product.h"
@@ -132,6 +133,34 @@ TEST_CASE("Validate a canonical word", "[canonical_word]")
 	                  CanonicalABWord({{TARegionState{Location{"s0"}, "c0", 0}},
 	                                   {TARegionState{Location{"s0"}, "c1", 2}}})),
 	                InvalidCanonicalWordException);
+}
+
+TEST_CASE("Comparison of ABRegionSymbols", "[canonical_word]")
+{
+	using ABRegionSymbol = ABRegionSymbol<std::string, std::string>;
+	CHECK(ABRegionSymbol{TARegionState{Location{"l0"}, "x", 0}}
+	      < ABRegionSymbol{TARegionState{Location{"l0"}, "x", 1}});
+	CHECK(ABRegionSymbol{TARegionState{Location{"l0"}, "x", 0}}
+	      < ABRegionSymbol{TARegionState{Location{"l1"}, "x", 0}});
+	CHECK(ABRegionSymbol{TARegionState{Location{"l0"}, "x", 1}}
+	      < ABRegionSymbol{TARegionState{Location{"l0"}, "y", 0}});
+	CHECK(!(ABRegionSymbol{TARegionState{Location{"l0"}, "x", 1}}
+	        < ABRegionSymbol{TARegionState{Location{"l0"}, "x", 0}}));
+	CHECK(ABRegionSymbol{TARegionState{Location{"l0"}, "x", 0}}
+	      == ABRegionSymbol{TARegionState{Location{"l0"}, "x", 0}});
+	CHECK(ABRegionSymbol{TARegionState{Location{"l0"}, "x", 0}}
+	      < ABRegionSymbol{ATARegionState{AP{"l0"}, 0}});
+	CHECK(ABRegionSymbol{TARegionState{Location{"l1"}, "x", 1}}
+	      < ABRegionSymbol{ATARegionState{AP{"l0"}, 0}});
+	CHECK(ABRegionSymbol{ATARegionState{AP{"s0"}, 0}} < ABRegionSymbol{ATARegionState{AP{"s1"}, 0}});
+	CHECK(
+	  !(ABRegionSymbol{ATARegionState{AP{"s1"}, 0}} < ABRegionSymbol{ATARegionState{AP{"s0"}, 0}}));
+	CHECK(ABRegionSymbol{ATARegionState{AP{"s0"}, 0}} < ABRegionSymbol{ATARegionState{AP{"s0"}, 1}});
+	CHECK(
+	  !(ABRegionSymbol{ATARegionState{AP{"s0"}, 1}} < ABRegionSymbol{ATARegionState{AP{"s0"}, 0}}));
+	CHECK(ABRegionSymbol{ATARegionState{AP{"s0"}, 0}} == ABRegionSymbol{ATARegionState{AP{"s0"}, 0}});
+	CHECK(!(ABRegionSymbol{TARegionState{Location{"l0"}, "x", 0}}
+	        == ABRegionSymbol{ATARegionState{AP{"l0"}, 0}}));
 }
 
 TEST_CASE("Get the time successor for a canonical AB word", "[canonical_word]")

--- a/test/test_synchronous_product.cpp
+++ b/test/test_synchronous_product.cpp
@@ -68,7 +68,7 @@ TEST_CASE("Get a canonical word of a simple state", "[canonical_word]")
 	CHECK(std::get<TARegionState>(symbol1) == TARegionState{"s", "c", 0});
 	const auto &symbol2 = *std::next(abs1.begin());
 	REQUIRE(std::holds_alternative<ATARegionState>(symbol2));
-	CHECK(std::get<ATARegionState>(symbol2) == ATARegionState(f, 0));
+	CHECK(std::get<ATARegionState>(symbol2) == ATARegionState{f, 0});
 }
 
 TEST_CASE("Get a canonical word of a more complex state", "[canonical_word]")
@@ -97,10 +97,10 @@ TEST_CASE("Get a canonical word of a more complex state", "[canonical_word]")
 		CHECK(std::get<TARegionState>(symbol1) == TARegionState{"s", "c2", 1});
 		const auto &symbol2 = *std::next(abs2.begin());
 		REQUIRE(std::holds_alternative<ATARegionState>(symbol2));
-		CHECK(std::get<ATARegionState>(symbol2) == ATARegionState(a, 1));
+		CHECK(std::get<ATARegionState>(symbol2) == ATARegionState{a, 1});
 		const auto &symbol3 = *std::next(abs2.begin(), 2);
 		REQUIRE(std::holds_alternative<ATARegionState>(symbol3));
-		CHECK(std::get<ATARegionState>(symbol3) == ATARegionState(b, 3));
+		CHECK(std::get<ATARegionState>(symbol3) == ATARegionState{b, 3});
 	}
 }
 

--- a/test/test_synchronous_product_print.cpp
+++ b/test/test_synchronous_product_print.cpp
@@ -31,10 +31,11 @@ using TARegionState  = synchronous_product::TARegionState<std::string>;
 using ATARegionState = synchronous_product::ATARegionState<std::string>;
 using AP             = logic::AtomicProposition<std::string>;
 using MTLFormula     = logic::MTLFormula<std::string>;
+using Location       = automata::ta::Location<std::string>;
 
 TEST_CASE("Print a TARegionState", "[print]")
 {
-	const TARegionState state{"s", "c", 1};
+	const TARegionState state{Location{"s"}, "c", 1};
 	std::stringstream   stream;
 	stream << state;
 	REQUIRE(stream.str() == "(s, c, 1)");
@@ -53,7 +54,7 @@ TEST_CASE("Print an ATARegionState", "[print]")
 TEST_CASE("Print an ABRegionSymbol", "[print]")
 {
 	{
-		const ABRegionSymbol<std::string, std::string> symbol = TARegionState{"s", "c", 1};
+		const ABRegionSymbol<std::string, std::string> symbol = TARegionState{Location{"s"}, "c", 1};
 		std::stringstream                              stream;
 		stream << symbol;
 		REQUIRE(stream.str() == "(s, c, 1)");
@@ -77,7 +78,7 @@ TEST_CASE("Print a set of ABRegionSymbols (one Abs_i)", "[print]")
 	}
 	{
 		std::set<ABRegionSymbol<std::string, std::string>> word{
-		  TARegionState{"s", "c", 1},
+		  TARegionState{Location{"s"}, "c", 1},
 		  ATARegionState{logic::MTLFormula<std::string>{logic::AtomicProposition<std::string>{"s"}},
 		                 2}};
 		std::stringstream stream;
@@ -97,7 +98,7 @@ TEST_CASE("Print the canonical word H(s)", "[print]")
 	{
 		std::vector<std::set<ABRegionSymbol<std::string, std::string>>> word;
 		word.push_back(std::set<ABRegionSymbol<std::string, std::string>>(
-		  {TARegionState{"s", "c", 1},
+		  {TARegionState{Location{"s"}, "c", 1},
 		   ATARegionState{logic::MTLFormula<std::string>{logic::AtomicProposition<std::string>{"s"}},
 		                  2}}));
 		{
@@ -106,7 +107,7 @@ TEST_CASE("Print the canonical word H(s)", "[print]")
 			CHECK(stream.str() == "[ { (s, c, 1), (s, 2) } ]");
 		}
 		word.push_back(std::set<ABRegionSymbol<std::string, std::string>>(
-		  {TARegionState{"s", "c2", 5},
+		  {TARegionState{Location{"s"}, "c2", 5},
 		   ATARegionState{logic::MTLFormula<std::string>{logic::AtomicProposition<std::string>{"a"}},
 		                  3}}));
 		{
@@ -114,8 +115,8 @@ TEST_CASE("Print the canonical word H(s)", "[print]")
 			stream << word;
 			CHECK(stream.str() == "[ { (s, c, 1), (s, 2) }, { (s, c2, 5), (a, 3) } ]");
 		}
-		word.push_back(
-		  std::set<ABRegionSymbol<std::string, std::string>>({TARegionState{"s2", "c3", 10}}));
+		word.push_back(std::set<ABRegionSymbol<std::string, std::string>>(
+		  {TARegionState{Location{"s2"}, "c3", 10}}));
 		{
 			std::stringstream stream;
 			stream << word;
@@ -130,7 +131,7 @@ TEST_CASE("Print a triple (region index, action, canonical word)", "[print]")
 	str << std::make_tuple(automata::ta::RegionIndex(1),
 	                       std::string{"a"},
 	                       synchronous_product::CanonicalABWord<std::string, std::string>{
-	                         {TARegionState{"s", "c", 1}}});
+	                         {TARegionState{Location{"s"}, "c", 1}}});
 	CHECK(str.str() == "(1, a, [ { (s, c, 1) } ])");
 }
 
@@ -151,11 +152,11 @@ TEST_CASE("Print a vector of (region index, action, canonical word) triples", "[
 		  std::make_tuple(automata::ta::RegionIndex(1),
 		                  std::string{"a"},
 		                  synchronous_product::CanonicalABWord<std::string, std::string>{
-		                    {TARegionState{"l0", "c", 1}}}),
+		                    {TARegionState{Location{"l0"}, "c", 1}}}),
 		  std::make_tuple(automata::ta::RegionIndex(2),
 		                  std::string{"b"},
 		                  synchronous_product::CanonicalABWord<std::string, std::string>{
-		                    {TARegionState{"l1", "c", 3}}})};
+		                    {TARegionState{Location{"l1"}, "c", 3}}})};
 		CHECK(str.str() == "{ (1, a, [ { (l0, c, 1) } ]), (2, b, [ { (l1, c, 3) } ]) }");
 	}
 }

--- a/test/test_synchronous_product_print.cpp
+++ b/test/test_synchronous_product_print.cpp
@@ -161,24 +161,4 @@ TEST_CASE("Print a vector of (region index, action, canonical word) triples", "[
 	}
 }
 
-TEST_CASE("Print a set of pairs", "[print]")
-{
-	std::stringstream str;
-	SECTION("A simple set")
-	{
-		str << std::set<std::pair<int, std::string>>{{1, "1"}, {2, "2"}};
-		CHECK(str.str() == "{ (1, 1), (2, 2) }");
-	}
-	SECTION("A singleton")
-	{
-		str << std::set<std::pair<std::string, std::string>>{{"abc", "def"}};
-		CHECK(str.str() == "{ (abc, def) }");
-	}
-	SECTION("The empty set")
-	{
-		str << std::set<std::pair<int, int>>{};
-		CHECK(str.str() == "{}");
-	}
-}
-
 } // namespace

--- a/test/test_synchronous_product_print.cpp
+++ b/test/test_synchronous_product_print.cpp
@@ -53,7 +53,7 @@ TEST_CASE("Print an ATARegionState", "[print]")
 TEST_CASE("Print an ABRegionSymbol", "[print]")
 {
 	{
-		const ABRegionSymbol<std::string, std::string> symbol = TARegionState("s", "c", 1);
+		const ABRegionSymbol<std::string, std::string> symbol = TARegionState{"s", "c", 1};
 		std::stringstream                              stream;
 		stream << symbol;
 		REQUIRE(stream.str() == "(s, c, 1)");
@@ -77,7 +77,7 @@ TEST_CASE("Print a set of ABRegionSymbols (one Abs_i)", "[print]")
 	}
 	{
 		std::set<ABRegionSymbol<std::string, std::string>> word{
-		  TARegionState("s", "c", 1),
+		  TARegionState{"s", "c", 1},
 		  ATARegionState(logic::MTLFormula<std::string>{logic::AtomicProposition<std::string>{"s"}},
 		                 2)};
 		std::stringstream stream;
@@ -97,7 +97,7 @@ TEST_CASE("Print the canonical word H(s)", "[print]")
 	{
 		std::vector<std::set<ABRegionSymbol<std::string, std::string>>> word;
 		word.push_back(std::set<ABRegionSymbol<std::string, std::string>>(
-		  {TARegionState("s", "c", 1),
+		  {TARegionState{"s", "c", 1},
 		   ATARegionState(logic::MTLFormula<std::string>{logic::AtomicProposition<std::string>{"s"}},
 		                  2)}));
 		{
@@ -106,7 +106,7 @@ TEST_CASE("Print the canonical word H(s)", "[print]")
 			CHECK(stream.str() == "[ { (s, c, 1), (s, 2) } ]");
 		}
 		word.push_back(std::set<ABRegionSymbol<std::string, std::string>>(
-		  {TARegionState("s", "c2", 5),
+		  {TARegionState{"s", "c2", 5},
 		   ATARegionState(logic::MTLFormula<std::string>{logic::AtomicProposition<std::string>{"a"}},
 		                  3)}));
 		{
@@ -115,7 +115,7 @@ TEST_CASE("Print the canonical word H(s)", "[print]")
 			CHECK(stream.str() == "[ { (s, c, 1), (s, 2) }, { (s, c2, 5), (a, 3) } ]");
 		}
 		word.push_back(
-		  std::set<ABRegionSymbol<std::string, std::string>>({TARegionState("s2", "c3", 10)}));
+		  std::set<ABRegionSymbol<std::string, std::string>>({TARegionState{"s2", "c3", 10}}));
 		{
 			std::stringstream stream;
 			stream << word;
@@ -130,7 +130,7 @@ TEST_CASE("Print a triple (region index, action, canonical word)", "[print]")
 	str << std::make_tuple(automata::ta::RegionIndex(1),
 	                       std::string{"a"},
 	                       synchronous_product::CanonicalABWord<std::string, std::string>{
-	                         {TARegionState("s", "c", 1)}});
+	                         {TARegionState{"s", "c", 1}}});
 	CHECK(str.str() == "(1, a, [ { (s, c, 1) } ])");
 }
 
@@ -151,11 +151,11 @@ TEST_CASE("Print a vector of (region index, action, canonical word) triples", "[
 		  std::make_tuple(automata::ta::RegionIndex(1),
 		                  std::string{"a"},
 		                  synchronous_product::CanonicalABWord<std::string, std::string>{
-		                    {TARegionState("l0", "c", 1)}}),
+		                    {TARegionState{"l0", "c", 1}}}),
 		  std::make_tuple(automata::ta::RegionIndex(2),
 		                  std::string{"b"},
 		                  synchronous_product::CanonicalABWord<std::string, std::string>{
-		                    {TARegionState("l1", "c", 3)}})};
+		                    {TARegionState{"l1", "c", 3}}})};
 		CHECK(str.str() == "{ (1, a, [ { (l0, c, 1) } ]), (2, b, [ { (l1, c, 3) } ]) }");
 	}
 }

--- a/test/test_synchronous_product_print.cpp
+++ b/test/test_synchronous_product_print.cpp
@@ -60,7 +60,7 @@ TEST_CASE("Print an ABRegionSymbol", "[print]")
 	}
 	{
 		const ABRegionSymbol<std::string, std::string> symbol =
-		  ATARegionState(logic::MTLFormula<std::string>{logic::AtomicProposition<std::string>{"s"}}, 2);
+		  ATARegionState{logic::MTLFormula<std::string>{logic::AtomicProposition<std::string>{"s"}}, 2};
 		std::stringstream stream;
 		stream << symbol;
 		REQUIRE(stream.str() == "(s, 2)");
@@ -78,8 +78,8 @@ TEST_CASE("Print a set of ABRegionSymbols (one Abs_i)", "[print]")
 	{
 		std::set<ABRegionSymbol<std::string, std::string>> word{
 		  TARegionState{"s", "c", 1},
-		  ATARegionState(logic::MTLFormula<std::string>{logic::AtomicProposition<std::string>{"s"}},
-		                 2)};
+		  ATARegionState{logic::MTLFormula<std::string>{logic::AtomicProposition<std::string>{"s"}},
+		                 2}};
 		std::stringstream stream;
 		stream << word;
 		CHECK(stream.str() == "{ (s, c, 1), (s, 2) }");
@@ -98,8 +98,8 @@ TEST_CASE("Print the canonical word H(s)", "[print]")
 		std::vector<std::set<ABRegionSymbol<std::string, std::string>>> word;
 		word.push_back(std::set<ABRegionSymbol<std::string, std::string>>(
 		  {TARegionState{"s", "c", 1},
-		   ATARegionState(logic::MTLFormula<std::string>{logic::AtomicProposition<std::string>{"s"}},
-		                  2)}));
+		   ATARegionState{logic::MTLFormula<std::string>{logic::AtomicProposition<std::string>{"s"}},
+		                  2}}));
 		{
 			std::stringstream stream;
 			stream << word;
@@ -107,8 +107,8 @@ TEST_CASE("Print the canonical word H(s)", "[print]")
 		}
 		word.push_back(std::set<ABRegionSymbol<std::string, std::string>>(
 		  {TARegionState{"s", "c2", 5},
-		   ATARegionState(logic::MTLFormula<std::string>{logic::AtomicProposition<std::string>{"a"}},
-		                  3)}));
+		   ATARegionState{logic::MTLFormula<std::string>{logic::AtomicProposition<std::string>{"a"}},
+		                  3}}));
 		{
 			std::stringstream stream;
 			stream << word;

--- a/test/test_ta.cpp
+++ b/test/test_ta.cpp
@@ -30,8 +30,7 @@ namespace {
 
 using namespace automata;
 using namespace automata::ta;
-using Configuration = automata::ta::Configuration<std::string>;
-using Catch::Matchers::Contains;
+using Configuration  = automata::ta::Configuration<std::string>;
 using TimedAutomaton = automata::ta::TimedAutomaton<std::string, std::string>;
 using Transition     = automata::ta::Transition<std::string, std::string>;
 using Location       = Location<std::string>;
@@ -58,6 +57,34 @@ TEST_CASE("Clock constraints with integers", "[ta]")
 	CHECK(!GT(1).is_satisfied(0));
 	CHECK(!GT(1).is_satisfied(1));
 	CHECK(GT(1).is_satisfied(2));
+}
+
+TEST_CASE("Comparison of TA configurations", "[ta]")
+{
+	CHECK(Configuration{Location{"l0"}, {{"x", Clock{0}}}}
+	      < Configuration{Location{"l1"}, {{"x", Clock{0}}}});
+	CHECK(!(Configuration{Location{"l1"}, {{"x", Clock{0}}}}
+	        < Configuration{Location{"l0"}, {{"x", Clock{0}}}}));
+	CHECK(Configuration{Location{"l0"}, {{"x", Clock{0}}}}
+	      < Configuration{Location{"l0"}, {{"x", Clock{1}}}});
+	CHECK(!(Configuration{Location{"l0"}, {{"x", Clock{1}}}}
+	        < Configuration{Location{"l0"}, {{"x", Clock{0}}}}));
+	CHECK(Configuration{Location{"l0"}, {{"c", Clock{0}}}}
+	      < Configuration{Location{"l0"}, {{"x", Clock{0}}}});
+	CHECK(Configuration{Location{"l0"}, {{"c", Clock{0}}}}
+	      < Configuration{Location{"l0"}, {{"c", Clock{0}}, {"x", Clock{0}}}});
+	CHECK(Configuration{Location{"l0"}, {{"c", Clock{0}}, {"x", Clock{0}}}}
+	      < Configuration{Location{"l0"}, {{"c", Clock{1}}}});
+	CHECK(Configuration{Location{"l0"}, {{"x", Clock{0}}}}
+	      == Configuration{Location{"l0"}, {{"x", Clock{0}}}});
+	CHECK(Configuration{Location{"l1"}, {{"x", Clock{5}}}}
+	      == Configuration{Location{"l1"}, {{"x", Clock{5}}}});
+	CHECK(Configuration{Location{"l1"}, {{"c", Clock{5}}, {"x", Clock{3}}}}
+	      == Configuration{Location{"l1"}, {{"c", Clock{5}}, {"x", Clock{3}}}});
+	CHECK(!(Configuration{Location{"l0"}, {{"x", Clock{0}}}}
+	        == Configuration{Location{"l1"}, {{"x", Clock{0}}}}));
+	CHECK(!(Configuration{Location{"l1"}, {{"x", Clock{0}}}}
+	        == Configuration{Location{"l0"}, {{"x", Clock{0}}}}));
 }
 
 TEST_CASE("Simple TA", "[ta]")

--- a/test/test_ta.cpp
+++ b/test/test_ta.cpp
@@ -34,6 +34,7 @@ using Configuration = automata::ta::Configuration<std::string>;
 using Catch::Matchers::Contains;
 using TimedAutomaton = automata::ta::TimedAutomaton<std::string, std::string>;
 using Transition     = automata::ta::Transition<std::string, std::string>;
+using Location       = Location<std::string>;
 
 TEST_CASE("Clock constraints with integers", "[ta]")
 {
@@ -61,13 +62,14 @@ TEST_CASE("Clock constraints with integers", "[ta]")
 
 TEST_CASE("Simple TA", "[ta]")
 {
-	TimedAutomaton ta{{"a", "b"}, "s0", {"s0"}};
-	ta.add_transition(Transition("s0", "a", "s0"));
+	TimedAutomaton ta{{"a", "b"}, Location{"s0"}, {Location{"s0"}}};
+	ta.add_transition(Transition(Location{"s0"}, "a", Location{"s0"}));
 
-	CHECK(ta.get_initial_configuration() == Configuration{"s0", {}});
+	CHECK(ta.get_initial_configuration() == Configuration{Location{"s0"}, {}});
 
-	CHECK(ta.make_symbol_step({{"s0"}, {}}, "a") == std::set{Configuration{"s0", {}}});
-	CHECK(ta.make_symbol_step({{"s0"}, {}}, "b").empty());
+	CHECK(ta.make_symbol_step({{Location{"s0"}}, {}}, "a")
+	      == std::set{Configuration{Location{"s0"}, {}}});
+	CHECK(ta.make_symbol_step({{Location{"s0"}}, {}}, "b").empty());
 
 	CHECK(ta.accepts_word({}));
 	CHECK(ta.accepts_word({{"a", 0}}));
@@ -79,9 +81,9 @@ TEST_CASE("Simple TA", "[ta]")
 
 TEST_CASE("Simple TA with two locations", "[ta]")
 {
-	TimedAutomaton ta{{"a", "b"}, "s0", {"s1"}};
-	ta.add_transition(Transition("s0", "a", "s0"));
-	ta.add_transition(Transition("s0", "b", "s1"));
+	TimedAutomaton ta{{"a", "b"}, Location{"s0"}, {Location{"s1"}}};
+	ta.add_transition(Transition(Location{"s0"}, "a", Location{"s0"}));
+	ta.add_transition(Transition(Location{"s0"}, "b", Location{"s1"}));
 	// We must be in a final location.
 	CHECK(!ta.accepts_word({{"a", 0}}));
 	CHECK(ta.accepts_word({{"b", 0}}));
@@ -89,15 +91,16 @@ TEST_CASE("Simple TA with two locations", "[ta]")
 
 TEST_CASE("TA with a simple guard", "[ta]")
 {
-	TimedAutomaton  ta{{"a"}, "s0", {"s0"}};
+	TimedAutomaton  ta{{"a"}, Location{"s0"}, {Location{"s0"}}};
 	ClockConstraint c = AtomicClockConstraintT<std::less<Time>>(1);
 	ta.add_clock("x");
-	ta.add_transition(Transition("s0", "a", "s0", {{"x", c}}));
+	ta.add_transition(Transition(Location{"s0"}, "a", Location{"s0"}, {{"x", c}}));
 
-	CHECK(ta.get_initial_configuration() == Configuration{"s0", {{"x", 0}}});
+	CHECK(ta.get_initial_configuration() == Configuration{Location{"s0"}, {{"x", 0}}});
 
-	CHECK(ta.make_symbol_step({"s0", {{"x", 0}}}, "a") == std::set{Configuration{"s0", {{"x", 0}}}});
-	CHECK(ta.make_symbol_step({"s0", {{"x", 1}}}, "a").empty());
+	CHECK(ta.make_symbol_step({Location{"s0"}, {{"x", 0}}}, "a")
+	      == std::set{Configuration{Location{"s0"}, {{"x", 0}}}});
+	CHECK(ta.make_symbol_step({Location{"s0"}, {{"x", 1}}}, "a").empty());
 
 	CHECK(!ta.accepts_word({{"a", 2}}));
 	CHECK(ta.accepts_word({{"a", 0.5}}));
@@ -108,31 +111,34 @@ TEST_CASE("TA with clock reset", "[ta]")
 {
 	SECTION("Build TA step by step")
 	{
-		TimedAutomaton  ta{{"a"}, "s0", {"s0"}};
+		TimedAutomaton  ta{{"a"}, Location{"s0"}, {Location{"s0"}}};
 		ClockConstraint c = AtomicClockConstraintT<std::less<Time>>(2);
 		ta.add_clock("x");
-		ta.add_transition(Transition("s0", "a", "s0", {{"x", c}}, {"x"}));
-		CHECK(ta.get_initial_configuration() == Configuration{"s0", {{"x", 0}}});
+		ta.add_transition(Transition(Location{"s0"}, "a", Location{"s0"}, {{"x", c}}, {"x"}));
+		CHECK(ta.get_initial_configuration() == Configuration{Location{"s0"}, {{"x", 0}}});
 
-		CHECK(ta.make_symbol_step({"s0", {{"x", 1}}}, "a")
-		      == std::set{Configuration{"s0", {{"x", 0}}}});
+		CHECK(ta.make_symbol_step({Location{"s0"}, {{"x", 1}}}, "a")
+		      == std::set{Configuration{Location{"s0"}, {{"x", 0}}}});
 
 		CHECK(ta.accepts_word({{"a", 1}, {"a", 2}, {"a", 3}}));
 		CHECK(!ta.accepts_word({{"a", 1}, {"a", 3}, {"a", 3}}));
 	}
 	SECTION("Build TA with a single constructor call")
 	{
-		TimedAutomaton ta{
-		  {"s0"},
-		  {"a"},
-		  "s0",
-		  {"s0"},
-		  {"x"},
-		  {Transition{"s0", "a", "s0", {{"x", AtomicClockConstraintT<std::less<Time>>(2)}}, {"x"}}}};
-		CHECK(ta.get_initial_configuration() == Configuration{"s0", {{"x", 0}}});
+		TimedAutomaton ta{{Location{"s0"}},
+		                  {"a"},
+		                  Location{"s0"},
+		                  {Location{"s0"}},
+		                  {"x"},
+		                  {Transition{Location{"s0"},
+		                              "a",
+		                              Location{"s0"},
+		                              {{"x", AtomicClockConstraintT<std::less<Time>>(2)}},
+		                              {"x"}}}};
+		CHECK(ta.get_initial_configuration() == Configuration{Location{"s0"}, {{"x", 0}}});
 
-		CHECK(ta.make_symbol_step({"s0", {{"x", 1}}}, "a")
-		      == std::set{Configuration{"s0", {{"x", 0}}}});
+		CHECK(ta.make_symbol_step({Location{"s0"}, {{"x", 1}}}, "a")
+		      == std::set{Configuration{Location{"s0"}, {{"x", 0}}}});
 
 		CHECK(ta.accepts_word({{"a", 1}, {"a", 2}, {"a", 3}}));
 		CHECK(!ta.accepts_word({{"a", 1}, {"a", 3}, {"a", 3}}));
@@ -141,34 +147,34 @@ TEST_CASE("TA with clock reset", "[ta]")
 
 TEST_CASE("Simple non-deterministic TA", "[ta]")
 {
-	TimedAutomaton ta{{"a", "b"}, "s0", {"s2"}};
-	ta.add_location("s1");
-	ta.add_transition(Transition("s0", "a", "s1"));
-	ta.add_transition(Transition("s0", "a", "s2"));
-	ta.add_transition(Transition("s1", "b", "s1"));
-	ta.add_transition(Transition("s2", "b", "s2"));
+	TimedAutomaton ta{{"a", "b"}, Location{"s0"}, {Location{"s2"}}};
+	ta.add_location(Location{"s1"});
+	ta.add_transition(Transition(Location{"s0"}, "a", Location{"s1"}));
+	ta.add_transition(Transition(Location{"s0"}, "a", Location{"s2"}));
+	ta.add_transition(Transition(Location{"s1"}, "b", Location{"s1"}));
+	ta.add_transition(Transition(Location{"s2"}, "b", Location{"s2"}));
 
-	CHECK(ta.make_symbol_step({"s0", {}}, "a")
-	      == std::set{Configuration{"s1", {}}, Configuration{"s2", {}}});
+	CHECK(ta.make_symbol_step({Location{"s0"}, {}}, "a")
+	      == std::set{Configuration{Location{"s1"}, {}}, Configuration{Location{"s2"}, {}}});
 
 	CHECK(ta.accepts_word({{"a", 1}, {"b", 2}}));
 }
 
 TEST_CASE("Non-determinstic TA with clocks", "[ta]")
 {
-	TimedAutomaton ta{{"a", "b"}, "s0", {"s1", "s2"}};
-	ta.add_location("s1");
+	TimedAutomaton ta{{"a", "b"}, Location{"s0"}, {Location{"s1"}, Location{"s2"}}};
+	ta.add_location(Location{"s1"});
 	ta.add_clock("x");
 	ClockConstraint c1 = AtomicClockConstraintT<std::less<Time>>(2);
-	ta.add_transition(Transition("s0", "a", "s1"));
-	ta.add_transition(Transition("s0", "a", "s2"));
-	ta.add_transition(Transition("s1", "b", "s1", {{"x", c1}}));
+	ta.add_transition(Transition(Location{"s0"}, "a", Location{"s1"}));
+	ta.add_transition(Transition(Location{"s0"}, "a", Location{"s2"}));
+	ta.add_transition(Transition(Location{"s1"}, "b", Location{"s1"}, {{"x", c1}}));
 
 	CHECK(ta.accepts_word({{"a", 1}, {"b", 1}}));
 	CHECK(!ta.accepts_word({{"a", 1}, {"b", 3}}));
 
 	ClockConstraint c2 = AtomicClockConstraintT<std::greater<Time>>(2);
-	ta.add_transition(Transition("s2", "b", "s2", {{"x", c2}}));
+	ta.add_transition(Transition(Location{"s2"}, "b", Location{"s2"}, {{"x", c2}}));
 
 	CHECK(ta.accepts_word({{"a", 1}, {"b", 1}}));
 	CHECK(ta.accepts_word({{"a", 1}, {"b", 3}}));
@@ -176,27 +182,31 @@ TEST_CASE("Non-determinstic TA with clocks", "[ta]")
 
 TEST_CASE("Transitions must use the TA's alphabet, locations and clocks", "[ta]")
 {
-	TimedAutomaton ta{{"a", "b"}, "s0", {"s0"}};
-	ta.add_location("s1");
+	TimedAutomaton ta{{"a", "b"}, Location{"s0"}, {Location{"s0"}}};
+	ta.add_location(Location{"s1"});
 	ta.add_clock("x");
 
 	ClockConstraint c = AtomicClockConstraintT<std::less<Time>>(2);
-	CHECK_THROWS_AS(ta.add_transition(Transition("s0", "a", "s2")),
+	CHECK_THROWS_AS(ta.add_transition(Transition(Location{"s0"}, "a", Location{"s2"})),
 	                InvalidLocationException<std::string>);
-	CHECK_THROWS_AS(ta.add_transition(Transition("s2", "a", "s0")),
+	CHECK_THROWS_AS(ta.add_transition(Transition(Location{"s2"}, "a", Location{"s0"})),
 	                InvalidLocationException<std::string>);
-	CHECK_THROWS_AS(ta.add_transition(Transition("s0", "a", "s1", {{"y", c}})),
+	CHECK_THROWS_AS(ta.add_transition(Transition(Location{"s0"}, "a", Location{"s1"}, {{"y", c}})),
 	                InvalidClockException);
-	CHECK_THROWS_AS(ta.add_transition(Transition("s0", "a", "s1", {}, {"y"})), InvalidClockException);
-	CHECK_THROWS_AS(ta.add_transition(Transition("s0", "c", "s0")), InvalidSymbolException);
+	CHECK_THROWS_AS(ta.add_transition(Transition(Location{"s0"}, "a", Location{"s1"}, {}, {"y"})),
+	                InvalidClockException);
+	CHECK_THROWS_AS(ta.add_transition(Transition(Location{"s0"}, "c", Location{"s0"})),
+	                InvalidSymbolException);
 }
 
 TEST_CASE("Create a TA with non-string location types", "[ta]")
 {
-	automata::ta::TimedAutomaton<unsigned int, std::string> ta{{"a"}, 0, {0}};
+	using Location = automata::ta::Location<unsigned int>;
+	automata::ta::TimedAutomaton<unsigned int, std::string> ta{{"a"}, Location{0}, {Location{0}}};
 	ClockConstraint c = AtomicClockConstraintT<std::less<Time>>(1);
 	ta.add_clock("x");
-	ta.add_transition(automata::ta::Transition<unsigned int, std::string>(0, "a", 0, {{"x", c}}));
+	ta.add_transition(
+	  automata::ta::Transition<unsigned int, std::string>(Location{0}, "a", Location{0}, {{"x", c}}));
 	CHECK(!ta.accepts_word({{"a", 2}}));
 	CHECK(ta.accepts_word({{"a", 0.5}}));
 	CHECK(!ta.accepts_word({{"a", 1}}));
@@ -204,53 +214,52 @@ TEST_CASE("Create a TA with non-string location types", "[ta]")
 
 TEST_CASE("Get enabled transitions", "[ta]")
 {
-	TimedAutomaton ta{{"a", "b"}, "s0", {"s1"}};
-	Transition     t1{"s0", "a", "s1"};
+	TimedAutomaton ta{{"a", "b"}, Location{"s0"}, {Location{"s1"}}};
+	Transition     t1{Location{"s0"}, "a", Location{"s1"}};
 	ta.add_transition(t1);
-	CHECK(ta.get_enabled_transitions({"s0", {}}) == std::vector<Transition>{{t1}});
-	Transition t2{"s1", "a", "s1"};
+	CHECK(ta.get_enabled_transitions({Location{"s0"}, {}}) == std::vector<Transition>{{t1}});
+	Transition t2{Location{"s1"}, "a", Location{"s1"}};
 	ta.add_transition(t2);
 	// t2 should not be enabled
-	CHECK(ta.get_enabled_transitions({"s0", {}}) == std::vector<Transition>{{t1}});
-	Transition t3{"s0", "b", "s0"};
+	CHECK(ta.get_enabled_transitions({Location{"s0"}, {}}) == std::vector<Transition>{{t1}});
+	Transition t3{Location{"s0"}, "b", Location{"s0"}};
 	ta.add_transition(t3);
 	// t3 should be enabled
-	CHECK(ta.get_enabled_transitions({"s0", {{"c0", 0}}}) == std::vector<Transition>{{t1, t3}});
+	CHECK(ta.get_enabled_transitions({Location{"s0"}, {{"c0", 0}}})
+	      == std::vector<Transition>{{t1, t3}});
 	ta.add_clock("c0");
-	Transition t4{"s0", "b", "s0", {{"c0", AtomicClockConstraintT<std::greater<Time>>(1)}}};
+	Transition t4{Location{"s0"},
+	              "b",
+	              Location{"s0"},
+	              {{"c0", AtomicClockConstraintT<std::greater<Time>>(1)}}};
 	// t4 should not be enabled
-	CHECK(ta.get_enabled_transitions({"s0", {}}) == std::vector<Transition>{{t1, t3}});
-	Transition t5{"s0", "b", "s0", {{"c0", AtomicClockConstraintT<std::less<Time>>(1)}}};
+	CHECK(ta.get_enabled_transitions({Location{"s0"}, {}}) == std::vector<Transition>{{t1, t3}});
+	Transition t5{Location{"s0"},
+	              "b",
+	              Location{"s0"},
+	              {{"c0", AtomicClockConstraintT<std::less<Time>>(1)}}};
 	ta.add_transition(t5);
 	// t5 should be enabled
-	CHECK(ta.get_enabled_transitions({"s0", {{"c0", 0}}}) == std::vector<Transition>{{t1, t3, t5}});
+	CHECK(ta.get_enabled_transitions({Location{"s0"}, {{"c0", 0}}})
+	      == std::vector<Transition>{{t1, t3, t5}});
 }
 
 TEST_CASE("Constructing invalid TAs throws exceptions", "[ta]")
 {
-	CHECK_THROWS_WITH(TimedAutomaton({"l0"}, {"a"}, "non_existent_initial_location", {}, {}, {}),
-	                  Contains("Initial location"));
-	CHECK_THROWS_WITH(TimedAutomaton({"l0"}, {"a"}, "l0", {"non_existent_final_location"}, {}, {}),
-	                  Contains("Final location"));
-	CHECK_THROWS_WITH(
-	  TimedAutomaton(
-	    {"l0"},
-	    {"a"},
-	    "l0",
-	    {"l0"},
-	    {"x"},
-	    {Transition{"l0", "a", "l0", {{"y", AtomicClockConstraintT<std::less<Time>>(2)}}, {"x"}}}),
-	  Contains("unknown clock"));
-	CHECK_THROWS_WITH(
-	  TimedAutomaton(
-	    {"l0"},
-	    {"a"},
-	    "l0",
-	    {"l0"},
-	    {"x"},
-	    {Transition{
-	      "l0", "a", "l0", {{"x", AtomicClockConstraintT<std::not_equal_to<Time>>(2)}}, {"x"}}}),
-	  Contains("Inequality"));
+	CHECK_THROWS(
+	  TimedAutomaton({Location{"l0"}}, {"a"}, Location{"non_existent_initial_location"}, {}, {}, {}));
+	CHECK_THROWS(TimedAutomaton(
+	  {Location{"l0"}}, {"a"}, Location{"l0"}, {Location{"non_existent_final_location"}}, {}, {}));
+	CHECK_THROWS(TimedAutomaton({Location{"l0"}},
+	                            {"a"},
+	                            Location{"l0"},
+	                            {Location{"l0"}},
+	                            {"x"},
+	                            {Transition{Location{"s0"},
+	                                        "a",
+	                                        Location{"s0"},
+	                                        {{"y", AtomicClockConstraintT<std::less<Time>>(2)}},
+	                                        {"x"}}}));
 }
 
 // TODO Test case with multiple clocks

--- a/test/test_ta_print.cpp
+++ b/test/test_ta_print.cpp
@@ -28,30 +28,31 @@ namespace {
 using TA            = automata::ta::TimedAutomaton<std::string, std::string>;
 using Transition    = automata::ta::Transition<std::string, std::string>;
 using Configuration = automata::ta::Configuration<std::string>;
+using Location      = automata::ta::Location<std::string>;
 
 TEST_CASE("Print a TA transition", "[ta][print]")
 {
 	SECTION("A transition without constraints")
 	{
 		std::stringstream str;
-		str << Transition("s0", "a", "s1");
+		str << Transition(Location{"s0"}, "a", Location{"s1"});
 		CHECK(str.str() == u8"s0 → a / ⊤ / {} → s1");
 	}
 	SECTION("A transition with a constraint")
 	{
 		std::stringstream str;
-		str << Transition("s0",
+		str << Transition(Location{"s0"},
 		                  "a",
-		                  "s1",
+		                  Location{"s1"},
 		                  {{"x", automata::AtomicClockConstraintT<std::less<automata::Time>>{1}}});
 		CHECK(str.str() == u8"s0 → a / x < 1 / {} → s1");
 	}
 	SECTION("A transition with two constraints")
 	{
 		std::stringstream str;
-		str << Transition("s0",
+		str << Transition(Location{"s0"},
 		                  "a",
-		                  "s1",
+		                  Location{"s1"},
 		                  {{"x", automata::AtomicClockConstraintT<std::less<automata::Time>>{1}},
 		                   {"y", automata::AtomicClockConstraintT<std::greater<automata::Time>>{2}}});
 		CHECK(str.str() == u8"s0 → a / x < 1 ∧ y > 2 / {} → s1");
@@ -59,9 +60,9 @@ TEST_CASE("Print a TA transition", "[ta][print]")
 	SECTION("A transition with a constraint and a reset")
 	{
 		std::stringstream str;
-		str << Transition("s0",
+		str << Transition(Location{"s0"},
 		                  "a",
-		                  "s1",
+		                  Location{"s1"},
 		                  {{"x", automata::AtomicClockConstraintT<std::less<automata::Time>>{1}}},
 		                  {"x"});
 		CHECK(str.str() == u8"s0 → a / x < 1 / { x } → s1");
@@ -70,18 +71,18 @@ TEST_CASE("Print a TA transition", "[ta][print]")
 
 TEST_CASE("Print a TA", "[ta][print]")
 {
-	TA ta{{"a"}, "s0", {"s1"}};
+	TA ta{{"a"}, Location{"s0"}, {Location{"s1"}}};
 	ta.add_clock("x");
 	ta.add_transition(
-	  Transition("s0",
+	  Transition(Location{"s0"},
 	             "a",
-	             "s0",
+	             Location{"s0"},
 	             {{"x", automata::AtomicClockConstraintT<std::greater<automata::Time>>(2)}},
 	             {"x"}));
 	ta.add_transition(
-	  Transition("s0",
+	  Transition(Location{"s0"},
 	             "a",
-	             "s1",
+	             Location{"s1"},
 	             {{"x", automata::AtomicClockConstraintT<std::less<automata::Time>>(2)}},
 	             {"x"}));
 	std::stringstream str;
@@ -97,19 +98,19 @@ TEST_CASE("Print a TA configuration", "[ta][print]")
 	SECTION("A configuration without a clock")
 	{
 		std::stringstream str;
-		str << Configuration{"s0", {}};
+		str << Configuration{Location{"s0"}, {}};
 		CHECK(str.str() == "(s0, {})");
 	}
 	SECTION("A configuration with a single clock")
 	{
 		std::stringstream str;
-		str << Configuration{"s0", {{"x", 1}}};
+		str << Configuration{Location{"s0"}, {{"x", 1}}};
 		CHECK(str.str() == "(s0, { x: 1 } )");
 	}
 	SECTION("A configuration with two clocks")
 	{
 		std::stringstream str;
-		str << Configuration{"s0", {{"c1", 1}, {"c2", 3}}};
+		str << Configuration{Location{"s0"}, {{"c1", 1}, {"c2", 3}}};
 		CHECK(str.str() == "(s0, { c1: 1, c2: 3 } )");
 	}
 }

--- a/test/test_ta_product.cpp
+++ b/test/test_ta_product.cpp
@@ -29,27 +29,34 @@ using TA               = automata::ta::TimedAutomaton<std::string, std::string>;
 using SingleTransition = automata::ta::Transition<std::string, std::string>;
 using ProductTransition =
   automata::ta::Transition<std::tuple<std::string, std::string>, std::string>;
+using SingleLocation  = automata::ta::Location<std::string>;
+using ProductLocation = automata::ta::Location<std::tuple<std::string, std::string>>;
 using automata::AtomicClockConstraintT;
 using automata::Time;
 
 TEST_CASE("The product of two timed automata", "[ta]")
 {
-	TA ta1{{"a", "b"}, "1l1", {"1l1"}};
-	TA ta2{{"c", "d"}, "2l1", {"2l2"}};
-	ta1.add_location("1l2");
-	ta1.add_transition(SingleTransition{"1l1", "a", "1l1"});
-	ta2.add_transition(SingleTransition{"2l1", "c", "2l2"});
+	TA ta1{{"a", "b"}, SingleLocation{"1l1"}, {SingleLocation{"1l1"}}};
+	TA ta2{{"c", "d"}, SingleLocation{"2l1"}, {SingleLocation{"2l2"}}};
+	ta1.add_location(SingleLocation{"1l2"});
+	ta1.add_transition(SingleTransition{SingleLocation{"1l1"}, "a", SingleLocation{"1l1"}});
+	ta2.add_transition(SingleTransition{SingleLocation{"2l1"}, "c", SingleLocation{"2l2"}});
 	const auto product = automata::ta::get_product(ta1, ta2);
 	CHECK(product.get_alphabet() == std::set<std::string>{"a", "b", "c", "d"});
-	CHECK(product.get_initial_location() == std::make_tuple(std::string{"1l1"}, std::string{"2l1"}));
-	CHECK(product.get_final_locations()
-	      == std::set<std::tuple<std::string, std::string>>{{"1l1", "2l2"}});
-	CHECK(product.get_transitions()
-	      == std::multimap<std::tuple<std::string, std::string>, ProductTransition>{
-	        {{{"1l1", "2l1"}, ProductTransition{{"1l1", "2l1"}, "a", {"1l1", "2l1"}}},
-	         {{"1l1", "2l2"}, ProductTransition{{"1l1", "2l2"}, "a", {"1l1", "2l2"}}},
-	         {{"1l1", "2l1"}, ProductTransition{{"1l1", "2l1"}, "c", {"1l1", "2l2"}}},
-	         {{"1l2", "2l1"}, ProductTransition{{"1l2", "2l1"}, "c", {"1l2", "2l2"}}}}});
+	CHECK(product.get_initial_location() == ProductLocation{{"1l1", "2l1"}});
+	CHECK(product.get_final_locations() == std::set{ProductLocation{{"1l1", "2l2"}}});
+	CHECK(
+	  product.get_transitions()
+	  == std::multimap<ProductLocation, ProductTransition>{
+	    {{ProductLocation{{"1l1", "2l1"}},
+	      ProductTransition{ProductLocation{{"1l1", "2l1"}}, "a", ProductLocation{{"1l1", "2l1"}}}},
+	     {ProductLocation{{"1l1", "2l2"}},
+	      ProductTransition{ProductLocation{{"1l1", "2l2"}}, "a", ProductLocation{{"1l1", "2l2"}}}},
+	     {ProductLocation{{"1l1", "2l1"}},
+	      ProductTransition{ProductLocation{{"1l1", "2l1"}}, "c", ProductLocation{{"1l1", "2l2"}}}},
+	     {ProductLocation{{"1l2", "2l1"}},
+	      ProductTransition{
+	        ProductLocation{{"1l2", "2l1"}}, "c", ProductLocation{{"1l2", "2l2"}}}}}});
 	CHECK(product.accepts_word({{"a", 0}, {"c", 1}}));
 	CHECK_THROWS_AS(automata::ta::get_product(ta1, ta2, {"a"}),
 	                automata::ta::NotImplementedException);
@@ -57,41 +64,44 @@ TEST_CASE("The product of two timed automata", "[ta]")
 
 TEST_CASE("The product of two timed automata with clock constraints", "[ta]")
 {
-	TA ta1{{"a", "b"}, "1l1", {"1l1"}};
-	ta1.add_location("1l2");
+	TA ta1{{"a", "b"}, SingleLocation{"1l1"}, {SingleLocation{"1l1"}}};
+	ta1.add_location(SingleLocation{"1l2"});
 	ta1.add_clock("c1");
-	ta1.add_transition(
-	  SingleTransition{"1l1", "a", "1l1", {{"c1", AtomicClockConstraintT<std::less<Time>>{1}}}});
-	TA ta2{{"c", "d"}, "2l1", {"2l2"}};
+	ta1.add_transition(SingleTransition{SingleLocation{"1l1"},
+	                                    "a",
+	                                    SingleLocation{"1l1"},
+	                                    {{"c1", AtomicClockConstraintT<std::less<Time>>{1}}}});
+	TA ta2{{"c", "d"}, SingleLocation{"2l1"}, {SingleLocation{"2l2"}}};
 	ta2.add_clock("c2");
-	ta2.add_transition(
-	  SingleTransition{"2l1", "c", "2l2", {{"c2", AtomicClockConstraintT<std::greater<Time>>{2}}}});
+	ta2.add_transition(SingleTransition{SingleLocation{"2l1"},
+	                                    "c",
+	                                    SingleLocation{"2l2"},
+	                                    {{"c2", AtomicClockConstraintT<std::greater<Time>>{2}}}});
 	const auto product = automata::ta::get_product(ta1, ta2);
 	CHECK(product.get_alphabet() == std::set<std::string>{"a", "b", "c", "d"});
-	CHECK(product.get_initial_location() == std::make_tuple(std::string{"1l1"}, std::string{"2l1"}));
-	CHECK(product.get_final_locations()
-	      == std::set<std::tuple<std::string, std::string>>{{"1l1", "2l2"}});
+	CHECK(product.get_initial_location() == ProductLocation{{"1l1", "2l1"}});
+	CHECK(product.get_final_locations() == std::set{ProductLocation{{"1l1", "2l2"}}});
 	CHECK(product.get_transitions()
-	      == std::multimap<std::tuple<std::string, std::string>, ProductTransition>{
-	        {{{"1l1", "2l1"},
-	          ProductTransition{{"1l1", "2l1"},
+	      == std::multimap<ProductLocation, ProductTransition>{
+	        {{ProductLocation{{"1l1", "2l1"}},
+	          ProductTransition{ProductLocation{{"1l1", "2l1"}},
 	                            "a",
-	                            {"1l1", "2l1"},
+	                            ProductLocation{{"1l1", "2l1"}},
 	                            {{"c1", AtomicClockConstraintT<std::less<Time>>{1}}}}},
-	         {{"1l1", "2l2"},
-	          ProductTransition{{"1l1", "2l2"},
+	         {ProductLocation{{"1l1", "2l2"}},
+	          ProductTransition{ProductLocation{{"1l1", "2l2"}},
 	                            "a",
-	                            {"1l1", "2l2"},
+	                            ProductLocation{{"1l1", "2l2"}},
 	                            {{"c1", AtomicClockConstraintT<std::less<Time>>{1}}}}},
-	         {{"1l1", "2l1"},
-	          ProductTransition{{"1l1", "2l1"},
+	         {ProductLocation{{"1l1", "2l1"}},
+	          ProductTransition{ProductLocation{{"1l1", "2l1"}},
 	                            "c",
-	                            {"1l1", "2l2"},
+	                            ProductLocation{{"1l1", "2l2"}},
 	                            {{"c2", AtomicClockConstraintT<std::greater<Time>>{2}}}}},
-	         {{"1l2", "2l1"},
-	          ProductTransition{{"1l2", "2l1"},
+	         {ProductLocation{{"1l2", "2l1"}},
+	          ProductTransition{ProductLocation{{"1l2", "2l1"}},
 	                            "c",
-	                            {"1l2", "2l2"},
+	                            ProductLocation{{"1l2", "2l2"}},
 	                            {{"c2", AtomicClockConstraintT<std::greater<Time>>{2}}}}}}});
 	CHECK(!product.accepts_word({{"a", 0}, {"c", 1}}));
 	CHECK(product.accepts_word({{"a", 0}, {"c", 3}}));

--- a/test/test_ta_proto.cpp
+++ b/test/test_ta_proto.cpp
@@ -30,6 +30,7 @@ namespace {
 
 using TimedAutomaton = automata::ta::TimedAutomaton<std::string, std::string>;
 using Transition     = automata::ta::Transition<std::string, std::string>;
+using Location       = automata::ta::Location<std::string>;
 
 TEST_CASE("Parse a TA from a proto", "[proto][ta]")
 {
@@ -70,24 +71,24 @@ TEST_CASE("Parse a TA from a proto", "[proto][ta]")
     )pb",
 	  &proto_ta));
 	const auto ta = automata::ta::parse_proto(proto_ta);
-	CHECK(ta.get_locations() == std::set<std::string>{"s0", "s1", "s2"});
-	CHECK(ta.get_final_locations() == std::set<std::string>{"s2"});
+	CHECK(ta.get_locations() == std::set{Location{"s0"}, Location{"s1"}, Location{"s2"}});
+	CHECK(ta.get_final_locations() == std::set{Location{"s2"}});
 	CHECK(ta.get_alphabet() == std::set<std::string>{"a", "b"});
 	CHECK(
 	  ta.get_transitions()
-	  == std::multimap<std::string, Transition>{
-	    {{"s0"},
-	     Transition{"s0",
+	  == std::multimap<Location, Transition>{
+	    {{Location{"s0"}},
+	     Transition{Location{"s0"},
 	                "a",
-	                "s1",
+	                Location{"s1"},
 	                {{"c1", automata::AtomicClockConstraintT<std::less<automata::Time>>{1}},
 	                 {"c2", automata::AtomicClockConstraintT<std::less_equal<automata::Time>>{2}},
 	                 {"c3", automata::AtomicClockConstraintT<std::equal_to<automata::Time>>{3}}},
 	                {"c4", "c5"}}},
-	    {{"s1"},
-	     Transition{"s1",
+	    {{Location{"s1"}},
+	     Transition{Location{"s1"},
 	                "b",
-	                "s2",
+	                Location{"s2"},
 	                {{"c5", automata::AtomicClockConstraintT<std::greater_equal<automata::Time>>{5}},
 	                 {"c6", automata::AtomicClockConstraintT<std::greater<automata::Time>>{6}}},
 	                {"c6"}}}});

--- a/test/test_ta_region.cpp
+++ b/test/test_ta_region.cpp
@@ -42,8 +42,8 @@ TEST_CASE("Region Candidate", "[taRegion]")
 {
 	const auto candidate =
 	  get_region_candidate<std::string>({"s0", {{"c0", 2}, {"c1", 3}, {"c2", 0}}});
-	CHECK(candidate.first == "s0");
-	const auto &clock_set_valuation = candidate.second;
+	CHECK(candidate.location == "s0");
+	const auto &clock_set_valuation = candidate.clock_valuations;
 	REQUIRE(clock_set_valuation.find("c0") != clock_set_valuation.end());
 	CHECK_THAT(clock_set_valuation.at("c0"), Catch::Matchers::WithinULP(1.0, 4));
 	REQUIRE(clock_set_valuation.find("c1") != clock_set_valuation.end());

--- a/test/test_ta_region.cpp
+++ b/test/test_ta_region.cpp
@@ -27,6 +27,7 @@ namespace {
 
 using namespace automata;
 using namespace automata::ta;
+using Location = automata::ta::Location<std::string>;
 
 TEST_CASE("Region index", "[taRegion]")
 {
@@ -41,8 +42,8 @@ TEST_CASE("Region index", "[taRegion]")
 TEST_CASE("Region Candidate", "[taRegion]")
 {
 	const auto candidate =
-	  get_region_candidate<std::string>({"s0", {{"c0", 2}, {"c1", 3}, {"c2", 0}}});
-	CHECK(candidate.location == "s0");
+	  get_region_candidate<std::string>({Location{"s0"}, {{"c0", 2}, {"c1", 3}, {"c2", 0}}});
+	CHECK(candidate.location == Location{"s0"});
 	const auto &clock_set_valuation = candidate.clock_valuations;
 	REQUIRE(clock_set_valuation.find("c0") != clock_set_valuation.end());
 	CHECK_THAT(clock_set_valuation.at("c0"), Catch::Matchers::WithinULP(1.0, 4));
@@ -55,35 +56,43 @@ TEST_CASE("Region Candidate", "[taRegion]")
 
 TEST_CASE("Get largest region index", "[taRegion]")
 {
-	TimedAutomaton<std::string, std::string> ta{{"a", "b"}, "s0", {"s1", "s2"}};
-	ta.add_location("s1");
-	ta.add_location("s2");
+	TimedAutomaton<std::string, std::string> ta{{"a", "b"},
+	                                            Location{"s0"},
+	                                            {Location{"s1"}, Location{"s2"}}};
+	ta.add_location(Location{"s1"});
+	ta.add_location(Location{"s2"});
 	ta.add_clock("x");
 	SECTION("max constant is 3")
 	{
 		ClockConstraint c1 = AtomicClockConstraintT<std::less<Time>>(2);
 		ClockConstraint c2 = AtomicClockConstraintT<std::greater<Time>>(3);
-		ta.add_transition(Transition<std::string, std::string>("s0", "a", "s1"));
-		ta.add_transition(Transition<std::string, std::string>("s0", "a", "s2", {{"x", c2}}));
-		ta.add_transition(Transition<std::string, std::string>("s1", "b", "s1", {{"x", c1}}));
+		ta.add_transition(Transition<std::string, std::string>(Location{"s0"}, "a", Location{"s1"}));
+		ta.add_transition(
+		  Transition<std::string, std::string>(Location{"s0"}, "a", Location{"s2"}, {{"x", c2}}));
+		ta.add_transition(
+		  Transition<std::string, std::string>(Location{"s1"}, "b", Location{"s1"}, {{"x", c1}}));
 		CHECK(get_maximal_region_index(ta) == RegionIndex(7));
 	}
 	SECTION("max constant is 2")
 	{
 		ClockConstraint c1 = AtomicClockConstraintT<std::less<Time>>(1);
 		ClockConstraint c2 = AtomicClockConstraintT<std::greater<Time>>(2);
-		ta.add_transition(Transition<std::string, std::string>("s0", "a", "s1"));
-		ta.add_transition(Transition<std::string, std::string>("s0", "a", "s2", {{"x", c2}}));
-		ta.add_transition(Transition<std::string, std::string>("s1", "b", "s1", {{"x", c1}}));
+		ta.add_transition(Transition<std::string, std::string>(Location{"s0"}, "a", Location{"s1"}));
+		ta.add_transition(
+		  Transition<std::string, std::string>(Location{"s0"}, "a", Location{"s2"}, {{"x", c2}}));
+		ta.add_transition(
+		  Transition<std::string, std::string>(Location{"s1"}, "b", Location{"s1"}, {{"x", c1}}));
 		CHECK(get_maximal_region_index(ta) == RegionIndex(5));
 	}
 	SECTION("max constant is 1")
 	{
 		ClockConstraint c1 = AtomicClockConstraintT<std::less<Time>>(1);
 		ClockConstraint c2 = AtomicClockConstraintT<std::greater<Time>>(1);
-		ta.add_transition(Transition<std::string, std::string>("s0", "a", "s1"));
-		ta.add_transition(Transition<std::string, std::string>("s0", "a", "s2", {{"x", c2}}));
-		ta.add_transition(Transition<std::string, std::string>("s1", "b", "s1", {{"x", c1}}));
+		ta.add_transition(Transition<std::string, std::string>(Location{"s0"}, "a", Location{"s1"}));
+		ta.add_transition(
+		  Transition<std::string, std::string>(Location{"s0"}, "a", Location{"s2"}, {{"x", c2}}));
+		ta.add_transition(
+		  Transition<std::string, std::string>(Location{"s1"}, "b", Location{"s1"}, {{"x", c1}}));
 		CHECK(get_maximal_region_index(ta) == RegionIndex(3));
 	}
 }

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -1,0 +1,6 @@
+include(FetchContent)
+FetchContent_Declare(
+  NamedType
+  GIT_REPOSITORY https://github.com/joboccara/NamedType
+)
+FetchContent_MakeAvailable(NamedType)


### PR DESCRIPTION
Introduce strong types for data structures where it seems to be most useful. The biggest difference is in making TA locations strongly typed. This makes the code a bit more verbose, but also more readable, e.g., `Transition("s0", "a", "s1")` now becomes `Transition(Location{"s0"}, "a", Location{"s1"})`. Note that the actions are not strongly typed (yet).

This also avoids the need to define global ostream operators, as we can now all put them into the namespace where the type is defined.