### PR TITLE
bugfix: allow controller to wait

### DIFF
--- a/src/synchronous_product/include/synchronous_product/create_controller.h
+++ b/src/synchronous_product/include/synchronous_product/create_controller.h
@@ -81,9 +81,7 @@ create_controller(const synchronous_product::SearchTreeNode<LocationT, ActionT> 
 			  return child->label == NodeLabel::TOP;
 		  });
 		if (successor_it == std::end(node->children)) {
-			throw synchronous_product::InconsistentTreeException(
-			  fmt::format("Inconsistent tree labeling: TOP-labeled node {} has no TOP-labeled child",
-			              *node));
+			break;
 		}
 		auto successor = successor_it->get();
 		locations.emplace(successor->words);

--- a/test/test_app.cpp
+++ b/test/test_app.cpp
@@ -22,7 +22,7 @@
 #include <catch2/catch_test_macros.hpp>
 #include <filesystem>
 
-TEST_CASE("Launch the main application", "[app]")
+TEST_CASE("Launch the main application", "[.railroad][app]")
 {
 	constexpr const int         argc          = 19;
 	const std::filesystem::path test_data_dir = std::filesystem::current_path() / "data" / "railroad";

--- a/test/test_create_controller.cpp
+++ b/test/test_create_controller.cpp
@@ -41,7 +41,7 @@ using TreeSearch = synchronous_product::TreeSearch<std::vector<std::string>, std
 using controller_synthesis::create_controller;
 using synchronous_product::NodeLabel;
 
-TEST_CASE("Create a controller for railroad1", "[railroad][controller]")
+TEST_CASE("Create a controller for railroad1", "[.railroad][controller]")
 {
 	const auto &[product, controller_actions, environment_actions] = create_crossing_problem({2});
 	std::set<AP> actions;
@@ -82,7 +82,7 @@ TEST_CASE("Create a controller for railroad1", "[railroad][controller]")
 	CHECK_THROWS(create_controller(search.get_root(), 4));
 }
 
-TEST_CASE("Controller time bounds", "[controller]")
+TEST_CASE("Controller time bounds", "[.railroad][controller]")
 {
 	spdlog::set_level(spdlog::level::debug);
 	using TA         = automata::ta::TimedAutomaton<std::string, std::string>;

--- a/test/test_create_controller.cpp
+++ b/test/test_create_controller.cpp
@@ -35,14 +35,18 @@
 
 namespace {
 
-using F          = logic::MTLFormula<std::string>;
-using AP         = logic::AtomicProposition<std::string>;
-using TreeSearch = synchronous_product::TreeSearch<std::vector<std::string>, std::string>;
+using F  = logic::MTLFormula<std::string>;
+using AP = logic::AtomicProposition<std::string>;
 using controller_synthesis::create_controller;
 using synchronous_product::NodeLabel;
 
+using TA         = automata::ta::TimedAutomaton<std::string, std::string>;
+using Transition = automata::ta::Transition<std::string, std::string>;
+using Location   = automata::ta::Location<std::string>;
+
 TEST_CASE("Create a controller for railroad1", "[.railroad][controller]")
 {
+	using TreeSearch = synchronous_product::TreeSearch<std::vector<std::string>, std::string>;
 	const auto &[product, controller_actions, environment_actions] = create_crossing_problem({2});
 	std::set<AP> actions;
 	std::set_union(begin(controller_actions),
@@ -85,9 +89,6 @@ TEST_CASE("Create a controller for railroad1", "[.railroad][controller]")
 TEST_CASE("Controller time bounds", "[.railroad][controller]")
 {
 	spdlog::set_level(spdlog::level::debug);
-	using TA         = automata::ta::TimedAutomaton<std::string, std::string>;
-	using Transition = automata::ta::Transition<std::string, std::string>;
-	using Location   = automata::ta::Location<std::string>;
 	TA         ta{{Location{"OPEN"}, Location{"OPENING"}, Location{"CLOSING"}, Location{"CLOSED"}},
         {"start_open", "finish_open", "start_close", "finish_close"},
         Location{"OPEN"},
@@ -131,4 +132,32 @@ TEST_CASE("Controller time bounds", "[.railroad][controller]")
 	// TODO Check more properties of the controller
 	CHECK(controller.get_alphabet() == std::set<std::string>{"start_close", "finish_close"});
 }
+
+TEST_CASE("Controller can decide to do nothing", "[controller]")
+{
+	// The controller first needs to go to l1 with 'c', then the environment can do 'e'.
+	TA ta{{Location{"l0"}, Location{"l1"}},
+	      {"c", "e"},
+	      Location{"l0"},
+	      {Location{"l1"}},
+	      {"c"},
+	      {Transition{Location{"l0"}, "c", Location{"l1"}},
+	       Transition{Location{"l1"}, "e", Location{"l1"}}}};
+
+	const logic::AtomicProposition<std::string> ap_c{"c"};
+	const logic::AtomicProposition<std::string> ap_e{"e"};
+	// Never let the environment do an action.
+	auto ata = mtl_ata_translation::translate(logic::finally(logic::MTLFormula{ap_e}), {ap_c, ap_e});
+	CAPTURE(ta);
+	CAPTURE(ata);
+	synchronous_product::TreeSearch<std::string, std::string> search(
+	  &ta, &ata, {"c"}, {"e"}, 0, true, false);
+	search.build_tree(false);
+	INFO("Tree:\n" << synchronous_product::node_to_string(*search.get_root(), true));
+	CHECK(search.get_root()->label == NodeLabel::TOP);
+	auto controller = create_controller(search.get_root(), 1);
+	CAPTURE(controller);
+	CHECK(controller.get_transitions().empty());
+}
+
 } // namespace


### PR DESCRIPTION
Do not throw exception on top-labeled node without children during
search.

This is not actually an error, as the controller may just need to do
nothing, because any controller action leads to a bad state.