### PR TITLE
Add copy assignment and move constructors for MTL formulas

### DIFF
--- a/src/mtl/include/mtl/MTLFormula.h
+++ b/src/mtl/include/mtl/MTLFormula.h
@@ -156,14 +156,16 @@ public:
 	 * @brief Constructor from atomic proposition
 	 */
 	MTLFormula(const AtomicProposition<APType> &ap);
-	/**
-	 * @brief Copy-constructor
-	 * @param other
-	 */
-	MTLFormula(const MTLFormula &other);
 
-	/** @brief Copy assignment. */
-	MTLFormula &operator=(const MTLFormula &other);
+	/** * @brief Copy-constructor */
+	MTLFormula(const MTLFormula &) = default;
+	/** Move constructor */
+	MTLFormula(MTLFormula &&) = default;
+
+	/** Copy assignment. */
+	MTLFormula &operator=(const MTLFormula &) = default;
+	/** Move assignment. */
+	MTLFormula &operator=(MTLFormula &&) = default;
 
 	/// Get a formula that is always true.
 	static MTLFormula

--- a/src/mtl/include/mtl/MTLFormula.h
+++ b/src/mtl/include/mtl/MTLFormula.h
@@ -162,6 +162,9 @@ public:
 	 */
 	MTLFormula(const MTLFormula &other);
 
+	/** @brief Copy assignment. */
+	MTLFormula &operator=(const MTLFormula &other);
+
 	/// Get a formula that is always true.
 	static MTLFormula
 	TRUE()

--- a/src/mtl/include/mtl/MTLFormula.hpp
+++ b/src/mtl/include/mtl/MTLFormula.hpp
@@ -167,6 +167,19 @@ MTLFormula<APType>::MTLFormula(const MTLFormula &other)
 }
 
 template <typename APType>
+MTLFormula<APType> &
+MTLFormula<APType>::operator=(const MTLFormula &other)
+{
+	ap_       = other.ap_;
+	operator_ = other.operator_;
+	duration_ = other.duration_;
+	std::for_each(other.get_operands().begin(), other.get_operands().end(), [&](auto &o) {
+		operands_.push_back(o);
+	});
+	return *this;
+}
+
+template <typename APType>
 MTLFormula<APType>
 MTLFormula<APType>::operator&&(const MTLFormula &rhs) const
 {

--- a/src/mtl/include/mtl/MTLFormula.hpp
+++ b/src/mtl/include/mtl/MTLFormula.hpp
@@ -158,28 +158,6 @@ MTLFormula<APType>::MTLFormula(const AtomicProposition<APType> &ap) : ap_(ap), o
 }
 
 template <typename APType>
-MTLFormula<APType>::MTLFormula(const MTLFormula &other)
-: ap_(other.ap_), operator_(other.operator_), duration_(other.duration_)
-{
-	std::for_each(other.get_operands().begin(), other.get_operands().end(), [&](auto &o) {
-		operands_.push_back(o);
-	});
-}
-
-template <typename APType>
-MTLFormula<APType> &
-MTLFormula<APType>::operator=(const MTLFormula &other)
-{
-	ap_       = other.ap_;
-	operator_ = other.operator_;
-	duration_ = other.duration_;
-	std::for_each(other.get_operands().begin(), other.get_operands().end(), [&](auto &o) {
-		operands_.push_back(o);
-	});
-	return *this;
-}
-
-template <typename APType>
 MTLFormula<APType>
 MTLFormula<APType>::operator&&(const MTLFormula &rhs) const
 {


### PR DESCRIPTION
Also use default constructors where possible, no need to define them manually.