### PR TITLE
Feature/mtl extended translation

### DIFF
--- a/src/mtl_ata_translation/translator.cpp
+++ b/src/mtl_ata_translation/translator.cpp
@@ -187,20 +187,20 @@ translate(const MTLFormula<ActionType> &          input_formula,
 		// The ATA alphabet is the same as the formula alphabet.
 		alphabet = formula.get_alphabet();
 	}
-	if (alphabet.count({"phi_i"}) > 0) {
-		throw std::invalid_argument("The formula alphabet must not contain the symbol 'phi_i'");
+	if (alphabet.count({"l0"}) > 0) {
+		throw std::invalid_argument("The formula alphabet must not contain the symbol 'l0'");
 	}
-	// S = cl(phi) U {phi_i}
+	// S = cl(phi) U {l0}
 	auto locations = get_closure(formula);
-	locations.insert({AtomicProposition<ActionType>{"phi_i"}});
+	locations.insert({AtomicProposition<ActionType>{"l0"}});
 	const auto           untils              = formula.get_subformulas_of_type(LOP::LUNTIL);
 	const auto           dual_untils         = formula.get_subformulas_of_type(LOP::LDUNTIL);
 	const auto           accepting_locations = dual_untils;
 	std::set<Transition> transitions;
 	for (const auto &symbol : alphabet) {
-		// Initial transition delta(phi_i, symbol) -> phi
+		// Initial transition delta(l0, symbol) -> phi
 		transitions.insert(
-		  Transition(AtomicProposition<ActionType>{"phi_i"}, symbol.ap_, init(formula, symbol, true)));
+		  Transition(AtomicProposition<ActionType>{"l0"}, symbol.ap_, init(formula, symbol, true)));
 
 		for (const auto &until : untils) {
 			auto transition_formula = std::make_unique<DisjunctionFormula>(
@@ -223,7 +223,7 @@ translate(const MTLFormula<ActionType> &          input_formula,
 		}
 	}
 	return AlternatingTimedAutomaton(alphabet,
-	                                 MTLFormula<ActionType>{{"phi_i"}},
+	                                 MTLFormula<ActionType>{{"l0"}},
 	                                 accepting_locations,
 	                                 std::move(transitions));
 }

--- a/test/test_mtl_ata_translation.cpp
+++ b/test/test_mtl_ata_translation.cpp
@@ -227,7 +227,7 @@ TEST_CASE("ATA satisfiability of simple MTL formulas", "[translator]")
 
 TEST_CASE("MTL ATA Translation exceptions", "[translator][exceptions]")
 {
-	CHECK_THROWS_AS(translate(MTLFormula{AP{"phi_i"}}), std::invalid_argument);
+	CHECK_THROWS_AS(translate(MTLFormula{AP{"l0"}}), std::invalid_argument);
 }
 
 } // namespace

--- a/test/test_mtl_ata_translation.cpp
+++ b/test/test_mtl_ata_translation.cpp
@@ -223,6 +223,84 @@ TEST_CASE("ATA satisfiability of simple MTL formulas", "[translator]")
 		CHECK(!ata.accepts_word({{"a", 0}, {"b", 1}, {"a", 2.1}, {"b", 4}}));
 		CHECK(ata.accepts_word({{"a", 0}, {"b", 1}, {"a", 2}, {"b", 3}, {"a", 4}}));
 	}
+
+	SECTION("Single negation operation")
+	{
+		const MTLFormula phi             = !a;
+		const auto       ata             = translate(phi, {AP("a"), AP("b"), AP("c"), AP("d")});
+		const auto       ata_no_alphabet = translate(phi);
+
+		INFO("ATA:\n" << ata);
+		CHECK(ata.accepts_word({{"b", 0}}));
+		CHECK(ata.accepts_word({{"b", 0}, {"c", 1}}));
+		CHECK(ata.accepts_word({{"b", 0}, {"a", 1}}));
+		CHECK(!ata.accepts_word({{"a", 0}}));
+		CHECK(!ata.accepts_word({{"a", 0}, {"b", 1}}));
+
+		CHECK(!ata_no_alphabet.accepts_word({{"b", 0}}));
+		CHECK(!ata_no_alphabet.accepts_word({{"b", 0}, {"c", 1}}));
+		CHECK(!ata_no_alphabet.accepts_word({{"b", 0}, {"a", 1}}));
+		CHECK(!ata_no_alphabet.accepts_word({{"a", 0}}));
+		CHECK(!ata_no_alphabet.accepts_word({{"a", 0}, {"b", 1}}));
+	}
+
+	SECTION("Single conjunction of two different APs")
+	{
+		// TODO Conjunction of AP does not really make sense, since we can only read single symbols on a
+		// transition
+		const MTLFormula phi = a && b;
+		const auto       ata = translate(phi, {AP("a"), AP("b"), AP("c"), AP("d")});
+
+		INFO("ATA:\n" << ata);
+		CHECK(!ata.accepts_word({{"b", 0}}));
+		CHECK(!ata.accepts_word({{"a", 0}}));
+	}
+
+	SECTION("Single conjunction of two similar APs")
+	{
+		const MTLFormula phi = a && a;
+		const auto       ata = translate(phi, {AP("a"), AP("b"), AP("c"), AP("d")});
+
+		INFO("ATA:\n" << ata);
+		CHECK(!ata.accepts_word({{"b", 0}}));
+		CHECK(ata.accepts_word({{"a", 0}}));
+	}
+
+	SECTION("Single disjunction of two APs")
+	{
+		const MTLFormula phi = a || b;
+		const auto       ata = translate(phi, {AP("a"), AP("b"), AP("c"), AP("d")});
+
+		INFO("ATA:\n" << ata);
+		CHECK(ata.accepts_word({{"b", 0}}));
+		CHECK(ata.accepts_word({{"a", 0}}));
+		CHECK(!ata.accepts_word({{"c", 0}}));
+		CHECK(!ata.accepts_word({{"d", 0}}));
+	}
+
+	SECTION("Simple tautology")
+	{
+		const MTLFormula phi = a || !a;
+		const auto       ata = translate(phi, {AP("a"), AP("b"), AP("c"), AP("d")});
+
+		INFO("ATA:\n" << ata);
+		CHECK(ata.accepts_word({{"b", 0}}));
+		CHECK(ata.accepts_word({{"a", 0}}));
+		CHECK(ata.accepts_word({{"c", 0}}));
+		CHECK(ata.accepts_word({{"d", 0}}));
+	}
+
+	SECTION("Simple unsatisfiable ata")
+	{
+		const MTLFormula phi = a && !a;
+		const auto       ata = translate(phi, {AP("a"), AP("b"), AP("c"), AP("d")});
+
+		INFO("ATA:\n" << ata);
+		CHECK(!ata.accepts_word({{"b", 0}}));
+		CHECK(!ata.accepts_word({{"a", 0}}));
+		CHECK(!ata.accepts_word({{"c", 0}}));
+		CHECK(!ata.accepts_word({{"d", 0}}));
+	}
 }
 
 TEST_CASE("MTL ATA Translation exceptions", "[translator][exceptions]")

--- a/test/test_search.cpp
+++ b/test/test_search.cpp
@@ -79,7 +79,7 @@ TEST_CASE("Search in an ABConfiguration tree", "[search]")
 	{
 		CHECK(search.get_root()->words
 		      == std::set{CanonicalABWord({{TARegionState{Location{"l0"}, "x", 0},
-		                                    ATARegionState{logic::MTLFormula{AP{"phi_i"}}, 0}}})});
+		                                    ATARegionState{logic::MTLFormula{AP{"l0"}}, 0}}})});
 		CHECK(search.get_root()->state == NodeState::UNKNOWN);
 		CHECK(search.get_root()->parent == nullptr);
 		CHECK(search.get_root()->incoming_actions.empty());

--- a/test/test_synchronous_product.cpp
+++ b/test/test_synchronous_product.cpp
@@ -417,7 +417,7 @@ TEST_CASE("Get the next canonical word(s)", "[canonical_word]")
 	INFO("Initial word: " << initial_word);
 	CHECK(initial_word
 	      == CanonicalABWord({{TARegionState{Location{"l0"}, "x", 0},
-	                           ATARegionState{logic::MTLFormula{AP{"phi_i"}}, 0}}}));
+	                           ATARegionState{logic::MTLFormula{AP{"l0"}}, 0}}}));
 	auto next_words = synchronous_product::get_next_canonical_words(ta, ata, initial_word, 2);
 	INFO("Next words: " << next_words);
 	// TODO actually test what the word is.


### PR DESCRIPTION
Adds support for the translation of MTL-formulas which do not have until or dual-until as the outermost connective.

Exploits existing functions which already supported nesting formulas of different types, the only difference is to add an initial location (similar to the phi_i) explicitly for all formulas.