### PR TITLE
Add visualization of a TA as dot graph

### DIFF
--- a/src/utilities/graphviz/include/utilities/graphviz/graphviz.h
+++ b/src/utilities/graphviz/include/utilities/graphviz/graphviz.h
@@ -42,6 +42,10 @@ class Node
 	friend Graph;
 
 public:
+	/** Default constructor. */
+	Node() : node(nullptr)
+	{
+	}
 	/** Set a property to the given value.
 	 * @param property The property to set, e.g., label
 	 * @param value The value to set, e.g., the value of the label

--- a/src/utilities/graphviz/node.cpp
+++ b/src/utilities/graphviz/node.cpp
@@ -29,9 +29,11 @@ Node::Node(Agnode_t *ag_node) : node(ag_node)
 void
 Node::set_property(const std::string &property, const std::string &value)
 {
-	std::string p = property;
-	std::string v = value;
-	agsafeset(node, p.data(), v.data(), std::string().data());
+	if (node) {
+		std::string p = property;
+		std::string v = value;
+		agsafeset(node, p.data(), v.data(), std::string().data());
+	}
 }
 
 } // namespace utilities::graphviz

--- a/src/visualization/CMakeLists.txt
+++ b/src/visualization/CMakeLists.txt
@@ -1,6 +1,6 @@
 if (TARGET graphviz)
   find_package(fmt REQUIRED)
-  add_library(visualization SHARED tree_to_graphviz.cpp)
+  add_library(visualization SHARED visualization.cpp)
   target_link_libraries(visualization PUBLIC graphviz synchronous_product fmt::fmt)
   target_include_directories(visualization PUBLIC include)
 endif()

--- a/src/visualization/include/visualization/ta_to_graphviz.h
+++ b/src/visualization/include/visualization/ta_to_graphviz.h
@@ -47,9 +47,8 @@ ta_to_graphviz(const automata::ta::TimedAutomaton<LocationT, ActionT> &ta)
 	}
 	for (const auto &[source, transition] : ta.get_transitions()) {
 		std::stringstream edge;
-		edge << " " << transition.symbol_ << "\n"
-		     << transition.clock_constraints_ << "\n"
-		     << fmt::format("{{{}}}", fmt::join(transition.clock_resets_, ", "));
+		edge << " " << transition.symbol_ << " \n " << transition.clock_constraints_ << " \n "
+		     << fmt::format("{{{}}}", fmt::join(transition.clock_resets_, ", ")) << " ";
 		g.add_edge(nodes[transition.source_], nodes[transition.target_], edge.str());
 	}
 	return g;

--- a/src/visualization/include/visualization/ta_to_graphviz.h
+++ b/src/visualization/include/visualization/ta_to_graphviz.h
@@ -1,0 +1,56 @@
+/***************************************************************************
+ *  ta_to_graphviz.h - Generate a graphviz representation of a TA
+ *
+ *  Created:   Fri 16 Apr 09:15:33 CEST 2021
+ *  Copyright  2021  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ ****************************************************************************/
+/*  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Library General Public License for more details.
+ *
+ *  Read the full text in the LICENSE.md file.
+ */
+
+#pragma once
+
+#include <automata/ta.h>
+#include <fmt/format.h>
+#include <utilities/graphviz/graphviz.h>
+
+/** Generate a dot graph from a timed automaton.
+ * @param ta The timed automaton to visualize
+ * @return The ta as dot graph
+ */
+template <typename LocationT, typename ActionT>
+utilities::graphviz::Graph
+ta_to_graphviz(const automata::ta::TimedAutomaton<LocationT, ActionT> &ta)
+{
+	utilities::graphviz::Graph                                             g;
+	std::map<automata::ta::Location<LocationT>, utilities::graphviz::Node> nodes;
+	auto initial_node = g.add_node("");
+	initial_node.set_property("shape", "none");
+	for (const auto &location : ta.get_locations()) {
+		std::stringstream str;
+		// Use stream operator of the location.
+		str << location;
+		nodes.insert(std::make_pair(location, g.add_node(str.str())));
+	}
+	g.add_edge(initial_node, nodes[ta.get_initial_location()]);
+	for (const auto &final_location : ta.get_final_locations()) {
+		nodes[final_location].set_property("peripheries", "2");
+	}
+	for (const auto &[source, transition] : ta.get_transitions()) {
+		std::stringstream edge;
+		edge << " " << transition.symbol_ << "\n"
+		     << transition.clock_constraints_ << "\n"
+		     << fmt::format("{{{}}}", fmt::join(transition.clock_resets_, ", "));
+		g.add_edge(nodes[transition.source_], nodes[transition.target_], edge.str());
+	}
+	return g;
+}

--- a/src/visualization/include/visualization/tree_to_graphviz.h
+++ b/src/visualization/include/visualization/tree_to_graphviz.h
@@ -27,6 +27,13 @@
 
 namespace visualization {
 
+/** @brief Add a search tree node to a dot graph visualization of the search tree.
+ * Add node as dot node to thegraph. Additionally, add all its children along
+ * with edges from the given node to its children.
+ * @param search_node The node to add to the graph
+ * @param graph The graph to add the node to
+ * @return The graphviz node, which can be used as reference for adding additional edges.
+ */
 template <typename LocationT, typename ActionT>
 utilities::graphviz::Node
 add_search_node_to_graph(const synchronous_product::SearchTreeNode<LocationT, ActionT> *search_node,
@@ -70,7 +77,7 @@ add_search_node_to_graph(const synchronous_product::SearchTreeNode<LocationT, Ac
 
 /** @brief Generate a graphviz graph visualizing the search tree.
  * @param search_node The root node of the tree
- * @return A graphviz graph
+ * @return The search tree converted to a dot graph
  */
 template <typename LocationT, typename ActionT>
 utilities::graphviz::Graph

--- a/src/visualization/visualization.cpp
+++ b/src/visualization/visualization.cpp
@@ -1,0 +1,20 @@
+/***************************************************************************
+ *  visualization.cpp - Visualization with graphviz
+ *
+ *  Created:   Fri 16 Apr 09:16:07 CEST 2021
+ *  Copyright  2021  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ ****************************************************************************/
+/*  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Library General Public License for more details.
+ *
+ *  Read the full text in the LICENSE.md file.
+ */
+
+// Empty source file to avoid clangd errors with header-only libraries.

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -97,6 +97,11 @@ if (TARGET visualization)
   add_executable(test_tree_visualization test_tree_visualization.cpp)
   target_link_libraries(test_tree_visualization PRIVATE visualization Catch2::Catch2WithMain)
   catch_discover_tests(test_tree_visualization)
+
+  find_package(fmt REQUIRED)
+  add_executable(test_ta_visualization test_ta_visualization.cpp)
+  target_link_libraries(test_ta_visualization PRIVATE visualization fmt::fmt Catch2::Catch2WithMain)
+  catch_discover_tests(test_ta_visualization)
 endif()
 
 

--- a/test/test_graphviz.cpp
+++ b/test/test_graphviz.cpp
@@ -54,6 +54,7 @@ TEST_CASE("Create a graphviz graph", "[utilities][graphviz]")
 	CHECK_THAT(dot, Contains("color=green"));
 	g.render_to_file("graphviz.png");
 	CHECK_THROWS(g.render_to_file("nosuffix"));
+	CHECK_NOTHROW(utilities::graphviz::Node{}.set_property("color", "red"));
 }
 
 } // namespace

--- a/test/test_ta_visualization.cpp
+++ b/test/test_ta_visualization.cpp
@@ -1,0 +1,54 @@
+/***************************************************************************
+ *  test_ta_visualization.cpp - Test the graphviz visualization of a TA
+ *
+ *  Created:   Sat 17 Apr 14:45:55 CEST 2021
+ *  Copyright  2021  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ ****************************************************************************/
+/*  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Library General Public License for more details.
+ *
+ *  Read the full text in the LICENSE.md file.
+ */
+
+#include "automata/automata.h"
+#include "automata/ta.h"
+#include "visualization/ta_to_graphviz.h"
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_string.hpp>
+
+namespace {
+
+using TA         = automata::ta::TimedAutomaton<std::string, std::string>;
+using Location   = automata::ta::Location<std::string>;
+using Transition = automata::ta::Transition<std::string, std::string>;
+
+using Catch::Matchers::Contains;
+TEST_CASE("Visualize a TA", "[visualization]")
+{
+	TA   ta{{Location{"l0"}, Location{"l1"}},
+        {"a", "b"},
+        Location{"l0"},
+        {Location{"l1"}},
+        {"c", "x"},
+        {Transition{Location{"l0"},
+                    "a",
+                    Location{"l1"},
+                    {{"c", automata::AtomicClockConstraintT<std::less<automata::Time>>{2}}},
+                    {"c"}}}};
+	auto g   = ta_to_graphviz(ta);
+	auto dot = g.to_dot();
+	CHECK_THAT(dot, Contains("label=l0"));
+	CHECK_THAT(dot, Contains("label=l1"));
+	CHECK_THAT(dot, Contains("c < 2"));
+	CHECK_THAT(dot, Contains("{c}"));
+}
+
+} // namespace


### PR DESCRIPTION
Generate a dot graph for a TA. As an example, this is what the railroad product TA looks like:
![ta_product](https://user-images.githubusercontent.com/4573064/115119768-630d3a00-9faa-11eb-8867-448607a3ada0.png)

