### PR TITLE
Add time heuristic

### DIFF
--- a/src/automata/include/automata/ta_regions.h
+++ b/src/automata/include/automata/ta_regions.h
@@ -28,7 +28,7 @@
 
 namespace automata::ta {
 
-using RegionIndex        = size_t;
+using RegionIndex        = unsigned int;
 using RegionSetValuation = std::map<std::string, RegionIndex>;
 template <typename LocationT>
 using RegionalizedConfiguration = std::pair<Location<LocationT>, RegionSetValuation>;

--- a/src/synchronous_product/include/synchronous_product/heuristics.h
+++ b/src/synchronous_product/include/synchronous_product/heuristics.h
@@ -45,7 +45,7 @@ public:
 	}
 };
 
-/** The BFS heuristic.
+/** @brief The BFS heuristic.
  * The BFS heuristic simply decrements the priority with every evaluated node and therefore
  * processes them just like a FIFO queue, resulting in breadth-first sarch.
  * @tparam ValueT The value type of the heuristic function
@@ -64,7 +64,7 @@ public:
 	ValueT
 	compute_cost(SearchTreeNode<LocationT, ActionT> *) override
 	{
-		return -(++node_counter);
+		return ++node_counter;
 	}
 
 private:

--- a/src/synchronous_product/include/synchronous_product/heuristics.h
+++ b/src/synchronous_product/include/synchronous_product/heuristics.h
@@ -48,7 +48,7 @@ public:
 };
 
 /** @brief The BFS heuristic.
- * The BFS heuristic simply decrements the priority with every evaluated node and therefore
+ * The BFS heuristic simply increases the cost with every evaluated node and therefore
  * processes them just like a FIFO queue, resulting in breadth-first sarch.
  * @tparam ValueT The value type of the heuristic function
  * @tparam LocationT The type of the location of an automaton
@@ -67,6 +67,29 @@ public:
 	compute_cost(SearchTreeNode<LocationT, ActionT> *) override
 	{
 		return ++node_counter;
+	}
+
+private:
+	std::atomic_size_t node_counter{0};
+};
+
+/** @brief The DFS heuristic.
+ * The BFS heuristic simply decreases the cost with every evaluated node and therefore
+ * processes them just like a LIFO queue, resulting in depth-first sarch.
+ */
+template <typename ValueT, typename LocationT, typename ActionT>
+class DfsHeuristic : public Heuristic<ValueT, LocationT, ActionT>
+{
+public:
+	/** @brief Compute the cost of the given node.
+	 * The cost will strictly monotonically increase for each node, thereby emulating breadth-first
+	 * search.
+	 * @return The cost of the node
+	 */
+	ValueT
+	compute_cost(SearchTreeNode<LocationT, ActionT> *) override
+	{
+		return -(++node_counter);
 	}
 
 private:

--- a/src/synchronous_product/include/synchronous_product/search.h
+++ b/src/synchronous_product/include/synchronous_product/search.h
@@ -132,7 +132,7 @@ public:
 	void
 	add_node_to_queue(Node *node)
 	{
-		pool_.add_job([this, node] { expand_node(node); }, heuristic->compute_cost(node));
+		pool_.add_job([this, node] { expand_node(node); }, -heuristic->compute_cost(node));
 	}
 
 	/** Build the complete search tree by expanding nodes recursively.

--- a/src/synchronous_product/include/synchronous_product/search.h
+++ b/src/synchronous_product/include/synchronous_product/search.h
@@ -54,15 +54,18 @@ public:
 	 * @param K The maximal constant occurring in a clock constraint
 	 * @param incremental_labeling True, if incremental labeling should be used (default=false)
 	 * @param terminate_early If true, cancel the children of a node that has already been labeled
+	 * @param heuristic The heuristic to use during tree expansion
 	 */
 	TreeSearch(const automata::ta::TimedAutomaton<Location, ActionType> *                      ta,
 	           automata::ata::AlternatingTimedAutomaton<logic::MTLFormula<ActionType>,
 	                                                    logic::AtomicProposition<ActionType>> *ata,
-	           std::set<ActionType> controller_actions,
-	           std::set<ActionType> environment_actions,
-	           RegionIndex          K,
-	           bool                 incremental_labeling = false,
-	           bool                 terminate_early      = false)
+	           std::set<ActionType>                                   controller_actions,
+	           std::set<ActionType>                                   environment_actions,
+	           RegionIndex                                            K,
+	           bool                                                   incremental_labeling = false,
+	           bool                                                   terminate_early      = false,
+	           std::unique_ptr<Heuristic<long, Location, ActionType>> heuristic =
+	             std::make_unique<BfsHeuristic<long, Location, ActionType>>())
 	: ta_(ta),
 	  ata_(ata),
 	  controller_actions_(controller_actions),
@@ -72,7 +75,7 @@ public:
 	  terminate_early_(terminate_early),
 	  tree_root_(std::make_unique<Node>(std::set<CanonicalABWord<Location, ActionType>>{
 	    get_canonical_word(ta->get_initial_configuration(), ata->get_initial_configuration(), K)})),
-	  heuristic(std::make_unique<BfsHeuristic<long, Location, ActionType>>())
+	  heuristic(std::move(heuristic))
 	{
 		// Assert that the two action sets are disjoint.
 		assert(

--- a/test/test_heuristics.cpp
+++ b/test/test_heuristics.cpp
@@ -17,7 +17,10 @@
  *  Read the full text in the LICENSE.md file.
  */
 
+#include "automata/ta_regions.h"
+#include "synchronous_product/canonical_word.h"
 #include "synchronous_product/heuristics.h"
+#include "synchronous_product/search_tree.h"
 
 #include <catch2/catch_test_macros.hpp>
 
@@ -32,6 +35,33 @@ TEST_CASE("Test BFS heuristic", "[search][heuristics]")
 	long h3 = bfs.compute_cost(nullptr);
 	CHECK(h1 < h2);
 	CHECK(h2 < h3);
+}
+
+TEST_CASE("Test time heuristic", "[search][heuristics]")
+{
+	spdlog::set_level(spdlog::level::debug);
+	synchronous_product::TimeHeuristic<long, std::string, std::string> h;
+
+	using Node = synchronous_product::SearchTreeNode<std::string, std::string>;
+	auto create_test_node =
+	  [](Node *                                                            parent  = nullptr,
+	     const std::set<std::pair<automata::ta::RegionIndex, std::string>> actions = {}) {
+		  auto node = std::make_unique<Node>(
+		    std::set<synchronous_product::CanonicalABWord<std::string, std::string>>{},
+		    parent,
+		    actions);
+		  return node;
+	  };
+	auto root = create_test_node();
+	CHECK(h.compute_cost(root.get()) == 0);
+	auto c1 = create_test_node(root.get(), {{1, "a1"}});
+	CHECK(h.compute_cost(c1.get()) == 1);
+	auto c2 = create_test_node(root.get(), {{3, "a1"}, {4, "b"}});
+	CHECK(h.compute_cost(c2.get()) == 3);
+	auto cc1 = create_test_node(c1.get(), {{2, "a"}, {4, "a"}});
+	CHECK(h.compute_cost(cc1.get()) == 3);
+	auto cc2 = create_test_node(c2.get(), {{2, "a"}, {4, "a"}});
+	CHECK(h.compute_cost(cc2.get()) == 5);
 }
 
 } // namespace

--- a/test/test_heuristics.cpp
+++ b/test/test_heuristics.cpp
@@ -36,6 +36,16 @@ TEST_CASE("Test BFS heuristic", "[search][heuristics]")
 	CHECK(h1 < h2);
 	CHECK(h2 < h3);
 }
+TEST_CASE("Test DFS heuristic", "[search][heuristics]")
+{
+	synchronous_product::DfsHeuristic<long, std::string, std::string> dfs{};
+	// The heuristic does not care about the actual node, we can just give it nullptrs.
+	long h1 = dfs.compute_cost(nullptr);
+	long h2 = dfs.compute_cost(nullptr);
+	long h3 = dfs.compute_cost(nullptr);
+	CHECK(h1 > h2);
+	CHECK(h2 > h3);
+}
 
 TEST_CASE("Test time heuristic", "[search][heuristics]")
 {

--- a/test/test_heuristics.cpp
+++ b/test/test_heuristics.cpp
@@ -23,17 +23,15 @@
 
 namespace {
 
-using Bfs = synchronous_product::BfsHeuristic<long, std::string, std::string>;
-
 TEST_CASE("Test BFS heuristic", "[search][heuristics]")
 {
-	Bfs bfs{};
+	synchronous_product::BfsHeuristic<long, std::string, std::string> bfs{};
 	// The heuristic does not care about the actual node, we can just give it nullptrs.
 	long h1 = bfs.compute_cost(nullptr);
 	long h2 = bfs.compute_cost(nullptr);
 	long h3 = bfs.compute_cost(nullptr);
-	CHECK(h1 > h2);
-	CHECK(h2 > h3);
+	CHECK(h1 < h2);
+	CHECK(h2 < h3);
 }
 
 } // namespace

--- a/test/test_railroad.cpp
+++ b/test/test_railroad.cpp
@@ -85,7 +85,10 @@ TEST_CASE("Two railroad crossings", "[.medium][railroad]")
 {
 	spdlog::set_level(spdlog::level::trace);
 	spdlog::set_pattern("%t %v");
-	const auto &[product, controller_actions, environment_actions] = create_crossing_problem({2, 4});
+	const auto   problem             = create_crossing_problem({2, 4});
+	auto         plant               = std::get<0>(problem);
+	auto         controller_actions  = std::get<1>(problem);
+	auto         environment_actions = std::get<2>(problem);
 	std::set<AP> actions;
 	std::set_union(begin(controller_actions),
 	               end(controller_actions),
@@ -102,12 +105,12 @@ TEST_CASE("Two railroad crossings", "[.medium][railroad]")
 	  mtl_ata_translation::translate(((!finish_close_1).until(enter_1) && finally(enter_1))
 	                                   || ((!finish_close_2).until(enter_2) && finally(enter_2)),
 	                                 actions);
-	INFO("TA: " << product);
+	INFO("TA: " << plant);
 	INFO("ATA: " << ata);
 	BENCHMARK("Run the search")
 	{
 		TreeSearch search{
-		  &product,
+		  &plant,
 		  &ata,
 		  controller_actions,
 		  environment_actions,
@@ -142,8 +145,10 @@ TEST_CASE("Three railroad crossings", "[.large][railroad]")
 {
 	spdlog::set_level(spdlog::level::trace);
 	spdlog::set_pattern("%t %v");
-	const auto &[product, controller_actions, environment_actions] =
-	  create_crossing_problem({2, 2, 2});
+	const auto   problem             = create_crossing_problem({2, 2, 2});
+	auto         plant               = std::get<0>(problem);
+	auto         controller_actions  = std::get<1>(problem);
+	auto         environment_actions = std::get<2>(problem);
 	std::set<AP> actions;
 	std::set_union(begin(controller_actions),
 	               end(controller_actions),
@@ -169,7 +174,7 @@ TEST_CASE("Three railroad crossings", "[.large][railroad]")
 	BENCHMARK("Run the search")
 	{
 		TreeSearch search{
-		  &product,
+		  &plant,
 		  &ata,
 		  controller_actions,
 		  environment_actions,


### PR DESCRIPTION
Add a heuristic that always prefers nodes with incoming actions with a low region increment, thus preferring actions that occur early. This improves performance in the railroad benchmark significantly.

For completeness' sake, also add DFS.