### PR TITLE
Scale railroad example to multiple crossings

### DIFF
--- a/src/synchronous_product/include/synchronous_product/search.h
+++ b/src/synchronous_product/include/synchronous_product/search.h
@@ -55,7 +55,7 @@ public:
 	 * @param incremental_labeling True, if incremental labeling should be used (default=false)
 	 * @param terminate_early If true, cancel the children of a node that has already been labeled
 	 */
-	TreeSearch(automata::ta::TimedAutomaton<Location, ActionType> *                            ta,
+	TreeSearch(const automata::ta::TimedAutomaton<Location, ActionType> *                      ta,
 	           automata::ata::AlternatingTimedAutomaton<logic::MTLFormula<ActionType>,
 	                                                    logic::AtomicProposition<ActionType>> *ata,
 	           std::set<ActionType> controller_actions,
@@ -300,9 +300,9 @@ public:
 	}
 
 private:
-	automata::ta::TimedAutomaton<Location, ActionType> *                            ta_;
-	automata::ata::AlternatingTimedAutomaton<logic::MTLFormula<ActionType>,
-	                                         logic::AtomicProposition<ActionType>> *ata_;
+	const automata::ta::TimedAutomaton<Location, ActionType> *const                             ta_;
+	const automata::ata::AlternatingTimedAutomaton<logic::MTLFormula<ActionType>,
+	                                               logic::AtomicProposition<ActionType>> *const ata_;
 
 	const std::set<ActionType> controller_actions_;
 	const std::set<ActionType> environment_actions_;

--- a/test/test_railroad.cpp
+++ b/test/test_railroad.cpp
@@ -40,70 +40,92 @@ using AP = logic::AtomicProposition<std::string>;
 using synchronous_product::NodeLabel;
 using TreeSearch = synchronous_product::TreeSearch<std::vector<std::string>, std::string>;
 
+std::tuple<automata::ta::TimedAutomaton<std::vector<std::string>, std::string>,
+           std::set<std::string>,
+           std::set<std::string>>
+create_crossing_problem(std::vector<Time> distances)
+{
+	std::vector<TA>         automata;
+	std::set<std::string>   crossing_actions;
+	std::set<std::string>   train_actions;
+	std::set<Location>      train_locations;
+	std::vector<Transition> train_transitions;
+	for (std::size_t i = 1; i <= distances.size(); ++i) {
+		const std::string clock        = "c_" + std::to_string(i);
+		const std::string start_close  = "start_close_" + std::to_string(i);
+		const std::string finish_close = "finish_close_" + std::to_string(i);
+		const std::string start_open   = "start_open_" + std::to_string(i);
+		const std::string finish_open  = "finish_open_" + std::to_string(i);
+		crossing_actions.insert({start_close, finish_close, start_open, finish_open});
+		automata.push_back(
+		  TA{{Location{"OPEN"}, Location{"CLOSING"}, Location{"CLOSED"}, Location{"OPENING"}},
+		     {start_close, finish_close, start_open, finish_open},
+		     Location{"OPEN"},
+		     {Location{"OPEN"}},
+		     {clock},
+		     {Transition(Location{"OPEN"}, start_close, Location{"CLOSING"}, {}, {clock}),
+		      Transition(Location{"CLOSING"},
+		                 finish_close,
+		                 Location{"CLOSED"},
+		                 {{clock, AtomicClockConstraintT<std::equal_to<Time>>(4)}},
+		                 {clock}),
+		      Transition(Location{"CLOSED"},
+		                 start_open,
+		                 Location{"OPENING"},
+		                 {{clock, AtomicClockConstraintT<std::greater_equal<Time>>(1)}},
+		                 {clock}),
+		      Transition(Location{"OPENING"},
+		                 finish_open,
+		                 Location{"OPEN"},
+		                 {{clock, AtomicClockConstraintT<std::equal_to<Time>>(3)}},
+		                 {clock})}});
+		const std::string i_s = std::to_string(i);
+		const auto        far = i == 1 ? Location{"FAR"} : Location{"BEHIND_" + std::to_string(i - 1)};
+		const Location    near{"NEAR_" + i_s};
+		const Location    in{"IN_" + i_s};
+		const Location    behind{"BEHIND_" + i_s};
+		train_locations.insert({far, near, in, behind});
+		const std::string get_near{"get_near_" + i_s};
+		const std::string enter{"enter_" + i_s};
+		const std::string leave{"leave_" + i_s};
+		train_actions.insert({get_near, enter, leave});
+		train_transitions.push_back(
+		  Transition{far,
+		             get_near,
+		             near,
+		             {{"t", AtomicClockConstraintT<std::greater<Time>>(distances[i - 1])}},
+		             {"t"}});
+		train_transitions.push_back(
+		  Transition{near, enter, in, {{"t", AtomicClockConstraintT<std::greater<Time>>(2)}}, {"t"}});
+		train_transitions.push_back(Transition{
+		  in, leave, behind, {{"t", AtomicClockConstraintT<std::equal_to<Time>>(1)}}, {"t"}});
+	}
+	automata.push_back(TA{train_locations,
+	                      train_actions,
+	                      Location{"FAR"},
+	                      {Location{"BEHIND_" + std::to_string(distances.size())}},
+	                      {"t"},
+	                      train_transitions});
+	return std::make_tuple(automata::ta::get_product(automata), crossing_actions, train_actions);
+}
+
 TEST_CASE("A single railroad crossing", "[railroad]")
 {
 	spdlog::set_level(spdlog::level::trace);
 	spdlog::set_pattern("%t %v");
-	std::set<std::string> crossing_actions{"start_close",
-	                                       "finish_close",
-	                                       "start_open",
-	                                       "finish_open"};
-	TA crossing{{Location{"OPEN"}, Location{"CLOSING"}, Location{"CLOSED"}, Location{"OPENING"}},
-	            crossing_actions,
-	            Location{"OPEN"},
-	            {Location{"OPEN"}},
-	            {"x"},
-	            {Transition(Location{"OPEN"}, "start_close", Location{"CLOSING"}, {}, {"x"}),
-	             Transition(Location{"CLOSING"},
-	                        "finish_close",
-	                        Location{"CLOSED"},
-	                        {{"x", AtomicClockConstraintT<std::equal_to<Time>>(4)}},
-	                        {"x"}),
-	             Transition(Location{"CLOSED"},
-	                        "start_open",
-	                        Location{"OPENING"},
-	                        {{"x", AtomicClockConstraintT<std::greater_equal<Time>>(1)}},
-	                        {"x"}),
-	             Transition(Location{"OPENING"},
-	                        "finish_open",
-	                        Location{"OPEN"},
-	                        {{"x", AtomicClockConstraintT<std::equal_to<Time>>(3)}},
-	                        {"x"})}};
-	std::set<std::string> train_actions{"get_near", "enter", "leave"};
-	TA           train{{Location{"FAR"}, Location{"NEAR"}, Location{"IN"}, Location{"BEHIND"}},
-           train_actions,
-           Location{"FAR"},
-           {Location{"BEHIND"}},
-           {"t"},
-           {Transition(Location{"FAR"},
-                       "get_near",
-                       Location{"NEAR"},
-                       {{"t", AtomicClockConstraintT<std::greater<Time>>(10)}},
-                       {"t"}),
-            Transition(Location{"NEAR"},
-                       "enter",
-                       Location{"IN"},
-                       {{"t", AtomicClockConstraintT<std::greater<Time>>(2)}},
-                       {"t"}),
-            Transition(Location{"IN"},
-                       "leave",
-                       Location{"BEHIND"},
-                       {{"t", AtomicClockConstraintT<std::equal_to<Time>>(1)}},
-                       {"t"})}
-
-  };
-	auto         product = automata::ta::get_product<std::string, std::string>({crossing, train});
+	const auto &[product, crossing_actions, train_actions] = create_crossing_problem({5});
 	std::set<AP> actions;
 	std::set_union(begin(crossing_actions),
 	               end(crossing_actions),
 	               begin(train_actions),
 	               end(train_actions),
 	               inserter(actions, end(actions)));
-	auto ata = mtl_ata_translation::translate(F{AP{"true"}}.until(!AP{"enter"} || AP{"finish_close"}),
-	                                          actions);
+	auto ata =
+	  mtl_ata_translation::translate(F{AP{"true"}}.until(!AP{"enter_1"} || AP{"finish_close_1"}),
+	                                 actions);
 	INFO("TA: " << product);
 	INFO("ATA: " << ata);
-	TreeSearch search{&product, &ata, crossing_actions, train_actions, 10, true, true};
+	TreeSearch search{&product, &ata, crossing_actions, train_actions, 5, true, true};
 	search.build_tree(true);
 	std::stringstream str;
 	print_to_ostream(str, *search.get_root(), true);

--- a/test/test_railroad.cpp
+++ b/test/test_railroad.cpp
@@ -94,12 +94,11 @@ TEST_CASE("A single railroad crossing", "[railroad]")
   };
 	auto         product = automata::ta::get_product<std::string, std::string>({crossing, train});
 	std::set<AP> actions;
-	for (const auto &action : crossing_actions) {
-		actions.insert(AP{action});
-	}
-	for (const auto &action : train_actions) {
-		actions.insert(AP{action});
-	}
+	std::set_union(begin(crossing_actions),
+	               end(crossing_actions),
+	               begin(train_actions),
+	               end(train_actions),
+	               inserter(actions, end(actions)));
 	auto ata = mtl_ata_translation::translate(F{AP{"true"}}.until(!AP{"enter"} || AP{"finish_close"}),
 	                                          actions);
 	INFO("TA: " << product);

--- a/test/test_railroad.cpp
+++ b/test/test_railroad.cpp
@@ -48,45 +48,50 @@ TEST_CASE("A single railroad crossing", "[railroad]")
 	                                       "finish_close",
 	                                       "start_open",
 	                                       "finish_open"};
-	TA                    crossing{crossing_actions, Location{"OPEN"}, {Location{"OPEN"}}};
-	crossing.add_clock("x");
-	crossing.add_locations({Location{"CLOSING"}, Location{"CLOSED"}, Location{"OPENING"}});
-	crossing.add_transition(
-	  Transition(Location{"OPEN"}, "start_close", Location{"CLOSING"}, {}, {"x"}));
-	crossing.add_transition(Transition(Location{"CLOSING"},
-	                                   "finish_close",
-	                                   Location{"CLOSED"},
-	                                   {{"x", AtomicClockConstraintT<std::equal_to<Time>>(4)}},
-	                                   {"x"}));
-	crossing.add_transition(Transition(Location{"CLOSED"},
-	                                   "start_open",
-	                                   Location{"OPENING"},
-	                                   {{"x", AtomicClockConstraintT<std::greater_equal<Time>>(1)}},
-	                                   {"x"}));
-	crossing.add_transition(Transition(Location{"OPENING"},
-	                                   "finish_open",
-	                                   Location{"OPEN"},
-	                                   {{"x", AtomicClockConstraintT<std::equal_to<Time>>(3)}},
-	                                   {"x"}));
+	TA crossing{{Location{"OPEN"}, Location{"CLOSING"}, Location{"CLOSED"}, Location{"OPENING"}},
+	            crossing_actions,
+	            Location{"OPEN"},
+	            {Location{"OPEN"}},
+	            {"x"},
+	            {Transition(Location{"OPEN"}, "start_close", Location{"CLOSING"}, {}, {"x"}),
+	             Transition(Location{"CLOSING"},
+	                        "finish_close",
+	                        Location{"CLOSED"},
+	                        {{"x", AtomicClockConstraintT<std::equal_to<Time>>(4)}},
+	                        {"x"}),
+	             Transition(Location{"CLOSED"},
+	                        "start_open",
+	                        Location{"OPENING"},
+	                        {{"x", AtomicClockConstraintT<std::greater_equal<Time>>(1)}},
+	                        {"x"}),
+	             Transition(Location{"OPENING"},
+	                        "finish_open",
+	                        Location{"OPEN"},
+	                        {{"x", AtomicClockConstraintT<std::equal_to<Time>>(3)}},
+	                        {"x"})}};
 	std::set<std::string> train_actions{"get_near", "enter", "leave"};
-	TA                    train{train_actions, Location{"FAR"}, {Location{"BEHIND"}}};
-	train.add_clock("t");
-	train.add_locations({Location{"FAR"}, Location{"NEAR"}, Location{"IN"}, Location{"BEHIND"}});
-	train.add_transition(Transition(Location{"FAR"},
-	                                "get_near",
-	                                Location{"NEAR"},
-	                                {{"t", AtomicClockConstraintT<std::greater<Time>>(10)}},
-	                                {"t"}));
-	train.add_transition(Transition(Location{"NEAR"},
-	                                "enter",
-	                                Location{"IN"},
-	                                {{"t", AtomicClockConstraintT<std::greater<Time>>(2)}},
-	                                {"t"}));
-	train.add_transition(Transition(Location{"IN"},
-	                                "leave",
-	                                Location{"BEHIND"},
-	                                {{"t", AtomicClockConstraintT<std::equal_to<Time>>(1)}},
-	                                {"t"}));
+	TA           train{{Location{"FAR"}, Location{"NEAR"}, Location{"IN"}, Location{"BEHIND"}},
+           train_actions,
+           Location{"FAR"},
+           {Location{"BEHIND"}},
+           {"t"},
+           {Transition(Location{"FAR"},
+                       "get_near",
+                       Location{"NEAR"},
+                       {{"t", AtomicClockConstraintT<std::greater<Time>>(10)}},
+                       {"t"}),
+            Transition(Location{"NEAR"},
+                       "enter",
+                       Location{"IN"},
+                       {{"t", AtomicClockConstraintT<std::greater<Time>>(2)}},
+                       {"t"}),
+            Transition(Location{"IN"},
+                       "leave",
+                       Location{"BEHIND"},
+                       {{"t", AtomicClockConstraintT<std::equal_to<Time>>(1)}},
+                       {"t"})}
+
+  };
 	auto         product = automata::ta::get_product<std::string, std::string>({crossing, train});
 	std::set<AP> actions;
 	for (const auto &action : crossing_actions) {


### PR DESCRIPTION
Extend the railroad example so it allows multiple crossings.

This does not contain yet any other fixes that are pending.