### PR TITLE
Add all good successor nodes to the controller, merge clock constraints

### DIFF
--- a/src/automata/include/automata/automata.hpp
+++ b/src/automata/include/automata/automata.hpp
@@ -49,4 +49,22 @@ operator<<(std::ostream &os, const automata::AtomicClockConstraintT<Comp> &const
 	return os;
 }
 
+template <typename ActionT>
+std::ostream &
+operator<<(
+  std::ostream &                                                                       os,
+  const std::multimap<ActionT, std::multimap<std::string, automata::ClockConstraint>> &constraints)
+{
+	bool first = true;
+	for (const auto &[action, action_constraints] : constraints) {
+		if (first) {
+			first = false;
+		} else {
+			os << ", ";
+		}
+		os << action << ": " << action_constraints;
+	}
+	return os;
+}
+
 } // namespace automata

--- a/src/automata/include/automata/ta.h
+++ b/src/automata/include/automata/ta.h
@@ -365,6 +365,25 @@ public:
 	{
 		locations_.insert(location);
 	}
+
+	/** Add a final location to the TA.
+	 * @param location the location to add
+	 */
+	void
+	add_final_location(const Location<LocationT> &location)
+	{
+		locations_.insert(location);
+		final_locations_.insert(location);
+	}
+
+	/** Add an action to the TA.
+	 * @param action The action to add
+	 */
+	void
+	add_action(const AP &action)
+	{
+		alphabet_.insert(action);
+	}
 	/** Add a clock to the TA.
 	 * @param name the name of the clock
 	 */
@@ -441,7 +460,7 @@ private:
 	std::set<AP>                                                  alphabet_;
 	std::set<Location<LocationT>>                                 locations_;
 	const Location<LocationT>                                     initial_location_;
-	const std::set<Location<LocationT>>                           final_locations_;
+	std::set<Location<LocationT>>                                 final_locations_;
 	std::set<std::string>                                         clocks_;
 	std::multimap<Location<LocationT>, Transition<LocationT, AP>> transitions_;
 };

--- a/src/automata/include/automata/ta_regions.h
+++ b/src/automata/include/automata/ta_regions.h
@@ -34,6 +34,8 @@ template <typename LocationT>
 using RegionalizedConfiguration = std::pair<Location<LocationT>, RegionSetValuation>;
 using Integer                   = unsigned; ///< fix integer type
 
+enum class ConstraintBoundType { LOWER, UPPER, BOTH };
+
 /// A set of one-dimensional regions
 struct TimedAutomatonRegions
 {
@@ -67,8 +69,9 @@ RegionIndex get_maximal_region_index(const TimedAutomaton<LocationT, AP> &ta);
  * the given region
  */
 std::vector<ClockConstraint>
-get_clock_constraints_from_region_index(ta::RegionIndex region_index,
-                                        ta::RegionIndex max_region_index);
+get_clock_constraints_from_region_index(ta::RegionIndex     region_index,
+                                        ta::RegionIndex     max_region_index,
+                                        ConstraintBoundType bound_type = ConstraintBoundType::BOTH);
 
 } // namespace automata::ta
 

--- a/src/automata/ta_regions.cpp
+++ b/src/automata/ta_regions.cpp
@@ -43,15 +43,17 @@ get_clock_constraints_from_region_index(ta::RegionIndex     region_index,
                                         ta::RegionIndex     max_region_index,
                                         ConstraintBoundType bound_type)
 {
-	const bool                   get_lower = bound_type != ConstraintBoundType::UPPER;
-	const bool                   get_upper = bound_type != ConstraintBoundType::LOWER;
+	const bool get_lower =
+	  bound_type == ConstraintBoundType::LOWER || bound_type == ConstraintBoundType::BOTH;
+	const bool get_upper =
+	  bound_type == ConstraintBoundType::UPPER || bound_type == ConstraintBoundType::BOTH;
 	std::vector<ClockConstraint> res;
 	if (region_index % 2 == 0) {
 		if (get_lower && get_upper) {
 			return {AtomicClockConstraintT<std::equal_to<Time>>(region_index / 2)};
 		}
 		if (get_lower && region_index > 0) {
-			res.push_back(AtomicClockConstraintT<std::greater_equal<Time>>(region_index / 2));
+			return {AtomicClockConstraintT<std::greater_equal<Time>>(region_index / 2)};
 		}
 		if (get_upper) {
 			if (region_index == 0) {

--- a/src/automata/ta_regions.cpp
+++ b/src/automata/ta_regions.cpp
@@ -43,32 +43,38 @@ get_clock_constraints_from_region_index(ta::RegionIndex     region_index,
                                         ta::RegionIndex     max_region_index,
                                         ConstraintBoundType bound_type)
 {
-	bool get_lower = false;
-	bool get_upper = false;
+	bool get_lower = true;
+	bool get_upper = true;
 	switch (bound_type) {
-	case ConstraintBoundType::BOTH:
-		get_lower = true;
-		get_upper = true;
-		break;
-	case ConstraintBoundType::LOWER: get_lower = true; break;
-	case ConstraintBoundType::UPPER: get_upper = true; break;
+	case ConstraintBoundType::LOWER: get_upper = false; break;
+	case ConstraintBoundType::UPPER: get_lower = false; break;
+	case ConstraintBoundType::BOTH: break;
 	}
 	std::vector<ClockConstraint> res;
-	if (get_upper && region_index < max_region_index) {
-		if (region_index % 2 == 0) {
-			res.push_back(AtomicClockConstraintT<std::less_equal<Time>>(region_index / 2));
-		} else {
-			res.push_back(AtomicClockConstraintT<std::less<Time>>((region_index + 1) / 2));
+	if (region_index % 2 == 0) {
+		if (get_lower && get_upper) {
+			return {AtomicClockConstraintT<std::equal_to<Time>>(region_index / 2)};
 		}
-	}
-	if (get_lower && region_index > 0) {
-		if (region_index % 2 == 0) {
+		if (get_lower && region_index > 0) {
 			res.push_back(AtomicClockConstraintT<std::greater_equal<Time>>(region_index / 2));
-		} else {
+		}
+		if (get_upper) {
+			if (region_index == 0) {
+				return {AtomicClockConstraintT<std::equal_to<Time>>(0)};
+			} else {
+				res.push_back(AtomicClockConstraintT<std::less_equal<Time>>(region_index / 2));
+			}
+		}
+		return res;
+	} else {
+		if (get_lower) {
 			res.push_back(AtomicClockConstraintT<std::greater<Time>>(region_index / 2));
 		}
+		if (get_upper && region_index < max_region_index) {
+			res.push_back(AtomicClockConstraintT<std::less<Time>>((region_index + 1) / 2));
+		}
+		return res;
 	}
-	return res;
 }
 
 } // namespace automata::ta

--- a/src/automata/ta_regions.cpp
+++ b/src/automata/ta_regions.cpp
@@ -43,13 +43,8 @@ get_clock_constraints_from_region_index(ta::RegionIndex     region_index,
                                         ta::RegionIndex     max_region_index,
                                         ConstraintBoundType bound_type)
 {
-	bool get_lower = true;
-	bool get_upper = true;
-	switch (bound_type) {
-	case ConstraintBoundType::LOWER: get_upper = false; break;
-	case ConstraintBoundType::UPPER: get_lower = false; break;
-	case ConstraintBoundType::BOTH: break;
-	}
+	const bool                   get_lower = bound_type != ConstraintBoundType::UPPER;
+	const bool                   get_upper = bound_type != ConstraintBoundType::LOWER;
 	std::vector<ClockConstraint> res;
 	if (region_index % 2 == 0) {
 		if (get_lower && get_upper) {

--- a/src/synchronous_product/include/synchronous_product/create_controller.h
+++ b/src/synchronous_product/include/synchronous_product/create_controller.h
@@ -95,14 +95,23 @@ add_node_to_controller(
 				if (std::next(increment) == std::end(increments)
 				    || *std::next(increment) > *increment + 1) {
 					std::multimap<std::string, automata::ClockConstraint> constraints;
-					constraints.merge(get_constraints_from_time_successor(
-					  synchronous_product::get_nth_time_successor(node_reg_a, *first_good_increment, K),
-					  K,
-					  automata::ta::ConstraintBoundType::LOWER));
-					constraints.merge(get_constraints_from_time_successor(
-					  synchronous_product::get_nth_time_successor(node_reg_a, *increment, K),
-					  K,
-					  automata::ta::ConstraintBoundType::UPPER));
+					if (first_good_increment == increment) {
+						// They are the same, create both constraints at the same time to obtain a = constraint
+						// for even regions. constraints.merge(
+						constraints.merge(get_constraints_from_time_successor(
+						  synchronous_product::get_nth_time_successor(node_reg_a, *first_good_increment, K),
+						  K,
+						  automata::ta::ConstraintBoundType::BOTH));
+					} else {
+						constraints.merge(get_constraints_from_time_successor(
+						  synchronous_product::get_nth_time_successor(node_reg_a, *first_good_increment, K),
+						  K,
+						  automata::ta::ConstraintBoundType::LOWER));
+						constraints.merge(get_constraints_from_time_successor(
+						  synchronous_product::get_nth_time_successor(node_reg_a, *increment, K),
+						  K,
+						  automata::ta::ConstraintBoundType::UPPER));
+					}
 
 					for (const auto &[clock_name, constraint] : constraints) {
 						controller->add_clock(clock_name);

--- a/src/synchronous_product/include/synchronous_product/create_controller.h
+++ b/src/synchronous_product/include/synchronous_product/create_controller.h
@@ -44,12 +44,13 @@ get_constraints_from_time_successor(
 {
 	using TARegionState = synchronous_product::TARegionState<LocationT>;
 	std::multimap<std::string, automata::ClockConstraint> res;
+	const auto                                            max_region_index = 2 * max_constant + 1;
 	for (const auto &symbol : word) {
 		for (const auto &region_state : symbol) {
 			assert(std::holds_alternative<TARegionState>(region_state));
 			const TARegionState state = std::get<TARegionState>(region_state);
 			for (const auto &constraint : automata::ta::get_clock_constraints_from_region_index(
-			       state.region_index, 2 * max_constant + 1, bound_type)) {
+			       state.region_index, max_region_index, bound_type)) {
 				res.insert({{state.clock, constraint}});
 			}
 		}

--- a/src/synchronous_product/include/synchronous_product/create_controller.h
+++ b/src/synchronous_product/include/synchronous_product/create_controller.h
@@ -29,6 +29,7 @@
 #include <stdexcept>
 namespace controller_synthesis {
 
+namespace details {
 /** Construct a set of constraints from a time successor CanonicalABWord.
  */
 template <typename LocationT, typename ActionT>
@@ -54,10 +55,12 @@ get_constraints_from_time_successor(
 }
 
 template <typename LocationT, typename ActionT>
-automata::ta::TimedAutomaton<std::set<synchronous_product::CanonicalABWord<LocationT, ActionT>>,
-                             ActionT>
-create_controller(const synchronous_product::SearchTreeNode<LocationT, ActionT> *const root,
-                  synchronous_product::RegionIndex                                     K)
+void
+add_node_to_controller(
+  const synchronous_product::SearchTreeNode<LocationT, ActionT> *const node,
+  synchronous_product::RegionIndex                                     K,
+  automata::ta::TimedAutomaton<std::set<synchronous_product::CanonicalABWord<LocationT, ActionT>>,
+                               ActionT> *                              controller)
 {
 	using synchronous_product::NodeLabel;
 	using Transition =
@@ -65,45 +68,51 @@ create_controller(const synchronous_product::SearchTreeNode<LocationT, ActionT> 
 	                           ActionT>;
 	using Location =
 	  automata::ta::Location<std::set<synchronous_product::CanonicalABWord<LocationT, ActionT>>>;
-	auto               node = root;
-	std::set<Location> locations;
-	locations.emplace(root->words);
-	std::set<ActionT>       actions;
-	std::vector<Transition> transitions;
-	std::set<std::string>   clocks;
 	if (node->label != NodeLabel::TOP) {
 		throw std::invalid_argument(
-		  "Cannot create a controller for a search tree that is not labeled with TOP");
+		  "Cannot create a controller for a node that is not labeled with TOP");
 	}
-	while (!node->children.empty()) {
-		auto successor_it =
-		  std::find_if(begin(node->children), end(node->children), [](const auto &child) {
-			  return child->label == NodeLabel::TOP;
-		  });
-		if (successor_it == std::end(node->children)) {
-			break;
+	for (const auto &successor : node->children) {
+		if (successor->label != NodeLabel::TOP) {
+			continue;
 		}
-		auto successor = successor_it->get();
-		locations.emplace(successor->words);
+		controller->add_location(Location{successor->words});
+		controller->add_final_location(Location{successor->words});
 		for (const auto &[region_increment, action] : successor->incoming_actions) {
-			// TODO source/target location and action are done. What about clock constraints and resets?
-			// We need to reconstruct them from the node's words and the child's words.
+			// TODO source/target location and action are done. What about clock constraints and
+			// resets? We need to reconstruct them from the node's words and the child's words.
 			// Problem: We do not know which node word matches which child's node.
 			// Is it sufficient to consider the reg_a components of the words?
-			actions.insert(action);
+			controller->add_action(action);
 			auto constraints = get_constraints_from_time_successor(
 			  get_nth_time_successor(reg_a(*std::begin(node->words)), region_increment, K), K);
 			for (const auto &[clock_name, constraint] : constraints) {
-				clocks.insert(clock_name);
+				controller->add_clock(clock_name);
 			}
-			transitions.push_back(
+			controller->add_transition(
 			  Transition{Location{node->words}, action, Location{successor->words}, constraints, {}});
 		}
-		node = successor;
-	}
-	return automata::ta::TimedAutomaton<
-	  std::set<synchronous_product::CanonicalABWord<LocationT, ActionT>>,
-	  ActionT>{locations, actions, Location{root->words}, locations, clocks, transitions};
+		add_node_to_controller(successor.get(), K, controller);
+	};
+}
+
+} // namespace details
+
+template <typename LocationT, typename ActionT>
+automata::ta::TimedAutomaton<std::set<synchronous_product::CanonicalABWord<LocationT, ActionT>>,
+                             ActionT>
+create_controller(const synchronous_product::SearchTreeNode<LocationT, ActionT> *const root,
+                  synchronous_product::RegionIndex                                     K)
+{
+	using namespace details;
+	using synchronous_product::NodeLabel;
+	using Location =
+	  automata::ta::Location<std::set<synchronous_product::CanonicalABWord<LocationT, ActionT>>>;
+	automata::ta::TimedAutomaton<std::set<synchronous_product::CanonicalABWord<LocationT, ActionT>>,
+	                             ActionT>
+	  controller{{}, Location{root->words}, {}};
+	add_node_to_controller(root, K, &controller);
+	return controller;
 }
 
 } // namespace controller_synthesis

--- a/test/test_create_controller.cpp
+++ b/test/test_create_controller.cpp
@@ -169,11 +169,11 @@ TEST_CASE("Compute clock constraints from outgoing actions", "[controller]")
 {
 	using controller_synthesis::details::get_constraints_from_outgoing_actions;
 	using TARegionState = synchronous_product::TARegionState<std::string>;
-	// using ATARegionState = synchronous_product::ATARegionState<std::string>;
-	const synchronous_product::CanonicalABWord<std::string, std::string> word(
-	  {{TARegionState{Location{"s0"}, "c1", 0}}, {TARegionState{Location{"s0"}, "c2", 1}}});
 	CHECK(get_constraints_from_outgoing_actions<std::string, std::string>(
-	        {word}, {{synchronous_product::RegionIndex{1}, "a"}}, 3)
+	        {synchronous_product::CanonicalABWord<std::string, std::string>(
+	          {{TARegionState{Location{"s0"}, "c1", 0}}, {TARegionState{Location{"s0"}, "c2", 1}}})},
+	        {{synchronous_product::RegionIndex{1}, "a"}},
+	        3)
 	      == std::multimap<std::string, std::multimap<std::string, automata::ClockConstraint>>{
 	        {"a",
 	         std::multimap<std::string, automata::ClockConstraint>{
@@ -182,6 +182,18 @@ TEST_CASE("Compute clock constraints from outgoing actions", "[controller]")
 	           {"c1", automata::AtomicClockConstraintT<std::greater<automata::Time>>{0}},
 	           {"c1", automata::AtomicClockConstraintT<std::less<automata::Time>>{1}},
 	           {"c2", automata::AtomicClockConstraintT<std::equal_to<automata::Time>>{1}}}}});
+	CHECK(get_constraints_from_outgoing_actions<std::string, std::string>(
+	        {synchronous_product::CanonicalABWord<std::string, std::string>(
+	          {{TARegionState{Location{"s0"}, "c1", 0}}, {TARegionState{Location{"s0"}, "c2", 1}}})},
+	        {{synchronous_product::RegionIndex{1}, "a"}, {synchronous_product::RegionIndex{2}, "a"}},
+	        3)
+	      == std::multimap<std::string, std::multimap<std::string, automata::ClockConstraint>>{
+	        {"a",
+	         std::multimap<std::string, automata::ClockConstraint>{
+	           {"c1", automata::AtomicClockConstraintT<std::greater<automata::Time>>{0}},
+	           {"c1", automata::AtomicClockConstraintT<std::less_equal<automata::Time>>{1}},
+	           {"c2", automata::AtomicClockConstraintT<std::greater_equal<automata::Time>>{1}},
+	           {"c2", automata::AtomicClockConstraintT<std::less<automata::Time>>{2}}}}});
 }
 
 } // namespace

--- a/test/test_create_controller.cpp
+++ b/test/test_create_controller.cpp
@@ -20,12 +20,17 @@
 #include "automata/automata.h"
 #include "automata/ta.h"
 #include "automata/ta_product.h"
+#include "automata/ta_regions.h"
 #include "mtl/MTLFormula.h"
 #include "mtl_ata_translation/translator.h"
 #include "railroad.h"
+#include "synchronous_product/canonical_word.h"
 #include "synchronous_product/create_controller.h"
 #include "synchronous_product/search.h"
 #include "synchronous_product/search_tree.h"
+
+#include <spdlog/fmt/ostr.h>
+#include <spdlog/spdlog.h>
 
 #ifdef HAVE_VISUALIZATION
 #	include "visualization/ta_to_graphviz.h"
@@ -158,6 +163,25 @@ TEST_CASE("Controller can decide to do nothing", "[controller]")
 	auto controller = create_controller(search.get_root(), 1);
 	CAPTURE(controller);
 	CHECK(controller.get_transitions().empty());
+}
+
+TEST_CASE("Compute clock constraints from outgoing actions", "[controller]")
+{
+	using controller_synthesis::details::get_constraints_from_outgoing_actions;
+	using TARegionState = synchronous_product::TARegionState<std::string>;
+	// using ATARegionState = synchronous_product::ATARegionState<std::string>;
+	const synchronous_product::CanonicalABWord<std::string, std::string> word(
+	  {{TARegionState{Location{"s0"}, "c1", 0}}, {TARegionState{Location{"s0"}, "c2", 1}}});
+	CHECK(get_constraints_from_outgoing_actions<std::string, std::string>(
+	        {word}, {{synchronous_product::RegionIndex{1}, "a"}}, 3)
+	      == std::multimap<std::string, std::multimap<std::string, automata::ClockConstraint>>{
+	        {"a",
+	         std::multimap<std::string, automata::ClockConstraint>{
+	           // TODO The first two constraints are correct actually unnecessary as they are implied
+	           // by the third constraint. We should only produce the third constraint.
+	           {"c1", automata::AtomicClockConstraintT<std::greater<automata::Time>>{0}},
+	           {"c1", automata::AtomicClockConstraintT<std::less<automata::Time>>{1}},
+	           {"c2", automata::AtomicClockConstraintT<std::equal_to<automata::Time>>{1}}}}});
 }
 
 } // namespace

--- a/test/test_ta_region.cpp
+++ b/test/test_ta_region.cpp
@@ -100,6 +100,7 @@ TEST_CASE("Get largest region index", "[taRegion]")
 
 TEST_CASE("Get clock constraint from region", "[taRegion]")
 {
+	// both
 	CHECK(get_clock_constraints_from_region_index(0, 5)
 	      == std::vector<ClockConstraint>{AtomicClockConstraintT<std::equal_to<Time>>{0}});
 	CHECK(get_clock_constraints_from_region_index(1, 5)
@@ -114,6 +115,34 @@ TEST_CASE("Get clock constraint from region", "[taRegion]")
 	      == std::vector<ClockConstraint>{AtomicClockConstraintT<std::equal_to<Time>>{2}});
 	CHECK(get_clock_constraints_from_region_index(5, 5)
 	      == std::vector<ClockConstraint>{AtomicClockConstraintT<std::greater<Time>>{2}});
+
+	// lower
+	CHECK(get_clock_constraints_from_region_index(0, 5, ConstraintBoundType::LOWER)
+	      == std::vector<ClockConstraint>{});
+	CHECK(get_clock_constraints_from_region_index(1, 5, ConstraintBoundType::LOWER)
+	      == std::vector<ClockConstraint>{AtomicClockConstraintT<std::greater<Time>>{0}});
+	CHECK(get_clock_constraints_from_region_index(2, 5, ConstraintBoundType::LOWER)
+	      == std::vector<ClockConstraint>{AtomicClockConstraintT<std::greater_equal<Time>>{1}});
+	CHECK(get_clock_constraints_from_region_index(3, 5, ConstraintBoundType::LOWER)
+	      == std::vector<ClockConstraint>{AtomicClockConstraintT<std::greater<Time>>{1}});
+	CHECK(get_clock_constraints_from_region_index(4, 5, ConstraintBoundType::LOWER)
+	      == std::vector<ClockConstraint>{AtomicClockConstraintT<std::greater_equal<Time>>{2}});
+	CHECK(get_clock_constraints_from_region_index(5, 5, ConstraintBoundType::LOWER)
+	      == std::vector<ClockConstraint>{AtomicClockConstraintT<std::greater<Time>>{2}});
+
+	// upper
+	CHECK(get_clock_constraints_from_region_index(0, 5, ConstraintBoundType::UPPER)
+	      == std::vector<ClockConstraint>{AtomicClockConstraintT<std::equal_to<Time>>{0}});
+	CHECK(get_clock_constraints_from_region_index(1, 5, ConstraintBoundType::UPPER)
+	      == std::vector<ClockConstraint>{AtomicClockConstraintT<std::less<Time>>{1}});
+	CHECK(get_clock_constraints_from_region_index(2, 5, ConstraintBoundType::UPPER)
+	      == std::vector<ClockConstraint>{AtomicClockConstraintT<std::less_equal<Time>>{1}});
+	CHECK(get_clock_constraints_from_region_index(3, 5, ConstraintBoundType::UPPER)
+	      == std::vector<ClockConstraint>{AtomicClockConstraintT<std::less<Time>>{2}});
+	CHECK(get_clock_constraints_from_region_index(4, 5, ConstraintBoundType::UPPER)
+	      == std::vector<ClockConstraint>{AtomicClockConstraintT<std::less_equal<Time>>{2}});
+	CHECK(get_clock_constraints_from_region_index(5, 5, ConstraintBoundType::UPPER)
+	      == std::vector<ClockConstraint>{});
 }
 
 } // namespace


### PR DESCRIPTION
We may need all transitions to the successors, e.g., if one of them is an environment action that the environment may or may not take. So just add all successors. Additionally, merge the clock constraints such that two transitions with different but adjacent region increments that lead to the same successor node are merged into one.