### PR TITLE
Extend TA product to more than two input automata

### DIFF
--- a/src/automata/CMakeLists.txt
+++ b/src/automata/CMakeLists.txt
@@ -1,7 +1,8 @@
 find_package(range-v3 REQUIRED)
+find_package(fmt REQUIRED)
 
 add_library(ta SHARED ta.cpp automata.cpp ata.cpp ta_regions.cpp)
-target_link_libraries(ta PRIVATE range-v3::range-v3 PUBLIC utilities NamedType)
+target_link_libraries(ta PUBLIC range-v3::range-v3 utilities fmt::fmt NamedType)
 target_include_directories(ta PUBLIC include ${Boost_INCLUDE_DIR})
 
 find_package(Protobuf QUIET)

--- a/src/automata/include/automata/ta_product.h
+++ b/src/automata/include/automata/ta_product.h
@@ -33,11 +33,21 @@ class NotImplementedException : public std::logic_error
 };
 
 /** Print a product location. */
-template <typename LocationT1, typename LocationT2>
+template <typename LocationT>
 std::ostream &
-operator<<(std::ostream &os, const Location<std::tuple<LocationT1, LocationT2>> &location)
+operator<<(std::ostream &os, const Location<std::vector<LocationT>> &product_location)
 {
-	os << "(" << std::get<0>(location.get()) << ", " << std::get<1>(location.get()) << ")";
+	os << "(";
+	bool first = true;
+	for (const auto &location : product_location.get()) {
+		if (first) {
+			first = false;
+		} else {
+			os << ", ";
+		}
+		os << location;
+	}
+	os << ")";
 	return os;
 }
 
@@ -59,11 +69,10 @@ operator<<(std::ostream &os, const Location<std::tuple<LocationT1, LocationT2>> 
  * @param synchronized_actions The actions on which the two TAs must synchronize
  * @return The product automaton
  */
-template <typename LocationT1, typename LocationT2, typename ActionT>
-TimedAutomaton<std::tuple<LocationT1, LocationT2>, ActionT>
-get_product(const TimedAutomaton<LocationT1, ActionT> &ta1,
-            const TimedAutomaton<LocationT2, ActionT> &ta2,
-            const std::set<ActionT> &                  synchronized_actions = {});
+template <typename LocationT, typename ActionT>
+TimedAutomaton<std::vector<LocationT>, ActionT>
+get_product(const std::vector<TimedAutomaton<LocationT, ActionT>> &automata,
+            const std::set<ActionT> &                              synchronized_actions = {});
 
 } // namespace automata::ta
 

--- a/src/automata/include/automata/ta_product.hpp
+++ b/src/automata/include/automata/ta_product.hpp
@@ -121,24 +121,13 @@ get_product(const std::vector<TimedAutomaton<LocationT, ActionT>> &automata,
 		for (const auto &[source_location, transition] : ta.get_transitions()) {
 			for (const auto &product_source_location : product_locations) {
 				if (product_source_location.get()[ta_i] == transition.source_.get()) {
-					for (const auto &product_target_location : product_locations) {
-						// All the locations must be equal except for the location at ta_i, which switches to
-						// the target location of the transition.
-						if (std::equal(begin(product_source_location.get()),
-						               begin(product_source_location.get()) + ta_i,
-						               begin(product_target_location.get()))
-						    && product_target_location.get()[ta_i] == transition.target_.get()
-
-						    && std::equal(begin(product_source_location.get()) + ta_i + 1,
-						                  end(product_source_location.get()),
-						                  begin(product_target_location.get()) + ta_i + 1)) {
-							product_transitions.emplace_back(product_source_location,
-							                                 transition.symbol_,
-							                                 product_target_location,
-							                                 transition.clock_constraints_,
-							                                 transition.clock_resets_);
-						}
-					}
+					auto product_target_location        = product_source_location;
+					product_target_location.get()[ta_i] = transition.target_.get();
+					product_transitions.emplace_back(product_source_location,
+					                                 transition.symbol_,
+					                                 product_target_location,
+					                                 transition.clock_constraints_,
+					                                 transition.clock_resets_);
 				}
 			}
 		};

--- a/src/automata/include/automata/ta_product.hpp
+++ b/src/automata/include/automata/ta_product.hpp
@@ -22,7 +22,12 @@
 #include "automata/ta.h"
 #include "ta_product.h"
 
+#include <fmt/core.h>
+#include <fmt/format.h>
+
+#include <algorithm>
 #include <range/v3/view/enumerate.hpp>
+#include <stdexcept>
 
 namespace automata::ta {
 
@@ -37,6 +42,23 @@ get_product(const std::vector<TimedAutomaton<LocationT, ActionT>> &automata,
 	}
 	if (automata.empty()) {
 		throw std::invalid_argument("Cannot compute product of zero automata");
+	}
+	for (auto it1 = std::begin(automata); it1 != std::prev(std::end(automata)); ++it1) {
+		for (auto it2 = std::next(it1); it2 != std::end(automata); ++it2) {
+			std::set<std::string> common_clocks;
+			std::set_intersection(begin(it1->get_clocks()),
+			                      end(it1->get_clocks()),
+			                      begin(it2->get_clocks()),
+			                      end(it2->get_clocks()),
+			                      std::inserter(common_clocks, end(common_clocks)));
+
+			if (!common_clocks.empty()) {
+				throw std::invalid_argument(
+				  fmt::format("Cannot construct product automaton for two automata with non-disjoint "
+				              "clocks, common clocks: {}",
+				              fmt::join(common_clocks, ", ")));
+			}
+		}
 	}
 	using ProductLocation = Location<std::vector<LocationT>>;
 	std::set<ActionT>         actions;

--- a/test/test_railroad.cpp
+++ b/test/test_railroad.cpp
@@ -38,8 +38,7 @@ using automata::Time;
 using F  = logic::MTLFormula<std::string>;
 using AP = logic::AtomicProposition<std::string>;
 using synchronous_product::NodeLabel;
-using TreeSearch =
-  synchronous_product::TreeSearch<std::tuple<std::string, std::string>, std::string>;
+using TreeSearch = synchronous_product::TreeSearch<std::vector<std::string>, std::string>;
 
 TEST_CASE("A single railroad crossing", "[railroad]")
 {
@@ -88,7 +87,7 @@ TEST_CASE("A single railroad crossing", "[railroad]")
 	                                Location{"BEHIND"},
 	                                {{"t", AtomicClockConstraintT<std::equal_to<Time>>(1)}},
 	                                {"t"}));
-	auto         product = automata::ta::get_product(crossing, train);
+	auto         product = automata::ta::get_product<std::string, std::string>({crossing, train});
 	std::set<AP> actions;
 	for (const auto &action : crossing_actions) {
 		actions.insert(AP{action});

--- a/test/test_ta_product.cpp
+++ b/test/test_ta_product.cpp
@@ -220,4 +220,12 @@ TEST_CASE("The product of three timed automata", "[ta]")
 	CHECK(!product.accepts_word({{"3a", 0}, {"2a", 1}, {"3a", 2}}));
 	CHECK(!product.accepts_word({{"1a", 0}, {"2a", 3}, {"3a", 4}}));
 }
+
+TEST_CASE("Cannot construct a product of two TAs with common clocks", "[ta]")
+{
+	auto ta =
+	  TA{{SingleLocation{"1l0"}}, {"a"}, SingleLocation{"1l0"}, {SingleLocation{"1l0"}}, {"x"}, {}};
+	CHECK_THROWS(get_product<std::string, std::string>({ta, ta}));
+}
+
 } // namespace

--- a/test/test_ta_product.cpp
+++ b/test/test_ta_product.cpp
@@ -221,11 +221,18 @@ TEST_CASE("The product of three timed automata", "[ta]")
 	CHECK(!product.accepts_word({{"1a", 0}, {"2a", 3}, {"3a", 4}}));
 }
 
-TEST_CASE("Cannot construct a product of two TAs with common clocks", "[ta]")
+TEST_CASE("TA product error handling", "[ta]")
 {
-	auto ta =
-	  TA{{SingleLocation{"1l0"}}, {"a"}, SingleLocation{"1l0"}, {SingleLocation{"1l0"}}, {"x"}, {}};
-	CHECK_THROWS(get_product<std::string, std::string>({ta, ta}));
+	SECTION("Cannot construct a product of two TAs with common clocks")
+	{
+		auto ta =
+		  TA{{SingleLocation{"1l0"}}, {"a"}, SingleLocation{"1l0"}, {SingleLocation{"1l0"}}, {"x"}, {}};
+		CHECK_THROWS(get_product<std::string, std::string>({ta, ta}));
+	}
+	SECTION("Cannot construct a product of zero automata")
+	{
+		CHECK_THROWS(get_product<std::string, std::string>({}));
+	}
 }
 
 } // namespace

--- a/test/test_ta_product.cpp
+++ b/test/test_ta_product.cpp
@@ -25,14 +25,14 @@
 
 namespace {
 
-using TA               = automata::ta::TimedAutomaton<std::string, std::string>;
-using SingleTransition = automata::ta::Transition<std::string, std::string>;
-using ProductTransition =
-  automata::ta::Transition<std::tuple<std::string, std::string>, std::string>;
-using SingleLocation  = automata::ta::Location<std::string>;
-using ProductLocation = automata::ta::Location<std::tuple<std::string, std::string>>;
+using TA                = automata::ta::TimedAutomaton<std::string, std::string>;
+using SingleTransition  = automata::ta::Transition<std::string, std::string>;
+using ProductTransition = automata::ta::Transition<std::vector<std::string>, std::string>;
+using SingleLocation    = automata::ta::Location<std::string>;
+using ProductLocation   = automata::ta::Location<std::vector<std::string>>;
 using automata::AtomicClockConstraintT;
 using automata::Time;
+using automata::ta::get_product;
 
 TEST_CASE("The product of two timed automata", "[ta]")
 {
@@ -41,7 +41,7 @@ TEST_CASE("The product of two timed automata", "[ta]")
 	ta1.add_location(SingleLocation{"1l2"});
 	ta1.add_transition(SingleTransition{SingleLocation{"1l1"}, "a", SingleLocation{"1l1"}});
 	ta2.add_transition(SingleTransition{SingleLocation{"2l1"}, "c", SingleLocation{"2l2"}});
-	const auto product = automata::ta::get_product(ta1, ta2);
+	const auto product = get_product<std::string, std::string>({ta1, ta2});
 	CHECK(product.get_alphabet() == std::set<std::string>{"a", "b", "c", "d"});
 	CHECK(product.get_initial_location() == ProductLocation{{"1l1", "2l1"}});
 	CHECK(product.get_final_locations() == std::set{ProductLocation{{"1l1", "2l2"}}});
@@ -58,7 +58,9 @@ TEST_CASE("The product of two timed automata", "[ta]")
 	      ProductTransition{
 	        ProductLocation{{"1l2", "2l1"}}, "c", ProductLocation{{"1l2", "2l2"}}}}}});
 	CHECK(product.accepts_word({{"a", 0}, {"c", 1}}));
-	CHECK_THROWS_AS(automata::ta::get_product(ta1, ta2, {"a"}),
+
+	// Synchronized actions are not implemented.
+	CHECK_THROWS_AS((get_product<std::string, std::string>({ta1, ta2}, {"a"})),
 	                automata::ta::NotImplementedException);
 }
 
@@ -77,7 +79,7 @@ TEST_CASE("The product of two timed automata with clock constraints", "[ta]")
 	                                    "c",
 	                                    SingleLocation{"2l2"},
 	                                    {{"c2", AtomicClockConstraintT<std::greater<Time>>{2}}}});
-	const auto product = automata::ta::get_product(ta1, ta2);
+	const auto product = get_product<std::string, std::string>({ta1, ta2});
 	CHECK(product.get_alphabet() == std::set<std::string>{"a", "b", "c", "d"});
 	CHECK(product.get_initial_location() == ProductLocation{{"1l1", "2l1"}});
 	CHECK(product.get_final_locations() == std::set{ProductLocation{{"1l1", "2l2"}}});
@@ -106,5 +108,116 @@ TEST_CASE("The product of two timed automata with clock constraints", "[ta]")
 	CHECK(!product.accepts_word({{"a", 0}, {"c", 1}}));
 	CHECK(product.accepts_word({{"a", 0}, {"c", 3}}));
 	CHECK(!product.accepts_word({{"a", 2}, {"c", 3}}));
+}
+
+TEST_CASE("The product of three timed automata", "[ta]")
+{
+	TA   ta1{{SingleLocation{"1l0"}, SingleLocation{"1l1"}},
+         {"1a", "1b"},
+         SingleLocation{"1l0"},
+         {SingleLocation{"1l1"}},
+         {"1c1"},
+         {SingleTransition{SingleLocation{"1l0"},
+                           "1a",
+                           SingleLocation{"1l1"},
+                           {{"1c1", AtomicClockConstraintT<std::less<Time>>{1}}}}}};
+	TA   ta2{{SingleLocation{"2l0"}, SingleLocation{"2l1"}},
+         {"2a", "2b"},
+         SingleLocation{"2l0"},
+         {SingleLocation{"2l1"}},
+         {"2c1"},
+         {SingleTransition{SingleLocation{"2l0"},
+                           "2a",
+                           SingleLocation{"2l1"},
+                           {{"2c1", AtomicClockConstraintT<std::less<Time>>{2}}}}}};
+	TA   ta3{{SingleLocation{"3l0"}, SingleLocation{"3l1"}},
+         {"3a", "3b"},
+         SingleLocation{"3l0"},
+         {SingleLocation{"3l1"}},
+         {"3c1"},
+         {SingleTransition{SingleLocation{"3l0"},
+                           "3a",
+                           SingleLocation{"3l1"},
+                           {{"3c1", AtomicClockConstraintT<std::less<Time>>{3}}}}}};
+	auto product = get_product<std::string, std::string>({ta1, ta2, ta3});
+	CHECK(product.get_locations()
+	      == std::set<ProductLocation>{ProductLocation{{"1l0", "2l0", "3l0"}},
+	                                   ProductLocation{{"1l0", "2l0", "3l1"}},
+	                                   ProductLocation{{"1l0", "2l1", "3l0"}},
+	                                   ProductLocation{{"1l0", "2l1", "3l1"}},
+	                                   ProductLocation{{"1l1", "2l0", "3l0"}},
+	                                   ProductLocation{{"1l1", "2l0", "3l1"}},
+	                                   ProductLocation{{"1l1", "2l1", "3l0"}},
+	                                   ProductLocation{{"1l1", "2l1", "3l1"}}});
+	CHECK(product.get_final_locations()
+	      == std::set<ProductLocation>{ProductLocation{{"1l1", "2l1", "3l1"}}});
+	CHECK(product.get_clocks() == std::set<std::string>{"1c1", "2c1", "3c1"});
+	CHECK(product.get_transitions()
+	      == std::multimap<ProductLocation, ProductTransition>{
+	        {{ProductLocation{{"1l0", "2l0", "3l0"}},
+	          ProductTransition{ProductLocation{{"1l0", "2l0", "3l0"}},
+	                            "1a",
+	                            ProductLocation{{"1l1", "2l0", "3l0"}},
+	                            {{"1c1", AtomicClockConstraintT<std::less<Time>>{1}}}}},
+	         {ProductLocation{{"1l0", "2l0", "3l1"}},
+	          ProductTransition{ProductLocation{{"1l0", "2l0", "3l1"}},
+	                            "1a",
+	                            ProductLocation{{"1l1", "2l0", "3l1"}},
+	                            {{"1c1", AtomicClockConstraintT<std::less<Time>>{1}}}}},
+	         {ProductLocation{{"1l0", "2l1", "3l0"}},
+	          ProductTransition{ProductLocation{{"1l0", "2l1", "3l0"}},
+	                            "1a",
+	                            ProductLocation{{"1l1", "2l1", "3l0"}},
+	                            {{"1c1", AtomicClockConstraintT<std::less<Time>>{1}}}}},
+	         {ProductLocation{{"1l0", "2l1", "3l1"}},
+	          ProductTransition{ProductLocation{{"1l0", "2l1", "3l1"}},
+	                            "1a",
+	                            ProductLocation{{"1l1", "2l1", "3l1"}},
+	                            {{"1c1", AtomicClockConstraintT<std::less<Time>>{1}}}}},
+	         {ProductLocation{{"1l0", "2l0", "3l0"}},
+	          ProductTransition{ProductLocation{{"1l0", "2l0", "3l0"}},
+	                            "2a",
+	                            ProductLocation{{"1l0", "2l1", "3l0"}},
+	                            {{"2c1", AtomicClockConstraintT<std::less<Time>>{2}}}}},
+	         {ProductLocation{{"1l0", "2l0", "3l1"}},
+	          ProductTransition{ProductLocation{{"1l0", "2l0", "3l1"}},
+	                            "2a",
+	                            ProductLocation{{"1l0", "2l1", "3l1"}},
+	                            {{"2c1", AtomicClockConstraintT<std::less<Time>>{2}}}}},
+	         {ProductLocation{{"1l1", "2l0", "3l0"}},
+	          ProductTransition{ProductLocation{{"1l1", "2l0", "3l0"}},
+	                            "2a",
+	                            ProductLocation{{"1l1", "2l1", "3l0"}},
+	                            {{"2c1", AtomicClockConstraintT<std::less<Time>>{2}}}}},
+	         {ProductLocation{{"1l1", "2l0", "3l1"}},
+	          ProductTransition{ProductLocation{{"1l1", "2l0", "3l1"}},
+	                            "2a",
+	                            ProductLocation{{"1l1", "2l1", "3l1"}},
+	                            {{"2c1", AtomicClockConstraintT<std::less<Time>>{2}}}}},
+	         {ProductLocation{{"1l0", "2l0", "3l0"}},
+	          ProductTransition{ProductLocation{{"1l0", "2l0", "3l0"}},
+	                            "3a",
+	                            ProductLocation{{"1l0", "2l0", "3l1"}},
+	                            {{"3c1", AtomicClockConstraintT<std::less<Time>>{3}}}}},
+	         {ProductLocation{{"1l0", "2l1", "3l0"}},
+	          ProductTransition{ProductLocation{{"1l0", "2l1", "3l0"}},
+	                            "3a",
+	                            ProductLocation{{"1l0", "2l1", "3l1"}},
+	                            {{"3c1", AtomicClockConstraintT<std::less<Time>>{3}}}}},
+	         {ProductLocation{{"1l1", "2l0", "3l0"}},
+	          ProductTransition{ProductLocation{{"1l1", "2l0", "3l0"}},
+	                            "3a",
+	                            ProductLocation{{"1l1", "2l0", "3l1"}},
+	                            {{"3c1", AtomicClockConstraintT<std::less<Time>>{3}}}}},
+	         {ProductLocation{{"1l1", "2l1", "3l0"}},
+	          ProductTransition{ProductLocation{{"1l1", "2l1", "3l0"}},
+	                            "3a",
+	                            ProductLocation{{"1l1", "2l1", "3l1"}},
+	                            {{"3c1", AtomicClockConstraintT<std::less<Time>>{3}}}}}}});
+	CHECK(product.accepts_word({{"1a", 0}, {"2a", 1}, {"3a", 2}}));
+	CHECK(product.accepts_word({{"3a", 0}, {"2a", 0}, {"1a", 0}}));
+	CHECK(!product.accepts_word({{"1a", 0}, {"2a", 1}}));
+	CHECK(!product.accepts_word({{"3a", 0}, {"2a", 1}, {"3a", 2}}));
+	CHECK(!product.accepts_word({{"1a", 0}, {"2a", 3}, {"3a", 4}}));
 }
 } // namespace


### PR DESCRIPTION
We may want to compute the product of more than two automata. While
theoretically, this is possibly by computing (ta1 x (ta2 x ta3)), this
is not feasible in practice, as the result is a tuple of tuples.
Instead, take a vector of automata when computing the product and
directly compute the product of all the input automata.

This restricts the input automata to be of the same type. However, in
our applications, this restriction is acceptable.