### PR TITLE
Feature/synchronized actions

### DIFF
--- a/src/automata/include/automata/automata.h
+++ b/src/automata/include/automata/automata.h
@@ -232,6 +232,46 @@ private:
 
 bool is_satisfied(const ClockConstraint &constraint, const ClockValuation &valuation);
 
+inline std::size_t
+get_relation_index(const ClockConstraint &constraint)
+{
+	if (std::holds_alternative<AtomicClockConstraintT<std::less<Time>>>(constraint)) {
+		return 0;
+	} else if (std::holds_alternative<AtomicClockConstraintT<std::less_equal<Time>>>(constraint)) {
+		return 1;
+	} else if (std::holds_alternative<AtomicClockConstraintT<std::equal_to<Time>>>(constraint)) {
+		return 2;
+	} else if (std::holds_alternative<AtomicClockConstraintT<std::not_equal_to<Time>>>(constraint)) {
+		return 3;
+	} else if (std::holds_alternative<AtomicClockConstraintT<std::greater_equal<Time>>>(constraint)) {
+		return 4;
+	} else if (std::holds_alternative<AtomicClockConstraintT<std::greater<Time>>>(constraint)) {
+		return 5;
+	} else {
+		assert(false);
+	}
+}
+
+inline bool
+operator<(const ClockConstraint &lhs, const ClockConstraint &rhs)
+{
+	auto lhs_idx = get_relation_index(lhs);
+	auto rhs_idx = get_relation_index(rhs);
+	if (lhs_idx < rhs_idx) {
+		return true;
+	} else if (lhs_idx == rhs_idx) {
+		Time lhs_time = std::visit([](const auto &atomic_clock_constraint)
+		                             -> Time { return atomic_clock_constraint.get_comparand(); },
+		                           lhs);
+		Time rhs_time = std::visit([](const auto &atomic_clock_constraint)
+		                             -> Time { return atomic_clock_constraint.get_comparand(); },
+		                           lhs);
+		return lhs_time < rhs_time;
+	} else {
+		return false;
+	}
+}
+
 } // namespace automata
 
 #include "automata.hpp"

--- a/src/automata/include/automata/automata.h
+++ b/src/automata/include/automata/automata.h
@@ -257,6 +257,7 @@ operator<(const ClockConstraint &lhs, const ClockConstraint &rhs)
 {
 	auto lhs_idx = get_relation_index(lhs);
 	auto rhs_idx = get_relation_index(rhs);
+	std::cout << "lhs_id: " << lhs_idx << " rhs_id: " << rhs_idx << std::endl;
 	if (lhs_idx < rhs_idx) {
 		return true;
 	} else if (lhs_idx == rhs_idx) {
@@ -265,7 +266,9 @@ operator<(const ClockConstraint &lhs, const ClockConstraint &rhs)
 		                           lhs);
 		Time rhs_time = std::visit([](const auto &atomic_clock_constraint)
 		                             -> Time { return atomic_clock_constraint.get_comparand(); },
-		                           lhs);
+		                           rhs);
+		std::cout << "lhs: " << lhs_time << " rhs: " << rhs_time << std::endl;
+
 		return lhs_time < rhs_time;
 	} else {
 		return false;

--- a/src/automata/include/automata/ta.h
+++ b/src/automata/include/automata/ta.h
@@ -184,6 +184,9 @@ public:
 	std::set<std::string>                       clock_resets_;      ///< resets
 };
 
+template <typename LocationT, typename AP>
+bool operator<(const Transition<LocationT, AP> &lhs, const Transition<LocationT, AP> &rhs);
+
 /// One specific (finite) path in the timed automaton.
 template <typename LocationT, typename AP>
 class Path

--- a/src/automata/include/automata/ta.hpp
+++ b/src/automata/include/automata/ta.hpp
@@ -162,6 +162,8 @@ operator<(const Transition<LocationT, AP> &lhs, const Transition<LocationT, AP> 
 		if (lhs_clocks_it->first == rhs_clocks_it->first) {
 			// compare the constraints on a single clock, if clocks are equal
 			if (lhs_clocks_it->second == rhs_clocks_it->second) {
+				++lhs_clocks_it;
+				++rhs_clocks_it;
 				continue;
 			} else {
 				return lhs_clocks_it->second < rhs_clocks_it->second;
@@ -181,6 +183,13 @@ operator<(const Transition<LocationT, AP> &lhs, const Transition<LocationT, AP> 
 	}
 	// both are equal
 	return false;
+}
+
+template <typename LocationT, typename AP>
+bool
+operator>(const Transition<LocationT, AP> &lhs, const Transition<LocationT, AP> &rhs)
+{
+	return rhs < lhs;
 }
 
 template <typename LocationT, typename AP>

--- a/src/automata/include/automata/ta.hpp
+++ b/src/automata/include/automata/ta.hpp
@@ -123,6 +123,64 @@ operator==(const Transition<LocationT, AP> &lhs, const Transition<LocationT, AP>
 }
 
 template <typename LocationT, typename AP>
+bool
+operator<(const Transition<LocationT, AP> &lhs, const Transition<LocationT, AP> &rhs)
+{
+	// cheap checks first
+	if (lhs.source_ < rhs.source_) {
+		return true;
+	} else if (lhs.source_ > rhs.source_) {
+		return false;
+	}
+
+	if (lhs.target_ < rhs.target_) {
+		return true;
+	} else if (lhs.target_ > rhs.target_) {
+		return false;
+	}
+
+	if (lhs.symbol_ < rhs.symbol_) {
+		return true;
+	} else if (lhs.symbol_ > rhs.symbol_) {
+		return false;
+	}
+
+	if (lhs.clock_resets_ < rhs.clock_resets_) {
+		return true;
+	} else if (lhs.clock_resets_ > rhs.clock_resets_) {
+		return false;
+	}
+	// compare clock constraints
+	auto lhs_clocks_it = std::begin(lhs.clock_constraints_);
+	auto rhs_clocks_it = std::begin(rhs.clock_constraints_);
+	while (lhs_clocks_it != std::end(lhs.clock_constraints_)
+	       && rhs_clocks_it != std::end(rhs.clock_constraints_)) {
+		// compare which clocks are constrained
+		if (lhs_clocks_it->first == rhs_clocks_it->first) {
+			// compare the constraints on a single clock, if clocks are equal
+			if (lhs_clocks_it->second == rhs_clocks_it->second) {
+				continue;
+			} else {
+				lhs_clocks_it->second < rhs_clocks_it->second;
+			}
+		} else {
+			return lhs_clocks_it->first < rhs_clocks_it->first;
+		}
+		++lhs_clocks_it;
+		++rhs_clocks_it;
+	}
+	if (lhs_clocks_it == std::end(lhs.clock_constraints_)
+	    && rhs_clocks_it != std::end(rhs.clock_constraints_)) {
+		return true;
+	} else if (lhs_clocks_it != std::end(lhs.clock_constraints_)
+	           && rhs_clocks_it == std::end(rhs.clock_constraints_)) {
+		return false;
+	}
+	// both are equal
+	return false;
+}
+
+template <typename LocationT, typename AP>
 Path<LocationT, AP>::Path(LocationT initial_location, std::set<std::string> clocks)
 : current_location_(initial_location), tick_(0)
 {

--- a/src/automata/include/automata/ta.hpp
+++ b/src/automata/include/automata/ta.hpp
@@ -164,7 +164,7 @@ operator<(const Transition<LocationT, AP> &lhs, const Transition<LocationT, AP> 
 			if (lhs_clocks_it->second == rhs_clocks_it->second) {
 				continue;
 			} else {
-				lhs_clocks_it->second < rhs_clocks_it->second;
+				return lhs_clocks_it->second < rhs_clocks_it->second;
 			}
 		} else {
 			return lhs_clocks_it->first < rhs_clocks_it->first;

--- a/src/automata/include/automata/ta.hpp
+++ b/src/automata/include/automata/ta.hpp
@@ -130,9 +130,11 @@ bool
 operator<(const Transition<LocationT, AP> &lhs, const Transition<LocationT, AP> &rhs)
 {
 	// cheap checks first
-	auto left_tie = std::tie(lhs.source_, lhs.target_, lhs.symbol_, lhs.clock_resets));
-	auto right_tie = std::tie(rhs.source_, rhs.target_, rhs.symbol_, rhs.clock_resets));
-	if (left_tie != right_tie) { return left_tie < right_tie; }
+	auto left_tie  = std::tie(lhs.source_, lhs.target_, lhs.symbol_, lhs.clock_resets_);
+	auto right_tie = std::tie(rhs.source_, rhs.target_, rhs.symbol_, rhs.clock_resets_);
+	if (left_tie != right_tie) {
+		return left_tie < right_tie;
+	}
 	// compare clock constraints
 	auto lhs_clocks_it = std::begin(lhs.clock_constraints_);
 	auto rhs_clocks_it = std::begin(rhs.clock_constraints_);

--- a/src/automata/include/automata/ta.hpp
+++ b/src/automata/include/automata/ta.hpp
@@ -130,29 +130,9 @@ bool
 operator<(const Transition<LocationT, AP> &lhs, const Transition<LocationT, AP> &rhs)
 {
 	// cheap checks first
-	if (lhs.source_ < rhs.source_) {
-		return true;
-	} else if (lhs.source_ > rhs.source_) {
-		return false;
-	}
-
-	if (lhs.target_ < rhs.target_) {
-		return true;
-	} else if (lhs.target_ > rhs.target_) {
-		return false;
-	}
-
-	if (lhs.symbol_ < rhs.symbol_) {
-		return true;
-	} else if (lhs.symbol_ > rhs.symbol_) {
-		return false;
-	}
-
-	if (lhs.clock_resets_ < rhs.clock_resets_) {
-		return true;
-	} else if (lhs.clock_resets_ > rhs.clock_resets_) {
-		return false;
-	}
+	auto left_tie = std::tie(lhs.source_, lhs.target_, lhs.symbol_, lhs.clock_resets));
+	auto right_tie = std::tie(rhs.source_, rhs.target_, rhs.symbol_, rhs.clock_resets));
+	if (left_tie != right_tie) { return left_tie < right_tie; }
 	// compare clock constraints
 	auto lhs_clocks_it = std::begin(lhs.clock_constraints_);
 	auto rhs_clocks_it = std::begin(rhs.clock_constraints_);

--- a/src/automata/include/automata/ta.hpp
+++ b/src/automata/include/automata/ta.hpp
@@ -21,6 +21,9 @@
 
 #include "ta.h"
 
+#include <algorithm>
+#include <iterator>
+
 namespace automata::ta {
 
 template <typename LocationT, typename AP>

--- a/src/automata/include/automata/ta_product.h
+++ b/src/automata/include/automata/ta_product.h
@@ -51,6 +51,20 @@ operator<<(std::ostream &os, const Location<std::vector<LocationT>> &product_loc
 	return os;
 }
 
+/**
+ * @brief  Checks which automata may synchronize on which label by comparing the set of
+ * synchronizing labels and the individual alphabets.
+ * @tparam ActionT labeltype
+ * @param synchronized_actions a set of actions which should be synchronized
+ * @param alphabets a vector of alphabets for different ta which should be synchonized
+ * @return std::map<ActionT, std::vector<std::size_t>> a map which assigns each label indices of ta
+ * which synchronize with this label
+ */
+template <typename ActionT>
+std::map<ActionT, std::vector<std::size_t>>
+collect_synchronizing_alphabets(const std::set<ActionT> &             synchronized_actions,
+                                const std::vector<std::set<ActionT>> &alphabets);
+
 /** Compute the product automaton of two timed automata.
  * The resulting automaton's location set is the cartesian product of the
  * input automata's locations.

--- a/src/automata/include/automata/ta_product.hpp
+++ b/src/automata/include/automata/ta_product.hpp
@@ -24,7 +24,6 @@
 
 #include <fmt/core.h>
 #include <fmt/format.h>
-#include <spdlog/spdlog.h>
 
 #include <algorithm>
 #include <ctime>
@@ -171,11 +170,6 @@ get_product(const std::vector<TimedAutomaton<LocationT, ActionT>> &automata,
 								                                 product_target_location,
 								                                 transition.clock_constraints_,
 								                                 transition.clock_resets_);
-								SPDLOG_TRACE("Add non-synchronizing transition  {}",
-								             fmt::format("{} -{}-> {}",
-								                         fmt::join(product_transitions.back().source_.get(), "_"),
-								                         product_transitions.back().symbol_,
-								                         fmt::join(product_transitions.back().target_.get(), "_")));
 							}
 						}
 					} else {
@@ -196,13 +190,6 @@ get_product(const std::vector<TimedAutomaton<LocationT, ActionT>> &automata,
 									                                        product_target_location,
 									                                        transition.clock_constraints_,
 									                                        transition.clock_resets_);
-									// SPDLOG_TRACE(
-									//  "Initialize synchronizing transition  {}",
-									//  fmt::format(
-									//    "{} -{}-> {}",
-									//    fmt::join(new_synchronizing_jumps[symbol].back().source_.get(), "_"),
-									//    new_synchronizing_jumps[symbol].back().symbol_,
-									//    fmt::join(new_synchronizing_jumps[symbol].back().target_.get(), "_")));
 								}
 							}
 						} else {
@@ -224,13 +211,6 @@ get_product(const std::vector<TimedAutomaton<LocationT, ActionT>> &automata,
 								                                        product_target_location,
 								                                        constraints,
 								                                        resets);
-								// SPDLOG_TRACE(
-								//  "Duplicate synchronizing transition  {}",
-								//  fmt::format("{} -{}-> {}",
-								//              fmt::join(new_synchronizing_jumps[symbol].back().source_.get(),
-								//              "_"), new_synchronizing_jumps[symbol].back().symbol_,
-								//              fmt::join(new_synchronizing_jumps[symbol].back().target_.get(),
-								//                        "_")));
 							}
 						}
 					}

--- a/src/automata/include/automata/ta_product.hpp
+++ b/src/automata/include/automata/ta_product.hpp
@@ -144,13 +144,14 @@ get_product(const std::vector<TimedAutomaton<LocationT, ActionT>> &automata,
 				auto candidates = synchronized_transition_candidates.equal_range(transition.symbol_);
 				if (candidates.first == candidates.second) {
 					// initialize candidate for synchronized jump
-					Transition<std::vector<LocationT>, ActionT> transition =
-					  Transition<std::vector<LocationT>, ActionT>(ProductLocation{transition.source_.get()},
+					Transition<std::vector<LocationT>, ActionT> new_transition =
+					  Transition<std::vector<LocationT>, ActionT>(ProductLocation({transition.source_.get()}),
 					                                              transition.symbol_,
-					                                              ProductLocation{transition.target_.get()},
+					                                              ProductLocation({transition.target_.get()}),
 					                                              transition.clock_constraints_,
 					                                              transition.clock_resets_);
-					synchronized_transition_candidates.insert(std::make_pair(transition.symbol_, transition));
+					synchronized_transition_candidates.insert(
+					  std::make_pair(transition.symbol_, new_transition));
 				} else {
 					// Augment existing candidates. If this is the first candidate for this automaton, the
 					// vector of source and target locations of the existing candidates will be of length i-1

--- a/src/automata/include/automata/ta_product.hpp
+++ b/src/automata/include/automata/ta_product.hpp
@@ -131,114 +131,122 @@ get_product(const std::vector<TimedAutomaton<LocationT, ActionT>> &automata,
 	ProductLocation                                          product_initial_location;
 	std::set<std::string>                                    product_clocks;
 	std::vector<Transition<std::vector<LocationT>, ActionT>> product_transitions;
-	std::multimap<ActionT, Transition<std::vector<LocationT>, ActionT>>
-	  synchronized_transition_candidates;
-	for (const auto &[ta_i, ta] : ranges::views::enumerate(automata)) {
+	// datastructures required for synchronization
+	std::vector<std::set<ActionT>> alphabets;
+	// build alphabet, initial location and clocks of the product
+	std::for_each(std::begin(automata), std::end(automata), [&](const auto &ta) {
+		alphabets.emplace_back(ta.get_alphabet());
 		product_alphabet.insert(std::begin(ta.get_alphabet()), std::end(ta.get_alphabet()));
 		product_initial_location->push_back(ta.get_initial_location().get());
 		product_clocks.insert(std::begin(ta.get_clocks()), std::end(ta.get_clocks()));
-		for (const auto &[source_location, transition] : ta.get_transitions()) {
-			// handling of non-synchronized transitions
-			if (std::find(std::begin(synchronized_actions),
-			              std::end(synchronized_actions),
-			              transition.symbol_)
-			    == std::end(synchronized_actions)) {
-				for (const auto &product_source_location : product_locations) {
-					if (product_source_location.get()[ta_i] == transition.source_.get()) {
-						auto product_target_location        = product_source_location;
-						product_target_location.get()[ta_i] = transition.target_.get();
-						product_transitions.emplace_back(product_source_location,
-						                                 transition.symbol_,
-						                                 product_target_location,
-						                                 transition.clock_constraints_,
-						                                 transition.clock_resets_);
-					}
-				}
-			} else {
-				// Synchronized jumps will be constructend iteratively. We build candidates iteratively by
-				// creating transitions for all combinations of source and target location which occur in
-				// the original automata. For a given automaton with a synchronizing jump on symbol "a" we
-				// create all combinations of jumps also labelled with "a" from all other automata.
-				auto candidates = synchronized_transition_candidates.equal_range(transition.symbol_);
-				if (candidates.first == candidates.second) {
-					// initialize candidate for synchronized jump
-					Transition<std::vector<LocationT>, ActionT> new_transition =
-					  Transition<std::vector<LocationT>, ActionT>(ProductLocation({transition.source_.get()}),
-					                                              transition.symbol_,
-					                                              ProductLocation({transition.target_.get()}),
-					                                              transition.clock_constraints_,
-					                                              transition.clock_resets_);
-					synchronized_transition_candidates.insert(
-					  std::make_pair(transition.symbol_, new_transition));
-				} else {
-					// Augment existing candidates. If this is the first candidate for this automaton, the
-					// vector of source and target locations of the existing candidates will be of length i-1
-					// (i is the automaton index), otherwise the length will be i. In the later case we need
-					// to duplicate all candidates in order to be able to create all combinations of
-					// synchronizing jumps.
-					if (candidates.first->second.source_.get().size() == ta_i) {
-						// first case: augment existing candidates by this new candidate-component.
-						for (auto it = candidates.first; it != candidates.second; ++it) {
-							auto &[symbol, candidate] = *it;
-							candidate.source_.get().push_back(transition.source_);
-							candidate.target_.get().push_back(transition.source_);
-							candidate.clock_constraints_.insert(std::begin(transition.clock_constraints_),
-							                                    std::end(transition.clock_constraints_));
-							candidate.clock_resets_.insert(std::begin(transition.clock_resets_),
-							                               std::end(transition.clock_resets_));
+	});
+	// collect which automata synchronize on which actions
+	std::map<ActionT, std::vector<std::size_t>> synchronizing_actions =
+	  collect_synchronizing_alphabets(synchronized_actions, alphabets);
+	// collects synchronizing transitions
+	std::map<ActionT, std::set<Transition<std::vector<LocationT>, ActionT>>> synchronized_transitions;
+
+	for (const auto symbol : product_alphabet) {
+		bool symbol_synchronizes =
+		  (synchronizing_actions.find(symbol) != std::end(synchronizing_actions));
+		for (const auto &[ta_i, ta] : ranges::views::enumerate(automata)) {
+			// before finalizing the construction for one automaton, we collect all candidates for
+			// synchronizing jumps to avoid expensive lookup.
+			std::map<ActionT, std::set<Transition<std::vector<LocationT>, ActionT>>>
+			  new_synchronizing_jumps;
+			for (const auto &[source_location, transition] : ta.get_transitions()) {
+				// Only consider transitions where the symbol matches. Note that if the automaton does not
+				// synchronize with this symbol, this check will always fail if the considered symbol is
+				// synchronizing.
+				if (transition.symbol_ == symbol) {
+					// Handling of non-synchronized transitions: insert transitions for all product locations
+					// where source and target of the local transition match.
+					if (!symbol_synchronizes) {
+						for (const auto &product_source_location : product_locations) {
+							if (product_source_location.get()[ta_i] == transition.source_.get()) {
+								auto product_target_location        = product_source_location;
+								product_target_location.get()[ta_i] = transition.target_.get();
+								product_transitions.emplace_back(product_source_location,
+								                                 transition.symbol_,
+								                                 product_target_location,
+								                                 transition.clock_constraints_,
+								                                 transition.clock_resets_);
+								SPDLOG_TRACE("Add non-synchronizing transition  {}",
+								             fmt::format("{} -{}-> {}",
+								                         fmt::join(product_transitions.back().source_.get(), "_"),
+								                         product_transitions.back().symbol_,
+								                         fmt::join(product_transitions.back().target_.get(), "_")));
+							}
 						}
 					} else {
-						// second case: there was already a synchronizing jump for this automaton, create
-						// duplicates.
-						std::vector<Transition<std::vector<LocationT>, ActionT>> new_combinations;
-						for (auto it = candidates.first; it != candidates.second; ++it) {
-							auto &[symbol, candidate] = *it;
-							// update source and target
-							std::vector<LocationT> sources{std::begin(candidate.source_.get()),
-							                               std::prev(std::end(candidate.source_.get()), 2)};
-							std::vector<LocationT> targets{std::begin(candidate.target_.get()),
-							                               std::prev(std::end(candidate.target_.get()), 2)};
-							sources.push_back(transition.source_);
-							targets.push_back(transition.target_);
-							// remove clock constraints which affect clocks of the current automaton to allow
-							// replacement with new constraints of the duplicate
-							auto guards = candidate.clock_constraints_;
-							std::for_each(std::begin(ta.get_clocks()),
-							              std::end(ta.get_clocks()),
-							              [&guards](const auto &clock) { guards.erase(clock); });
-							guards.insert(std::begin(transition.clock_constraints_),
-							              std::end(transition.clock_constraints_));
-							// remove clock resets which affect clocks of the current automaton to allow
-							// replacement with new resets of the duplicate
-							auto resets = candidate.clock_resets_;
-							std::for_each(std::begin(ta.get_clocks()),
-							              std::end(ta.get_clocks()),
-							              [&resets](const auto &clock) { resets.erase(clock); });
-							resets.insert(std::begin(transition.clock_resets_),
-							              std::end(transition.clock_resets_));
-							// create duplicate
-							new_combinations.emplace_back(
-							  ProductLocation(sources), symbol, ProductLocation(targets), guards, resets);
+						// We know the automaton *must* synchronize with the symbol
+						assert(std::find(std::begin(synchronizing_actions[symbol]),
+						                 std::end(synchronizing_actions[symbol]),
+						                 ta_i)
+						       != std::end(synchronizing_actions[symbol]));
+						// if this is the first synchronized transition with this symbol, initialize set of
+						// potentially synchronizing jumps.
+						if (synchronized_transitions[symbol].empty()) {
+							for (const auto &product_source_location : product_locations) {
+								if (product_source_location.get()[ta_i] == transition.source_.get()) {
+									auto product_target_location        = product_source_location;
+									product_target_location.get()[ta_i] = transition.target_.get();
+									new_synchronizing_jumps[symbol].emplace(product_source_location,
+									                                        transition.symbol_,
+									                                        product_target_location,
+									                                        transition.clock_constraints_,
+									                                        transition.clock_resets_);
+									// SPDLOG_TRACE(
+									//  "Initialize synchronizing transition  {}",
+									//  fmt::format(
+									//    "{} -{}-> {}",
+									//    fmt::join(new_synchronizing_jumps[symbol].back().source_.get(), "_"),
+									//    new_synchronizing_jumps[symbol].back().symbol_,
+									//    fmt::join(new_synchronizing_jumps[symbol].back().target_.get(), "_")));
+								}
+							}
+						} else {
+							// there are already transition-candidates for synchronization, we need to create
+							// candidates for each transition in the current automaton which also synchronizes.
+							for (const auto &sync_transition : synchronized_transitions[symbol]) {
+								auto product_source_location        = sync_transition.source_;
+								product_source_location.get()[ta_i] = transition.source_.get();
+								auto product_target_location        = sync_transition.target_;
+								product_target_location.get()[ta_i] = transition.target_.get();
+								auto constraints                    = sync_transition.clock_constraints_;
+								constraints.insert(std::begin(transition.clock_constraints_),
+								                   std::end(transition.clock_constraints_));
+								auto resets = sync_transition.clock_resets_;
+								resets.insert(std::begin(transition.clock_resets_),
+								              std::end(transition.clock_resets_));
+								new_synchronizing_jumps[symbol].emplace(product_source_location,
+								                                        transition.symbol_,
+								                                        product_target_location,
+								                                        constraints,
+								                                        resets);
+								// SPDLOG_TRACE(
+								//  "Duplicate synchronizing transition  {}",
+								//  fmt::format("{} -{}-> {}",
+								//              fmt::join(new_synchronizing_jumps[symbol].back().source_.get(),
+								//              "_"), new_synchronizing_jumps[symbol].back().symbol_,
+								//              fmt::join(new_synchronizing_jumps[symbol].back().target_.get(),
+								//                        "_")));
+							}
 						}
-						// insert duplicates into candidates list
-						std::transform(std::begin(new_combinations),
-						               std::end(new_combinations),
-						               std::inserter(synchronized_transition_candidates,
-						                             std::end(synchronized_transition_candidates)),
-						               [](const auto &transition) {
-							               return std::make_pair(transition.symbol_, transition);
-						               });
 					}
 				}
 			}
+			// update transitions
+			for (const auto &[symbol, transitions] : new_synchronizing_jumps) {
+				synchronized_transitions[symbol] = std::move(transitions);
+			}
 		}
 	}
-
-	// take only those synchronized actions on which *all* automata agree
-	for (const auto &[symbol, transition] : synchronized_transition_candidates) {
-		if (transition.source_.get().size() == automata.size()) {
-			product_transitions.emplace_back(transition);
-		}
+	// update transitions
+	for (const auto &[symbol, transitions] : synchronized_transitions) {
+		std::copy(std::begin(transitions),
+		          std::end(transitions),
+		          std::back_inserter(product_transitions));
 	}
 
 	return TimedAutomaton<std::vector<LocationT>, ActionT>{product_locations,

--- a/src/automata/include/automata/ta_product.hpp
+++ b/src/automata/include/automata/ta_product.hpp
@@ -24,6 +24,7 @@
 
 #include <fmt/core.h>
 #include <fmt/format.h>
+#include <spdlog/spdlog.h>
 
 #include <algorithm>
 #include <ctime>
@@ -33,6 +34,23 @@
 #include <tuple>
 
 namespace automata::ta {
+
+template <typename ActionT>
+std::map<ActionT, std::vector<std::size_t>>
+collect_synchronizing_alphabets(const std::set<ActionT> &             synchronized_actions,
+                                const std::vector<std::set<ActionT>> &alphabets)
+{
+	std::map<ActionT, std::vector<std::size_t>> res;
+	for (const auto &symbol : synchronized_actions) {
+		res[symbol] = {};
+		for (std::size_t i = 0; i < alphabets.size(); ++i) {
+			if (alphabets[i].find(symbol) != std::end(alphabets[i])) {
+				res[symbol].emplace_back(i);
+			}
+		}
+	}
+	return res;
+}
 
 template <typename LocationT, typename ActionT>
 TimedAutomaton<std::vector<LocationT>, ActionT>

--- a/src/automata/include/automata/ta_product.hpp
+++ b/src/automata/include/automata/ta_product.hpp
@@ -44,7 +44,7 @@ collect_synchronizing_alphabets(const std::set<ActionT> &             synchroniz
 		res[symbol] = {};
 		for (std::size_t i = 0; i < alphabets.size(); ++i) {
 			if (alphabets[i].find(symbol) != std::end(alphabets[i])) {
-				res[symbol].emplace_back(i);
+				res[symbol].push_back(i);
 			}
 		}
 	}
@@ -134,7 +134,7 @@ get_product(const std::vector<TimedAutomaton<LocationT, ActionT>> &automata,
 	std::vector<std::set<ActionT>> alphabets;
 	// build alphabet, initial location and clocks of the product
 	std::for_each(std::begin(automata), std::end(automata), [&](const auto &ta) {
-		alphabets.emplace_back(ta.get_alphabet());
+		alphabets.push_back(ta.get_alphabet());
 		product_alphabet.insert(std::begin(ta.get_alphabet()), std::end(ta.get_alphabet()));
 		product_initial_location->push_back(ta.get_initial_location().get());
 		product_clocks.insert(std::begin(ta.get_clocks()), std::end(ta.get_clocks()));
@@ -145,7 +145,7 @@ get_product(const std::vector<TimedAutomaton<LocationT, ActionT>> &automata,
 	// collects synchronizing transitions
 	std::map<ActionT, std::set<Transition<std::vector<LocationT>, ActionT>>> synchronized_transitions;
 
-	for (const auto symbol : product_alphabet) {
+	for (const auto &symbol : product_alphabet) {
 		bool symbol_synchronizes =
 		  (synchronizing_actions.find(symbol) != std::end(synchronizing_actions));
 		for (const auto &[ta_i, ta] : ranges::views::enumerate(automata)) {
@@ -155,8 +155,10 @@ get_product(const std::vector<TimedAutomaton<LocationT, ActionT>> &automata,
 			  new_synchronizing_jumps;
 			for (const auto &[source_location, transition] : ta.get_transitions()) {
 				// Only consider transitions where the symbol matches. Note that if the automaton does not
-				// synchronize with this symbol, this check will always fail if the considered symbol is
-				// synchronizing.
+				// synchronize with this symbol, this check will always fail since implicitly an automaton
+				// can only synchronize with a synchronizing symbol if it has at least one transition with
+				// this symbol. This information is relevant to establish, that the automaton is able to
+				// synchronize with this symbol in the second case (else-branch below).
 				if (transition.symbol_ == symbol) {
 					// Handling of non-synchronized transitions: insert transitions for all product locations
 					// where source and target of the local transition match.

--- a/test/test_ta.cpp
+++ b/test/test_ta.cpp
@@ -97,6 +97,50 @@ TEST_CASE("Lexicographical comparison of TA transitions", "[ta]")
 	CHECK((!(std::string("s0") > "s1")
 	       || (Transition(Location{"s1"}, "a", Location{"s0"})
 	           < Transition(Location{"s0"}, "a", Location{"s0"}))));
+	CHECK((!(std::string("s0") < "s1")
+	       || (Transition(Location{"s0"}, "a", Location{"s0"})
+	           < Transition(Location{"s0"}, "a", Location{"s1"}))));
+	CHECK((!(std::string("s0") > "s1")
+	       || (Transition(Location{"s0"}, "a", Location{"s1"})
+	           < Transition(Location{"s0"}, "a", Location{"s0"}))));
+
+	CHECK((!(std::string("a") < "b")
+	       || (Transition(Location{"s0"}, "a", Location{"s0"})
+	           < Transition(Location{"s0"}, "b", Location{"s0"}))));
+	CHECK((!(std::string("b") < "a")
+	       || (Transition(Location{"s0"}, "b", Location{"s0"})
+	           < Transition(Location{"s0"}, "a", Location{"s0"}))));
+
+	CHECK((!(std::set<std::string>{"x"} < std::set<std::string>{"y"})
+	       || (Transition(Location{"s0"}, "a", Location{"s0"}, {}, {"x"})
+	           < Transition(Location{"s0"}, "a", Location{"s0"}, {}, {"y"}))));
+	CHECK((!(std::set<std::string>{} < std::set<std::string>{"y"})
+	       || (Transition(Location{"s0"}, "a", Location{"s0"}, {}, {})
+	           < Transition(Location{"s0"}, "a", Location{"s0"}, {}, {"y"}))));
+}
+
+TEST_CASE("Lexicographical comparison of clock constraints", "[ta]")
+{
+	using LT = AtomicClockConstraintT<std::less<Time>>;
+	using LE = AtomicClockConstraintT<std::less_equal<Time>>;
+	using EQ = AtomicClockConstraintT<std::equal_to<Time>>;
+	using GE = AtomicClockConstraintT<std::greater_equal<Time>>;
+	using GT = AtomicClockConstraintT<std::greater<Time>>;
+	CHECK(LT(0) < LT(1));
+	CHECK(LE(0) < LE(1));
+	CHECK(EQ(0) < EQ(1));
+	CHECK(GE(0) < GE(1));
+	CHECK(GT(0) < GT(1));
+
+	CHECK(LT(1) < LE(1));
+	CHECK(EQ(1) < GE(1));
+	CHECK(GE(1) < GT(1));
+
+	CHECK(!(LT(1) < LT(1)));
+	CHECK(!(LE(1) < LE(1)));
+	CHECK(!(EQ(1) < EQ(1)));
+	CHECK(!(GE(1) < GE(1)));
+	CHECK(!(GT(1) < GT(1)));
 }
 
 TEST_CASE("Simple TA", "[ta]")

--- a/test/test_ta.cpp
+++ b/test/test_ta.cpp
@@ -92,48 +92,27 @@ TEST_CASE("Lexicographical comparison of TA transitions", "[ta]")
 	CHECK(!(Transition(Location{"s0"}, "a", Location{"s0"})
 	        < Transition(Location{"s0"}, "a", Location{"s0"})));
 	// source
-	CHECK((!(std::string("s0") < "s1")
-	       || (Transition(Location{"s0"}, "a", Location{"s0"})
-	           < Transition(Location{"s1"}, "a", Location{"s0"}))));
-	CHECK((!(std::string("s0") > "s1")
-	       || (Transition(Location{"s1"}, "a", Location{"s0"})
-	           < Transition(Location{"s0"}, "a", Location{"s0"}))));
+	CHECK((Transition(Location{"s0"}, "a", Location{"s0"})
+	       < Transition(Location{"s1"}, "a", Location{"s0"})));
 
 	// target
-	CHECK((!(std::string("s0") < "s1")
-	       || (Transition(Location{"s0"}, "a", Location{"s0"})
-	           < Transition(Location{"s0"}, "a", Location{"s1"}))));
-	CHECK((!(std::string("s0") > "s1")
-	       || (Transition(Location{"s0"}, "a", Location{"s1"})
-	           < Transition(Location{"s0"}, "a", Location{"s0"}))));
-	CHECK((!(std::string("s0") < "s1")
-	       || (Transition(Location{"s0"}, "a", Location{"s1"})
-	           > Transition(Location{"s0"}, "a", Location{"s0"}))));
-	CHECK((!(std::string("s0") > "s1")
-	       || (Transition(Location{"s0"}, "a", Location{"s0"})
-	           > Transition(Location{"s0"}, "a", Location{"s1"}))));
-	CHECK(!(!(std::string("s0") < "s1")
-	        || (Transition(Location{"s0"}, "a", Location{"s1"})
-	            < Transition(Location{"s0"}, "a", Location{"s0"}))));
+	CHECK(((Transition(Location{"s0"}, "a", Location{"s0"})
+	        < Transition(Location{"s0"}, "a", Location{"s1"}))));
+	CHECK(((Transition(Location{"s0"}, "a", Location{"s1"})
+	        > Transition(Location{"s0"}, "a", Location{"s0"}))));
+	CHECK(!((Transition(Location{"s0"}, "a", Location{"s1"})
+	         < Transition(Location{"s0"}, "a", Location{"s0"}))));
 
 	// action
 	CHECK((!(std::string("a") < "b")
 	       || (Transition(Location{"s0"}, "a", Location{"s0"})
 	           < Transition(Location{"s0"}, "b", Location{"s0"}))));
-	CHECK((!(std::string("b") < "a")
-	       || (Transition(Location{"s0"}, "b", Location{"s0"})
-	           < Transition(Location{"s0"}, "a", Location{"s0"}))));
-	CHECK((!(std::string("b") > "a")
-	       || !(Transition(Location{"s0"}, "b", Location{"s0"})
-	            < Transition(Location{"s0"}, "a", Location{"s0"}))));
+	CHECK(!((Transition(Location{"s0"}, "b", Location{"s0"})
+	         < Transition(Location{"s0"}, "a", Location{"s0"}))));
 
 	// resets
-	CHECK((!(std::set<std::string>{"x"} < std::set<std::string>{"y"})
-	       || (Transition(Location{"s0"}, "a", Location{"s0"}, {}, {"x"})
-	           < Transition(Location{"s0"}, "a", Location{"s0"}, {}, {"y"}))));
-	CHECK((!(std::set<std::string>{"x"} > std::set<std::string>{"y"})
-	       || !(Transition(Location{"s0"}, "a", Location{"s0"}, {}, {"x"})
-	            < Transition(Location{"s0"}, "a", Location{"s0"}, {}, {"y"}))));
+	CHECK(((Transition(Location{"s0"}, "a", Location{"s0"}, {}, {"x"})
+	        < Transition(Location{"s0"}, "a", Location{"s0"}, {}, {"y"}))));
 	CHECK((!(std::set<std::string>{} < std::set<std::string>{"y"})
 	       || (Transition(Location{"s0"}, "a", Location{"s0"}, {}, {})
 	           < Transition(Location{"s0"}, "a", Location{"s0"}, {}, {"y"}))));

--- a/test/test_ta.cpp
+++ b/test/test_ta.cpp
@@ -87,6 +87,18 @@ TEST_CASE("Comparison of TA configurations", "[ta]")
 	        == Configuration{Location{"l0"}, {{"x", Clock{0}}}}));
 }
 
+TEST_CASE("Lexicographical comparison of TA transitions", "[ta]")
+{
+	CHECK(!(Transition(Location{"s0"}, "a", Location{"s0"})
+	        < Transition(Location{"s0"}, "a", Location{"s0"})));
+	CHECK((!("s0" < "s1")
+	       || (Transition(Location{"s0"}, "a", Location{"s0"})
+	           < Transition(Location{"s1"}, "a", Location{"s0"}))));
+	CHECK((!("s0" > "s1")
+	       || (Transition(Location{"s1"}, "a", Location{"s0"})
+	           < Transition(Location{"s0"}, "a", Location{"s0"}))));
+}
+
 TEST_CASE("Simple TA", "[ta]")
 {
 	TimedAutomaton ta{{"a", "b"}, Location{"s0"}, {Location{"s0"}}};

--- a/test/test_ta.cpp
+++ b/test/test_ta.cpp
@@ -176,6 +176,7 @@ TEST_CASE("Lexicographical comparison of clock constraints", "[ta]")
 	using LT = AtomicClockConstraintT<std::less<Time>>;
 	using LE = AtomicClockConstraintT<std::less_equal<Time>>;
 	using EQ = AtomicClockConstraintT<std::equal_to<Time>>;
+	using NE = AtomicClockConstraintT<std::not_equal_to<Time>>;
 	using GE = AtomicClockConstraintT<std::greater_equal<Time>>;
 	using GT = AtomicClockConstraintT<std::greater<Time>>;
 	CHECK(LT(0) < LT(1));
@@ -186,7 +187,9 @@ TEST_CASE("Lexicographical comparison of clock constraints", "[ta]")
 
 	CHECK(LT(1) < LE(1));
 	CHECK(EQ(1) < GE(1));
+	CHECK(NE(1) < GE(1));
 	CHECK(GE(1) < GT(1));
+	CHECK(!(LE(1) < LT(1)));
 
 	CHECK(!(LT(1) < LT(1)));
 	CHECK(!(LE(1) < LE(1)));

--- a/test/test_ta.cpp
+++ b/test/test_ta.cpp
@@ -91,32 +91,84 @@ TEST_CASE("Lexicographical comparison of TA transitions", "[ta]")
 {
 	CHECK(!(Transition(Location{"s0"}, "a", Location{"s0"})
 	        < Transition(Location{"s0"}, "a", Location{"s0"})));
+	// source
 	CHECK((!(std::string("s0") < "s1")
 	       || (Transition(Location{"s0"}, "a", Location{"s0"})
 	           < Transition(Location{"s1"}, "a", Location{"s0"}))));
 	CHECK((!(std::string("s0") > "s1")
 	       || (Transition(Location{"s1"}, "a", Location{"s0"})
 	           < Transition(Location{"s0"}, "a", Location{"s0"}))));
+
+	// target
 	CHECK((!(std::string("s0") < "s1")
 	       || (Transition(Location{"s0"}, "a", Location{"s0"})
 	           < Transition(Location{"s0"}, "a", Location{"s1"}))));
 	CHECK((!(std::string("s0") > "s1")
 	       || (Transition(Location{"s0"}, "a", Location{"s1"})
 	           < Transition(Location{"s0"}, "a", Location{"s0"}))));
+	CHECK((!(std::string("s0") < "s1")
+	       || (Transition(Location{"s0"}, "a", Location{"s1"})
+	           > Transition(Location{"s0"}, "a", Location{"s0"}))));
+	CHECK((!(std::string("s0") > "s1")
+	       || (Transition(Location{"s0"}, "a", Location{"s0"})
+	           > Transition(Location{"s0"}, "a", Location{"s1"}))));
+	CHECK(!(!(std::string("s0") < "s1")
+	        || (Transition(Location{"s0"}, "a", Location{"s1"})
+	            < Transition(Location{"s0"}, "a", Location{"s0"}))));
 
+	// action
 	CHECK((!(std::string("a") < "b")
 	       || (Transition(Location{"s0"}, "a", Location{"s0"})
 	           < Transition(Location{"s0"}, "b", Location{"s0"}))));
 	CHECK((!(std::string("b") < "a")
 	       || (Transition(Location{"s0"}, "b", Location{"s0"})
 	           < Transition(Location{"s0"}, "a", Location{"s0"}))));
+	CHECK((!(std::string("b") > "a")
+	       || !(Transition(Location{"s0"}, "b", Location{"s0"})
+	            < Transition(Location{"s0"}, "a", Location{"s0"}))));
 
+	// resets
 	CHECK((!(std::set<std::string>{"x"} < std::set<std::string>{"y"})
 	       || (Transition(Location{"s0"}, "a", Location{"s0"}, {}, {"x"})
 	           < Transition(Location{"s0"}, "a", Location{"s0"}, {}, {"y"}))));
+	CHECK((!(std::set<std::string>{"x"} > std::set<std::string>{"y"})
+	       || !(Transition(Location{"s0"}, "a", Location{"s0"}, {}, {"x"})
+	            < Transition(Location{"s0"}, "a", Location{"s0"}, {}, {"y"}))));
 	CHECK((!(std::set<std::string>{} < std::set<std::string>{"y"})
 	       || (Transition(Location{"s0"}, "a", Location{"s0"}, {}, {})
 	           < Transition(Location{"s0"}, "a", Location{"s0"}, {}, {"y"}))));
+
+	// clock constraints
+	CHECK(Transition(Location{"s0"},
+	                 "a",
+	                 Location{"s0"},
+	                 std::multimap<std::string, ClockConstraint>{
+	                   {"x", automata::AtomicClockConstraintT<std::less<Time>>(0)}})
+	      < Transition(Location{"s0"},
+	                   "a",
+	                   Location{"s0"},
+	                   std::multimap<std::string, ClockConstraint>{
+	                     {"x", automata::AtomicClockConstraintT<std::less<Time>>(1)}}));
+	CHECK(!(Transition(Location{"s0"},
+	                   "a",
+	                   Location{"s0"},
+	                   std::multimap<std::string, ClockConstraint>{
+	                     {"x", automata::AtomicClockConstraintT<std::less<Time>>(0)}})
+	        < Transition(Location{"s0"},
+	                     "a",
+	                     Location{"s0"},
+	                     std::multimap<std::string, ClockConstraint>{
+	                       {"x", automata::AtomicClockConstraintT<std::less<Time>>(0)}})));
+	CHECK(!(Transition(Location{"s0"},
+	                   "a",
+	                   Location{"s0"},
+	                   std::multimap<std::string, ClockConstraint>{
+	                     {"x", automata::AtomicClockConstraintT<std::less<Time>>(1)}})
+	        < Transition(Location{"s0"},
+	                     "a",
+	                     Location{"s0"},
+	                     std::multimap<std::string, ClockConstraint>{
+	                       {"x", automata::AtomicClockConstraintT<std::less<Time>>(0)}})));
 }
 
 TEST_CASE("Lexicographical comparison of clock constraints", "[ta]")

--- a/test/test_ta.cpp
+++ b/test/test_ta.cpp
@@ -91,10 +91,10 @@ TEST_CASE("Lexicographical comparison of TA transitions", "[ta]")
 {
 	CHECK(!(Transition(Location{"s0"}, "a", Location{"s0"})
 	        < Transition(Location{"s0"}, "a", Location{"s0"})));
-	CHECK((!("s0" < "s1")
+	CHECK((!(std::string("s0") < "s1")
 	       || (Transition(Location{"s0"}, "a", Location{"s0"})
 	           < Transition(Location{"s1"}, "a", Location{"s0"}))));
-	CHECK((!("s0" > "s1")
+	CHECK((!(std::string("s0") > "s1")
 	       || (Transition(Location{"s1"}, "a", Location{"s0"})
 	           < Transition(Location{"s0"}, "a", Location{"s0"}))));
 }

--- a/test/test_ta_product.cpp
+++ b/test/test_ta_product.cpp
@@ -23,8 +23,6 @@
 #include "automata/ta.h"
 #include "automata/ta_product.h"
 
-#include <spdlog/spdlog.h>
-
 #include <catch2/catch_test_macros.hpp>
 
 namespace {
@@ -66,7 +64,6 @@ TEST_CASE("The product of two timed automata", "[ta]")
 
 TEST_CASE("The product of two timed automata with synchronized actions", "[ta]")
 {
-	spdlog::set_level(spdlog::level::trace);
 	TA ta1{{"a", "b"}, SingleLocation{"1l1"}, {SingleLocation{"1l2"}}};
 	TA ta2{{"a", "d"}, SingleLocation{"2l1"}, {SingleLocation{"2l2"}}};
 	ta1.add_location(SingleLocation{"1l2"});
@@ -102,7 +99,6 @@ TEST_CASE("The product of two timed automata with synchronized actions", "[ta]")
 
 TEST_CASE("The product of three timed automata with pairwise synchronized actions", "[ta]")
 {
-	spdlog::set_level(spdlog::level::trace);
 	TA ta1{{"a", "b"}, SingleLocation{"1l1"}, {SingleLocation{"1l2"}}};
 	TA ta2{{"a", "d"}, SingleLocation{"2l1"}, {SingleLocation{"2l2"}}};
 	TA ta3{{"c", "d"}, SingleLocation{"3l1"}, {SingleLocation{"3l2"}}};

--- a/test/test_ta_product.cpp
+++ b/test/test_ta_product.cpp
@@ -60,8 +60,8 @@ TEST_CASE("The product of two timed automata", "[ta]")
 	CHECK(product.accepts_word({{"a", 0}, {"c", 1}}));
 
 	// Synchronized actions are not implemented.
-	CHECK_THROWS_AS((get_product<std::string, std::string>({ta1, ta2}, {"a"})),
-	                automata::ta::NotImplementedException);
+	// CHECK_THROWS_AS((get_product<std::string, std::string>({ta1, ta2}, {"a"})),
+	//                automata::ta::NotImplementedException);
 }
 
 TEST_CASE("The product of two timed automata with clock constraints", "[ta]")

--- a/test/test_ta_product.cpp
+++ b/test/test_ta_product.cpp
@@ -100,6 +100,78 @@ TEST_CASE("The product of two timed automata with synchronized actions", "[ta]")
 	CHECK(product.accepts_word({{"b", 0}, {"a", 1}}));
 }
 
+TEST_CASE("The product of three timed automata with pairwise synchronized actions", "[ta]")
+{
+	spdlog::set_level(spdlog::level::trace);
+	TA ta1{{"a", "b"}, SingleLocation{"1l1"}, {SingleLocation{"1l2"}}};
+	TA ta2{{"a", "d"}, SingleLocation{"2l1"}, {SingleLocation{"2l2"}}};
+	TA ta3{{"c", "d"}, SingleLocation{"3l1"}, {SingleLocation{"3l2"}}};
+	ta1.add_location(SingleLocation{"1l2"});
+	ta1.add_transition(SingleTransition{SingleLocation{"1l1"}, "a", SingleLocation{"1l2"}});
+	ta1.add_transition(SingleTransition{SingleLocation{"1l1"}, "b", SingleLocation{"1l1"}});
+	ta1.add_transition(SingleTransition{SingleLocation{"1l2"}, "b", SingleLocation{"1l2"}});
+	ta2.add_transition(SingleTransition{SingleLocation{"2l1"}, "a", SingleLocation{"2l2"}});
+	ta2.add_transition(SingleTransition{SingleLocation{"2l2"}, "d", SingleLocation{"2l2"}});
+	ta3.add_transition(SingleTransition{SingleLocation{"3l1"}, "c", SingleLocation{"3l1"}});
+	ta3.add_transition(SingleTransition{SingleLocation{"3l1"}, "d", SingleLocation{"3l2"}});
+	const auto product = get_product<std::string, std::string>({ta1, ta2, ta3}, {"a", "d"});
+	CHECK(product.get_alphabet() == std::set<std::string>{"a", "b", "c", "d"});
+	CHECK(product.get_initial_location() == ProductLocation{{"1l1", "2l1", "3l1"}});
+	CHECK(product.get_final_locations() == std::set{ProductLocation{{"1l2", "2l2", "3l2"}}});
+	CHECK(product.get_transitions()
+	      == std::multimap<ProductLocation, ProductTransition>{{
+	        {ProductLocation{{"1l1", "2l1", "3l1"}},
+	         ProductTransition{
+	           ProductLocation{{"1l1", "2l1", "3l1"}}, "b", ProductLocation{{"1l1", "2l1", "3l1"}}}},
+	        {ProductLocation{{"1l2", "2l1", "3l1"}},
+	         ProductTransition{
+	           ProductLocation{{"1l2", "2l1", "3l1"}}, "b", ProductLocation{{"1l2", "2l1", "3l1"}}}},
+	        {ProductLocation{{"1l1", "2l2", "3l1"}},
+	         ProductTransition{
+	           ProductLocation{{"1l1", "2l2", "3l1"}}, "b", ProductLocation{{"1l1", "2l2", "3l1"}}}},
+	        {ProductLocation{{"1l1", "2l2", "3l1"}},
+	         ProductTransition{
+	           ProductLocation{{"1l1", "2l2", "3l1"}}, "c", ProductLocation{{"1l1", "2l2", "3l1"}}}},
+	        {ProductLocation{{"1l2", "2l2", "3l1"}},
+	         ProductTransition{
+	           ProductLocation{{"1l2", "2l2", "3l1"}}, "b", ProductLocation{{"1l2", "2l2", "3l1"}}}},
+	        {ProductLocation{{"1l2", "2l2", "3l1"}},
+	         ProductTransition{
+	           ProductLocation{{"1l2", "2l2", "3l1"}}, "c", ProductLocation{{"1l2", "2l2", "3l1"}}}},
+	        {ProductLocation{{"1l1", "2l2", "3l1"}},
+	         ProductTransition{
+	           ProductLocation{{"1l1", "2l2", "3l1"}}, "d", ProductLocation{{"1l1", "2l2", "3l2"}}}},
+	        {ProductLocation{{"1l2", "2l2", "3l1"}},
+	         ProductTransition{
+	           ProductLocation{{"1l2", "2l2", "3l1"}}, "d", ProductLocation{{"1l2", "2l2", "3l2"}}}},
+	        {ProductLocation{{"1l1", "2l1", "3l1"}},
+	         ProductTransition{
+	           ProductLocation{{"1l1", "2l1", "3l1"}}, "c", ProductLocation{{"1l1", "2l1", "3l1"}}}},
+	        {ProductLocation{{"1l1", "2l1", "3l1"}},
+	         ProductTransition{
+	           ProductLocation{{"1l1", "2l1", "3l1"}}, "a", ProductLocation{{"1l2", "2l2", "3l1"}}}},
+	        {ProductLocation{{"1l2", "2l1", "3l1"}},
+	         ProductTransition{
+	           ProductLocation{{"1l2", "2l1", "3l1"}}, "c", ProductLocation{{"1l2", "2l1", "3l1"}}}},
+	        {ProductLocation{{"1l1", "2l1", "3l2"}},
+	         ProductTransition{
+	           ProductLocation{{"1l1", "2l1", "3l2"}}, "b", ProductLocation{{"1l1", "2l1", "3l2"}}}},
+	        {ProductLocation{{"1l2", "2l1", "3l2"}},
+	         ProductTransition{
+	           ProductLocation{{"1l2", "2l1", "3l2"}}, "b", ProductLocation{{"1l2", "2l1", "3l2"}}}},
+	        {ProductLocation{{"1l1", "2l2", "3l2"}},
+	         ProductTransition{
+	           ProductLocation{{"1l1", "2l2", "3l2"}}, "b", ProductLocation{{"1l1", "2l2", "3l2"}}}},
+	        {ProductLocation{{"1l2", "2l2", "3l2"}},
+	         ProductTransition{
+	           ProductLocation{{"1l2", "2l2", "3l2"}}, "b", ProductLocation{{"1l2", "2l2", "3l2"}}}},
+	        {ProductLocation{{"1l1", "2l1", "3l2"}},
+	         ProductTransition{
+	           ProductLocation{{"1l1", "2l1", "3l2"}}, "a", ProductLocation{{"1l2", "2l2", "3l2"}}}},
+	      }});
+	CHECK(product.accepts_word({{"b", 0}, {"a", 1}, {"d", 2}}));
+}
+
 TEST_CASE("The product of two timed automata with clock constraints", "[ta]")
 {
 	TA ta1{{"a", "b"}, SingleLocation{"1l1"}, {SingleLocation{"1l1"}}};

--- a/test/test_tree_iteration.cpp
+++ b/test/test_tree_iteration.cpp
@@ -20,9 +20,6 @@
 #include "synchronous_product/preorder_traversal.h"
 #include "synchronous_product/search_tree.h"
 
-#include <spdlog/details/synchronous_factory.h>
-#include <spdlog/spdlog.h>
-
 #include <catch2/catch_test_macros.hpp>
 #include <memory>
 #include <ostream>


### PR DESCRIPTION
Extension of the product-construction for ta by synchronized actions.

- non-synchronizing actions are handled as before
- for synchronizing actions it is needed to determine which automaton synchronizes on them to allow to synchronize several automata with different subsets of labels. Transitions are built incrementally component-wise.
- the automaton still may contain non-reachable components. This does not affect the analysis but the size of the automaton.