### PR TITLE
controller: when we reached the max region index, do not add upper bound

### DIFF
--- a/src/automata/include/automata/ta_regions.h
+++ b/src/automata/include/automata/ta_regions.h
@@ -62,10 +62,13 @@ RegionIndex get_maximal_region_index(const TimedAutomaton<LocationT, AP> &ta);
 /** @brief Given a region index, compute a set of clock constraints that restrict a clock to that
  * region.
  * @param region_index The region index to construct the constraint for
+ * @param max_region_index The maximal region index that may occur
  * @return A set (with either one or two elements) of clock constraints that restrict some clock to
  * the given region
  */
-std::vector<ClockConstraint> get_clock_constraints_from_region_index(ta::RegionIndex region_index);
+std::vector<ClockConstraint>
+get_clock_constraints_from_region_index(ta::RegionIndex region_index,
+                                        ta::RegionIndex max_region_index);
 
 } // namespace automata::ta
 

--- a/src/automata/ta_regions.cpp
+++ b/src/automata/ta_regions.cpp
@@ -37,10 +37,13 @@ TimedAutomatonRegions::getRegionIndex(ClockValuation timePoint)
 }
 
 std::vector<ClockConstraint>
-get_clock_constraints_from_region_index(ta::RegionIndex region_index)
+get_clock_constraints_from_region_index(ta::RegionIndex region_index,
+                                        ta::RegionIndex max_region_index)
 {
 	if (region_index % 2 == 0) {
 		return {AtomicClockConstraintT<std::equal_to<Time>>(region_index / 2)};
+	} else if (region_index == max_region_index) {
+		return {AtomicClockConstraintT<std::greater<Time>>((region_index - 1) / 2)};
 	} else {
 		return {AtomicClockConstraintT<std::greater<Time>>((region_index - 1) / 2),
 		        AtomicClockConstraintT<std::less<Time>>((region_index + 1) / 2)};

--- a/src/synchronous_product/include/synchronous_product/create_controller.h
+++ b/src/synchronous_product/include/synchronous_product/create_controller.h
@@ -34,7 +34,8 @@ namespace controller_synthesis {
 template <typename LocationT, typename ActionT>
 std::multimap<std::string, automata::ClockConstraint>
 get_constraints_from_time_successor(
-  const synchronous_product::CanonicalABWord<LocationT, ActionT> &word)
+  const synchronous_product::CanonicalABWord<LocationT, ActionT> &word,
+  synchronous_product::RegionIndex                                max_constant)
 {
 	using TARegionState = synchronous_product::TARegionState<LocationT>;
 	std::multimap<std::string, automata::ClockConstraint> res;
@@ -43,7 +44,8 @@ get_constraints_from_time_successor(
 			assert(std::holds_alternative<TARegionState>(region_state));
 			const TARegionState state = std::get<TARegionState>(region_state);
 			for (const auto &constraint :
-			     automata::ta::get_clock_constraints_from_region_index(state.region_index)) {
+			     automata::ta::get_clock_constraints_from_region_index(state.region_index,
+			                                                           2 * max_constant + 1)) {
 				res.insert({{state.clock, constraint}});
 			}
 		}
@@ -92,7 +94,7 @@ create_controller(const synchronous_product::SearchTreeNode<LocationT, ActionT> 
 			// Is it sufficient to consider the reg_a components of the words?
 			actions.insert(action);
 			auto constraints = get_constraints_from_time_successor(
-			  get_nth_time_successor(reg_a(*std::begin(node->words)), region_increment, K));
+			  get_nth_time_successor(reg_a(*std::begin(node->words)), region_increment, K), K);
 			for (const auto &[clock_name, constraint] : constraints) {
 				clocks.insert(clock_name);
 			}

--- a/test/test_ta_region.cpp
+++ b/test/test_ta_region.cpp
@@ -100,18 +100,20 @@ TEST_CASE("Get largest region index", "[taRegion]")
 
 TEST_CASE("Get clock constraint from region", "[taRegion]")
 {
-	CHECK(get_clock_constraints_from_region_index(0)
+	CHECK(get_clock_constraints_from_region_index(0, 5)
 	      == std::vector<ClockConstraint>{AtomicClockConstraintT<std::equal_to<Time>>{0}});
-	CHECK(get_clock_constraints_from_region_index(1)
+	CHECK(get_clock_constraints_from_region_index(1, 5)
 	      == std::vector<ClockConstraint>{AtomicClockConstraintT<std::greater<Time>>{0},
 	                                      AtomicClockConstraintT<std::less<Time>>{1}});
-	CHECK(get_clock_constraints_from_region_index(2)
+	CHECK(get_clock_constraints_from_region_index(2, 5)
 	      == std::vector<ClockConstraint>{AtomicClockConstraintT<std::equal_to<Time>>{1}});
-	CHECK(get_clock_constraints_from_region_index(3)
+	CHECK(get_clock_constraints_from_region_index(3, 5)
 	      == std::vector<ClockConstraint>{AtomicClockConstraintT<std::greater<Time>>{1},
 	                                      AtomicClockConstraintT<std::less<Time>>{2}});
-	CHECK(get_clock_constraints_from_region_index(4)
+	CHECK(get_clock_constraints_from_region_index(4, 5)
 	      == std::vector<ClockConstraint>{AtomicClockConstraintT<std::equal_to<Time>>{2}});
+	CHECK(get_clock_constraints_from_region_index(5, 5)
+	      == std::vector<ClockConstraint>{AtomicClockConstraintT<std::greater<Time>>{2}});
 }
 
 } // namespace


### PR DESCRIPTION
If a clock reaches the max region, it should not have an upper bound, as
it may have values larger than 2*region+1.