### PR TITLE
Fix erroneous canonical word partitioning due to buggy floating point comparisons

### DIFF
--- a/src/synchronous_product/include/synchronous_product/synchronous_product.h
+++ b/src/synchronous_product/include/synchronous_product/synchronous_product.h
@@ -318,15 +318,10 @@ get_canonical_word(const automata::ta::Configuration<Location> &ta_configuration
 		g.insert(TAState<Location>{ta_configuration.location, clock_name, clock_value});
 	}
 	// Sort into partitions by the fractional parts.
-	auto RationalComparator = [](const auto &v1, const auto &v2) {
-		if (utilities::is_approx_same(v1, v2)) {
-			return false;
-		} else {
-			return v1 < v2;
-		}
-	};
-	std::map<ClockValuation, std::set<ABSymbol<Location, ActionType>>, decltype(RationalComparator)>
-	  partitioned_g(RationalComparator);
+	std::map<ClockValuation,
+	         std::set<ABSymbol<Location, ActionType>>,
+	         utilities::ApproxFloatComparator<Time>>
+	  partitioned_g(utilities::ApproxFloatComparator<Time>{});
 	for (const ABSymbol<Location, ActionType> &symbol : g) {
 		partitioned_g[utilities::getFractionalPart<int, ClockValuation>(get_time(symbol))].insert(
 		  symbol);

--- a/src/synchronous_product/include/synchronous_product/synchronous_product.h
+++ b/src/synchronous_product/include/synchronous_product/synchronous_product.h
@@ -318,7 +318,15 @@ get_canonical_word(const automata::ta::Configuration<Location> &ta_configuration
 		g.insert(TAState<Location>{ta_configuration.location, clock_name, clock_value});
 	}
 	// Sort into partitions by the fractional parts.
-	std::map<ClockValuation, std::set<ABSymbol<Location, ActionType>>> partitioned_g;
+	auto RationalComparator = [](const auto &v1, const auto &v2) {
+		if (utilities::is_approx_same(v1, v2)) {
+			return false;
+		} else {
+			return v1 < v2;
+		}
+	};
+	std::map<ClockValuation, std::set<ABSymbol<Location, ActionType>>, decltype(RationalComparator)>
+	  partitioned_g(RationalComparator);
 	for (const ABSymbol<Location, ActionType> &symbol : g) {
 		partitioned_g[utilities::getFractionalPart<int, ClockValuation>(get_time(symbol))].insert(
 		  symbol);

--- a/src/utilities/include/utilities/numbers.h
+++ b/src/utilities/include/utilities/numbers.h
@@ -34,6 +34,13 @@ isNearZero(Float in, int factor = absolute_epsilon_factor)
 	return fabs(in) < factor * std::numeric_limits<Float>::epsilon();
 }
 
+template <typename Float>
+bool
+is_approx_same(const Float &first, const Float &second, int factor = absolute_epsilon_factor)
+{
+	return isNearZero(first - second, factor);
+}
+
 template <typename Integer, typename Float>
 Integer
 getIntegerPart(Float in)

--- a/src/utilities/include/utilities/numbers.h
+++ b/src/utilities/include/utilities/numbers.h
@@ -22,6 +22,7 @@
 #include "config.h"
 
 #include <cmath>
+#include <limits>
 
 namespace utilities {
 

--- a/src/utilities/include/utilities/numbers.h
+++ b/src/utilities/include/utilities/numbers.h
@@ -62,4 +62,24 @@ isInteger(Float in)
 	return isNearZero(getFractionalPart<Integer, Float>(in));
 }
 
+/// Sort into partitions by the fractional parts.
+template <typename Float>
+struct ApproxFloatComparator
+{
+	/** @brief Compare two floats with approximate comparison.
+	 * @param v1 The first float
+	 * @param v2 The second float
+	 * @return true If v1 and v2 and not approximately the same and if v1 is smaller than v2.
+	 */
+	bool
+	operator()(const Float &v1, const Float &v2) const
+	{
+		if (is_approx_same(v1, v2)) {
+			return false;
+		} else {
+			return v1 < v2;
+		}
+	}
+};
+
 } // namespace utilities

--- a/test/test_number_utilities.cpp
+++ b/test/test_number_utilities.cpp
@@ -22,6 +22,7 @@
 
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
+#include <limits>
 
 namespace {
 
@@ -40,6 +41,19 @@ TEST_CASE("Get fractional and integer parts of numbers", "[libutilities]")
 
 	REQUIRE(!isInteger<int, double>(2.4));
 	REQUIRE(isInteger<int, double>(2.0));
+}
+
+TEST_CASE("Approximate float comparison", "[libutilities]")
+{
+	utilities::ApproxFloatComparator<float> comp;
+	CHECK(!comp(1.0, 1.0));
+	CHECK(!comp(1.0 - std::numeric_limits<float>::epsilon(), 1.0));
+	CHECK(!comp(1.0 - 4 * std::numeric_limits<float>::epsilon(), 1.0));
+	CHECK(comp(1.0 - 10 * std::numeric_limits<float>::epsilon(), 1.0));
+	CHECK(!comp(1.0, 1.0 - 10 * std::numeric_limits<float>::epsilon()));
+	CHECK(comp(1.0, 1.0 + 10 * std::numeric_limits<float>::epsilon()));
+	CHECK(comp(0.5, 1.0));
+	CHECK(!comp(1.5, 1.0));
 }
 
 } // namespace

--- a/test/test_synchronous_product.cpp
+++ b/test/test_synchronous_product.cpp
@@ -107,6 +107,20 @@ TEST_CASE("Get a canonical word of a more complex state", "[canonical_word]")
 	}
 }
 
+TEST_CASE("Canonical words with approximately equal fractional parts", "[canonical_word]")
+{
+	const logic::MTLFormula a{logic::AtomicProposition<std::string>{"a"}};
+	CHECK(get_canonical_word(automata::ta::Configuration<std::string>{Location{"l0"},
+	                                                                  {{"c1", 0.3}, {"c2", 5.3}}},
+	                         ATAConfiguration<std::string>{{a, 10.3}},
+	                         11)
+	      // All region states should end up in the same partition because they all have the same
+	      // fractional part (0.3).
+	      == CanonicalABWord({{TARegionState{Location{"l0"}, "c1", 1},
+	                           TARegionState{Location{"l0"}, "c2", 11},
+	                           ATARegionState{a, 21}}}));
+}
+
 TEST_CASE("Cannot get a canonical word if the TA does not have a clock", "[canonical_word]")
 {
 	CHECK_THROWS_AS(get_canonical_word(automata::ta::Configuration<std::string>{Location{"s"}, {}},


### PR DESCRIPTION
When partitioning  the region states on the fractional parts of the clock valuations, we must not just compare floats with equality, as this may possibly break if the integer parts are different. Consider the case from the test: We have three clocks c1, c2, c3 with the values 0.3, 5.3, and 10.3. They should all end up in the same partition, because they all have the fractional part `0.3`. To accomplish this, we need to define a non-default comparator that does approximate floating point comparison.
