### PR TITLE
Simplify ATA formulas during construction of the spec ATA

### DIFF
--- a/src/automata/include/automata/ata_formula.h
+++ b/src/automata/include/automata/ata_formula.h
@@ -325,6 +325,28 @@ private:
 	std::unique_ptr<Formula<LocationT>> sub_formula_;
 };
 
+/** @brief Create a conjunction of two formulas.
+ * If possible, the formula will be immediately simplified.
+ * @param conjunct1 The first conjunct
+ * @param conjunct2 The second conjunct
+ * @return A (possibly simplified) formula
+ */
+template <typename LocationT>
+std::unique_ptr<Formula<LocationT>>
+create_conjunction(std::unique_ptr<Formula<LocationT>> conjunct1,
+                   std::unique_ptr<Formula<LocationT>> conjunct2);
+
+/** @brief Create a disjunction of two formulas.
+ * If possible, the formula will be immediately simplified.
+ * @param disjunct1 The first disjunct
+ * @param disjunct2 The second disjunct
+ * @return A (possibly simplified) formula
+ */
+template <typename LocationT>
+std::unique_ptr<Formula<LocationT>>
+create_disjunction(std::unique_ptr<Formula<LocationT>> disjunct1,
+                   std::unique_ptr<Formula<LocationT>> disjunct2);
+
 } // namespace automata::ata
 
 #include "ata_formula.hpp"

--- a/src/automata/include/automata/ata_formula.h
+++ b/src/automata/include/automata/ata_formula.h
@@ -19,7 +19,7 @@
  */
 
 #ifndef SRC_AUTOMATA_INCLUDE_AUTOMATA_ATA_FORMULA_H
-#define SRC_AUTOMATA_INCLUDE_AUTOMATA_ATA_FORMULA_H value
+#define SRC_AUTOMATA_INCLUDE_AUTOMATA_ATA_FORMULA_H
 
 #include "automata.h"
 
@@ -27,10 +27,10 @@
 #include <memory>
 #include <range/v3/algorithm.hpp>
 #include <range/v3/view.hpp>
+#include <type_traits>
 #include <utility>
 
 namespace automata::ata {
-
 /** A state of an ATA.
  * An ATAState is always a pair (location, clock valuation).
  * @tparam The location type
@@ -74,6 +74,18 @@ operator==(const State<LocationT> &s1, const State<LocationT> &s2)
 
 template <typename LocationT>
 class Formula;
+
+/** Compare two ATA formulas. */
+template <typename LocationT>
+bool operator<(const Formula<LocationT> &, const Formula<LocationT> &);
+
+/** Compare two ATA formulas. */
+template <typename LocationT>
+bool operator==(const Formula<LocationT> &, const Formula<LocationT> &);
+
+/** Compare two ATA formulas. */
+template <typename LocationT>
+bool operator!=(const Formula<LocationT> &, const Formula<LocationT> &);
 
 /** Print a Formula to an ostream.
  * @param os The ostream to print to
@@ -164,6 +176,8 @@ protected:
 template <typename LocationT>
 class LocationFormula : public Formula<LocationT>
 {
+  friend bool operator< <>(const Formula<LocationT> &, const Formula<LocationT> &);
+
 public:
 	/** Constructor.
 	 * @param location The location that must be in the configuration to satisfy this formula
@@ -186,6 +200,8 @@ private:
 template <typename LocationT>
 class ClockConstraintFormula : public Formula<LocationT>
 {
+  friend bool operator< <>(const Formula<LocationT> &, const Formula<LocationT> &);
+
 public:
 	/** Constructor.
 	 * @param constraint The clock constraint that must be satisfied to satisfy this formula
@@ -210,6 +226,7 @@ private:
 template <typename LocationT>
 class ConjunctionFormula : public Formula<LocationT>
 {
+  friend bool operator< <>(const Formula<LocationT> &, const Formula<LocationT> &);
 public:
 	/** Constructor.
 	 * @param conjunct1 The first conjunct
@@ -242,6 +259,8 @@ private:
 template <typename LocationT>
 class DisjunctionFormula : public Formula<LocationT>
 {
+  friend bool operator< <>(const Formula<LocationT> &, const Formula<LocationT> &);
+
 public:
 	/** Constructor.
 	 * @param disjunct1 The first disjunct
@@ -272,6 +291,8 @@ private:
 template <typename LocationT>
 class ResetClockFormula : public Formula<LocationT>
 {
+  friend bool operator< <>(const Formula<LocationT> &, const Formula<LocationT> &);
+
 public:
 	/** Constructor.
 	 * @param sub_formula The sub-formula to evaluate with a reset clock

--- a/src/automata/include/automata/ata_formula.h
+++ b/src/automata/include/automata/ata_formula.h
@@ -129,7 +129,7 @@ public:
 
 	// clang-format off
 	friend std::ostream & operator<< <>(std::ostream &os, const Formula &formula);
-	//clang-format on
+	// clang-format on
 
 protected:
 	/** A virtual method to print a Formula to an ostream. We cannot just use
@@ -146,8 +146,7 @@ template <typename LocationT>
 class TrueFormula : public Formula<LocationT>
 {
 public:
-	bool
-	is_satisfied(const std::set<State<LocationT>> &, const ClockValuation &) const override;
+	bool is_satisfied(const std::set<State<LocationT>> &, const ClockValuation &) const override;
 	std::set<std::set<State<LocationT>>> get_minimal_models(const ClockValuation &) const override;
 
 protected:
@@ -176,14 +175,17 @@ protected:
 template <typename LocationT>
 class LocationFormula : public Formula<LocationT>
 {
-  friend bool operator< <>(const Formula<LocationT> &, const Formula<LocationT> &);
+	// clang-format off
+	friend bool operator< <>(const Formula<LocationT> &, const Formula<LocationT> &);
+	// clang-format on
 
 public:
 	/** Constructor.
 	 * @param location The location that must be in the configuration to satisfy this formula
 	 */
 	explicit LocationFormula(const LocationT &location) : location_(location){};
-	bool is_satisfied(const std::set<State<LocationT>> &states, const ClockValuation &v) const override;
+	bool                                 is_satisfied(const std::set<State<LocationT>> &states,
+	                                                  const ClockValuation &            v) const override;
 	std::set<std::set<State<LocationT>>> get_minimal_models(const ClockValuation &v) const override;
 
 protected:
@@ -200,7 +202,9 @@ private:
 template <typename LocationT>
 class ClockConstraintFormula : public Formula<LocationT>
 {
-  friend bool operator< <>(const Formula<LocationT> &, const Formula<LocationT> &);
+	// clang-format off
+	friend bool operator< <>(const Formula<LocationT> &, const Formula<LocationT> &);
+	// clang-format on
 
 public:
 	/** Constructor.
@@ -226,7 +230,10 @@ private:
 template <typename LocationT>
 class ConjunctionFormula : public Formula<LocationT>
 {
-  friend bool operator< <>(const Formula<LocationT> &, const Formula<LocationT> &);
+	// clang-format off
+	friend bool operator< <>(const Formula<LocationT> &, const Formula<LocationT> &);
+	// clang-format on
+
 public:
 	/** Constructor.
 	 * @param conjunct1 The first conjunct
@@ -238,11 +245,10 @@ public:
 	{
 	}
 
-	bool
-	is_satisfied(const std::set<State<LocationT>> &states, const ClockValuation &v) const override;
+	bool is_satisfied(const std::set<State<LocationT>> &states,
+	                  const ClockValuation &            v) const override;
 
-	std::set<std::set<State<LocationT>>>
-	get_minimal_models(const ClockValuation &v) const override;
+	std::set<std::set<State<LocationT>>> get_minimal_models(const ClockValuation &v) const override;
 
 protected:
 	/** Print a ConjunctionFormula to an ostream
@@ -259,7 +265,9 @@ private:
 template <typename LocationT>
 class DisjunctionFormula : public Formula<LocationT>
 {
-  friend bool operator< <>(const Formula<LocationT> &, const Formula<LocationT> &);
+	// clang-format off
+	friend bool operator< <>(const Formula<LocationT> &, const Formula<LocationT> &);
+	// clang-format on
 
 public:
 	/** Constructor.
@@ -272,15 +280,15 @@ public:
 	{
 	}
 
-	bool is_satisfied(const std::set<State<LocationT>> &states, const ClockValuation &v) const override;
+	bool                                 is_satisfied(const std::set<State<LocationT>> &states,
+	                                                  const ClockValuation &            v) const override;
 	std::set<std::set<State<LocationT>>> get_minimal_models(const ClockValuation &v) const override;
 
 protected:
 	/** Print a DisjunctionFormula to an ostream
 	 * @param os The ostream to print to
 	 */
-	void
-	print_to_ostream(std::ostream &os) const override;
+	void print_to_ostream(std::ostream &os) const override;
 
 private:
 	std::unique_ptr<Formula<LocationT>> disjunct1_;
@@ -291,7 +299,9 @@ private:
 template <typename LocationT>
 class ResetClockFormula : public Formula<LocationT>
 {
-  friend bool operator< <>(const Formula<LocationT> &, const Formula<LocationT> &);
+	// clang-format off
+	friend bool operator< <>(const Formula<LocationT> &, const Formula<LocationT> &);
+	// clang-format on
 
 public:
 	/** Constructor.
@@ -301,15 +311,15 @@ public:
 	: sub_formula_(std::move(sub_formula))
 	{
 	}
-	bool is_satisfied(const std::set<State<LocationT>> &states, const ClockValuation &) const override;
+	bool                                 is_satisfied(const std::set<State<LocationT>> &states,
+	                                                  const ClockValuation &) const override;
 	std::set<std::set<State<LocationT>>> get_minimal_models(const ClockValuation &) const override;
 
 protected:
 	/** Print a ResetClockFormula to an ostream
 	 * @param os The ostream to print to
 	 */
-	void
-	print_to_ostream(std::ostream &os) const override;
+	void print_to_ostream(std::ostream &os) const override;
 
 private:
 	std::unique_ptr<Formula<LocationT>> sub_formula_;

--- a/src/automata/include/automata/ata_formula.hpp
+++ b/src/automata/include/automata/ata_formula.hpp
@@ -305,4 +305,40 @@ operator!=(const Formula<LocationT> &first, const Formula<LocationT> &second)
 	return (first < second) || (second < first);
 }
 
+template <typename LocationT>
+std::unique_ptr<Formula<LocationT>>
+create_conjunction(std::unique_ptr<Formula<LocationT>> conjunct1,
+                   std::unique_ptr<Formula<LocationT>> conjunct2)
+{
+	if (*conjunct1 == FalseFormula<LocationT>{} || *conjunct2 == FalseFormula<LocationT>{}) {
+		return std::make_unique<FalseFormula<LocationT>>();
+	}
+	if (*conjunct1 == TrueFormula<LocationT>{}) {
+		return conjunct2;
+	}
+	if (*conjunct2 == TrueFormula<LocationT>{}) {
+		return conjunct1;
+	}
+	return std::make_unique<ConjunctionFormula<LocationT>>(std::move(conjunct1),
+	                                                       std::move(conjunct2));
+}
+
+template <typename LocationT>
+std::unique_ptr<Formula<LocationT>>
+create_disjunction(std::unique_ptr<Formula<LocationT>> disjunct1,
+                   std::unique_ptr<Formula<LocationT>> disjunct2)
+{
+	if (*disjunct1 == TrueFormula<LocationT>{} || *disjunct2 == TrueFormula<LocationT>{}) {
+		return std::make_unique<TrueFormula<LocationT>>();
+	}
+	if (*disjunct1 == FalseFormula<LocationT>{}) {
+		return disjunct2;
+	}
+	if (*disjunct2 == FalseFormula<LocationT>{}) {
+		return disjunct1;
+	}
+	return std::make_unique<DisjunctionFormula<LocationT>>(std::move(disjunct1),
+	                                                       std::move(disjunct2));
+}
+
 } // namespace automata::ata

--- a/test/test_ata_formula.cpp
+++ b/test/test_ata_formula.cpp
@@ -220,4 +220,41 @@ TEST_CASE("Minimal models of ATA disjunction formulas", "[ta]")
 	}
 }
 
+TEST_CASE("Compare ATA formulas", "[ta]")
+{
+	using T      = TrueFormula<std::string>;
+	using F      = FalseFormula<std::string>;
+	using C      = ConjunctionFormula<std::string>;
+	using D      = DisjunctionFormula<std::string>;
+	using L      = LocationFormula<std::string>;
+	using ClockC = ClockConstraintFormula<std::string>;
+	using R      = ResetClockFormula<std::string>;
+	CHECK(T{} == T{});
+	CHECK(F{} == F{});
+	CHECK(T{} != F{});
+	CHECK(T{} != C{std::make_unique<T>(), std::make_unique<T>()});
+	CHECK(C{std::make_unique<T>(), std::make_unique<T>()}
+	      == C{std::make_unique<T>(), std::make_unique<T>()});
+	CHECK(C{std::make_unique<F>(), std::make_unique<T>()}
+	      != C{std::make_unique<T>(), std::make_unique<T>()});
+	CHECK(C{std::make_unique<F>(), std::make_unique<T>()}
+	      != C{std::make_unique<T>(), std::make_unique<F>()});
+	CHECK(D{std::make_unique<T>(), std::make_unique<T>()}
+	      == D{std::make_unique<T>(), std::make_unique<T>()});
+	CHECK(D{std::make_unique<F>(), std::make_unique<T>()}
+	      != D{std::make_unique<T>(), std::make_unique<T>()});
+	CHECK(D{std::make_unique<F>(), std::make_unique<T>()}
+	      != D{std::make_unique<T>(), std::make_unique<F>()});
+	CHECK(L{"a"} < L{"b"});
+	CHECK(L{"a"} == L{"a"});
+	CHECK(ClockC{AtomicClockConstraintT<std::greater<Time>>(1)}
+	      < ClockC{AtomicClockConstraintT<std::greater<Time>>(2)});
+	CHECK(ClockC{AtomicClockConstraintT<std::greater<Time>>(1)}
+	      == ClockC{AtomicClockConstraintT<std::greater<Time>>(1)});
+	CHECK(ClockC{AtomicClockConstraintT<std::less<Time>>(1)}
+	      != ClockC{AtomicClockConstraintT<std::greater<Time>>(1)});
+	CHECK(R{std::make_unique<T>()} == R{std::make_unique<T>()});
+	CHECK(R{std::make_unique<T>()} != R{std::make_unique<F>()});
+}
+
 } // namespace

--- a/test/test_ata_formula.cpp
+++ b/test/test_ata_formula.cpp
@@ -257,4 +257,32 @@ TEST_CASE("Compare ATA formulas", "[ta]")
 	CHECK(R{std::make_unique<T>()} != R{std::make_unique<F>()});
 }
 
+TEST_CASE("Create simplified formulas", "[ta]")
+{
+	using T = TrueFormula<std::string>;
+	using F = FalseFormula<std::string>;
+	using L = LocationFormula<std::string>;
+	L l{"l"};
+
+	CHECK(*create_conjunction<std::string>(std::make_unique<T>(), std::make_unique<T>()) == T{});
+	CHECK(*create_conjunction<std::string>(std::make_unique<F>(), std::make_unique<F>()) == F{});
+	CHECK(*create_conjunction<std::string>(std::make_unique<T>(), std::make_unique<F>()) == F{});
+	CHECK(*create_conjunction<std::string>(std::make_unique<F>(), std::make_unique<T>()) == F{});
+
+	CHECK(*create_conjunction<std::string>(std::make_unique<T>(), std::make_unique<L>("l")) == l);
+	CHECK(*create_conjunction<std::string>(std::make_unique<F>(), std::make_unique<L>("l")) == F{});
+	CHECK(*create_conjunction<std::string>(std::make_unique<L>("l"), std::make_unique<T>()) == l);
+	CHECK(*create_conjunction<std::string>(std::make_unique<L>("l"), std::make_unique<F>()) == F{});
+
+	CHECK(*create_disjunction<std::string>(std::make_unique<T>(), std::make_unique<T>()) == T{});
+	CHECK(*create_disjunction<std::string>(std::make_unique<F>(), std::make_unique<F>()) == F{});
+	CHECK(*create_disjunction<std::string>(std::make_unique<T>(), std::make_unique<F>()) == T{});
+	CHECK(*create_disjunction<std::string>(std::make_unique<F>(), std::make_unique<T>()) == T{});
+
+	CHECK(*create_disjunction<std::string>(std::make_unique<T>(), std::make_unique<L>("l")) == T{});
+	CHECK(*create_disjunction<std::string>(std::make_unique<F>(), std::make_unique<L>("l")) == l);
+	CHECK(*create_disjunction<std::string>(std::make_unique<L>("l"), std::make_unique<T>()) == T{});
+	CHECK(*create_disjunction<std::string>(std::make_unique<L>("l"), std::make_unique<F>()) == l);
+}
+
 } // namespace


### PR DESCRIPTION
Directly simplify e.g. `true && false` to `false` when creating the ATA transitions. This simplifies the ATA significantly:

```
ATA:
Alphabet: {disappear, enter, finish_close, finish_open, get_near, leave, start_close, start_open}, initial location: l0, final locations: {}, transitions:
  (!(finish_close) U enter) → disappear → (!(finish_close) U enter)
  (!(finish_close) U enter) → enter → ⊤
  (!(finish_close) U enter) → finish_close → ⊥
  (!(finish_close) U enter) → finish_open → (!(finish_close) U enter)
  (!(finish_close) U enter) → get_near → (!(finish_close) U enter)
  (!(finish_close) U enter) → leave → (!(finish_close) U enter)
  (!(finish_close) U enter) → start_close → (!(finish_close) U enter)
  (!(finish_close) U enter) → start_open → (!(finish_close) U enter)
  (!(finish_open) U disappear) → disappear → ⊤
  (!(finish_open) U disappear) → enter → (!(finish_open) U disappear)
  (!(finish_open) U disappear) → finish_close → (!(finish_open) U disappear)
  (!(finish_open) U disappear) → finish_open → ⊥
  (!(finish_open) U disappear) → get_near → (!(finish_open) U disappear)
  (!(finish_open) U disappear) → leave → (!(finish_open) U disappear)
  (!(finish_open) U disappear) → start_close → (!(finish_open) U disappear)
  (!(finish_open) U disappear) → start_open → (!(finish_open) U disappear)
  l0 → disappear → ((!(finish_close) U enter) ∨ (!(finish_open) U disappear))
  l0 → enter → ((!(finish_close) U enter) ∨ (!(finish_open) U disappear))
  l0 → finish_close → ((!(finish_close) U enter) ∨ (!(finish_open) U disappear))
  l0 → finish_open → ((!(finish_close) U enter) ∨ (!(finish_open) U disappear))
  l0 → get_near → ((!(finish_close) U enter) ∨ (!(finish_open) U disappear))
  l0 → leave → ((!(finish_close) U enter) ∨ (!(finish_open) U disappear))
  l0 → start_close → ((!(finish_close) U enter) ∨ (!(finish_open) U disappear))
  l0 → start_open → ((!(finish_close) U enter) ∨ (!(finish_open) U disappear))
```