### PR TITLE
mtl: provide helper functions to create formulas finally and globally

### DIFF
--- a/src/mtl/include/mtl/MTLFormula.h
+++ b/src/mtl/include/mtl/MTLFormula.h
@@ -345,6 +345,32 @@ operator!(const AtomicProposition<APType> &ap)
 	return !MTLFormula<APType>(ap);
 }
 
+/** Create a formula F_I phi, which is equivalent to True Until_I phi.
+ * @param phi The sub-formula phi that must eventually be satisfied.
+ * @param duration The time bound I for the finally operator (i.e., phi must
+ * be satisfied within this interval)
+ * @return An MTL formula equivalent to F_I phi
+ */
+template <typename APType>
+MTLFormula<APType>
+finally(const MTLFormula<APType> &phi, const TimeInterval &duration = TimeInterval())
+{
+	return MTLFormula<APType>::TRUE().until(phi, duration);
+}
+
+/** Create a formula G_I phi, which is equivalent to not(F_I not phi)
+ * @param phi The sub-formula phi that must always be satisfied.
+ * @param duration The time bound I for the globally operator (i.e., phi must always be satisfied
+ * within this interval)
+ * @return An MTL formula equivalent to G_I phi
+ */
+template <typename APType>
+MTLFormula<APType>
+globally(const MTLFormula<APType> &phi, const TimeInterval &duration = TimeInterval())
+{
+	return !finally(!phi, duration);
+}
+
 /// outstream operator
 template <typename APType>
 std::ostream &operator<<(std::ostream &out, const logic::AtomicProposition<APType> &a);

--- a/test/test_mtlFormula.cpp
+++ b/test/test_mtlFormula.cpp
@@ -26,6 +26,9 @@
 
 namespace {
 
+using logic::finally;
+using logic::globally;
+
 TEST_CASE("Word boundaries", "[libmtl]")
 {
 	logic::AtomicProposition<std::string> a{"a"};
@@ -246,6 +249,27 @@ TEST_CASE("Get subformulas of type", "[libmtl]")
 
 	auto alphabet = phi6.get_alphabet();
 	REQUIRE(std::set<logic::AtomicProposition<std::string>>({{"a"}, {"b"}, {"c"}}) == alphabet);
+}
+
+TEST_CASE("MTL Finally and Globally", "[libmtl]")
+{
+	using MTLFormula = logic::MTLFormula<std::string>;
+	using AP         = logic::AtomicProposition<std::string>;
+	using MTLWord    = logic::MTLWord<std::string>;
+	using logic::TimeInterval;
+	const AP         a{"a"};
+	const AP         b{"b"};
+	const MTLFormula f_a{a};
+	const MTLFormula f_b{b};
+
+	CHECK(finally(f_a) == MTLFormula::TRUE().until(a));
+	CHECK(globally(f_a) == !(MTLFormula::TRUE().until(!a)));
+	CHECK(MTLWord({{{b}, 0}, {{b}, 1}, {{a}, 2}}).satisfies(finally(f_a, TimeInterval{0, 2})));
+	CHECK(MTLWord({{{b}, 0}, {{b}, 1}, {{a}, 2}}).satisfies(finally(f_a, TimeInterval{0, 2})));
+	CHECK(!MTLWord({{{b}, 0}, {{b}, 1}, {{a}, 3}}).satisfies(finally(f_a, TimeInterval{0, 2})));
+	CHECK(MTLWord({{{b}, 0}, {{b}, 1}, {{a}, 3}}).satisfies(globally(f_b, TimeInterval{0, 1})));
+	CHECK(!MTLWord({{{b}, 0}, {{b}, 1}, {{a}, 3}}).satisfies(globally(f_b, TimeInterval{0, 3})));
+	CHECK(!MTLWord({{{b}, 0}, {{b}, 1}, {{a}, 3}}).satisfies(globally(f_b)));
 }
 
 } // namespace


### PR DESCRIPTION
The formulas finally(a, I) and globally(a, I) correspond to F_I(a) and
G_I(a) and are commonly used as logical shortcuts.