### PR TITLE
Do not cancel labeled nodes and avoid race while labeling

### DIFF
--- a/src/synchronous_product/include/synchronous_product/search_tree.h
+++ b/src/synchronous_product/include/synchronous_product/search_tree.h
@@ -82,8 +82,12 @@ struct SearchTreeNode
 	set_label(NodeLabel new_label, bool cancel_children = false)
 	{
 		assert(new_label != NodeLabel::UNLABELED);
+		if (label != NodeLabel::UNLABELED) {
+			// Node already labeled, cancel.
+			return;
+		}
 		label = new_label;
-		if (cancel_children && is_expanded && new_label != NodeLabel::UNLABELED) {
+		if (cancel_children && is_expanded) {
 			for (const auto &child : children) {
 				child->set_label(NodeLabel::CANCELED, true);
 			}

--- a/src/synchronous_product/include/synchronous_product/search_tree.h
+++ b/src/synchronous_product/include/synchronous_product/search_tree.h
@@ -143,17 +143,19 @@ struct SearchTreeNode
 		RegionIndex    first_non_good_environment_step{max};
 		RegionIndex    first_bad_environment_step{max};
 		for (const auto &child : children) {
+			// Copy label to avoid races while checking the conditions below.
+			const NodeLabel child_label = child->label;
 			for (const auto &[step, action] : child->incoming_actions) {
-				if (child->label == NodeLabel::TOP
+				if (child_label == NodeLabel::TOP
 				    && controller_actions.find(action) != std::end(controller_actions)) {
 					first_good_controller_step = std::min(first_good_controller_step, step);
-				} else if (child->label == NodeLabel::BOTTOM
+				} else if (child_label == NodeLabel::BOTTOM
 				           && environment_actions.find(action) != std::end(environment_actions)) {
 					first_bad_environment_step = std::min(first_bad_environment_step, step);
-				} else if (child->label == NodeLabel::UNLABELED
+				} else if (child_label == NodeLabel::UNLABELED
 				           && environment_actions.find(action) != std::end(environment_actions)) {
 					first_non_good_environment_step = std::min(first_non_good_environment_step, step);
-				} else if (child->label == NodeLabel::UNLABELED
+				} else if (child_label == NodeLabel::UNLABELED
 				           && controller_actions.find(action) != std::end(controller_actions)) {
 					first_non_bad_controller_step = std::min(first_non_bad_controller_step, step);
 				}


### PR DESCRIPTION
If a node has been labeled already, do not set it to canceled.

Also avoid a race condition during labeling. This may occur if a child's label is changed while we are iterating over its incoming actions, possibly resulting in a wrong label of the parent.