### PR TITLE
Add more heuristics

### DIFF
--- a/src/synchronous_product/include/synchronous_product/heuristics.h
+++ b/src/synchronous_product/include/synchronous_product/heuristics.h
@@ -126,6 +126,46 @@ public:
 	}
 };
 
+/** @brief Prefer environment actions over controller actions.
+ * This heuristic assigns a cost of 0 to every node that has at least one environment action as
+ * incoming action. Otherwise, it assigns the cost 1.
+ */
+template <typename ValueT, typename LocationT, typename ActionT>
+class PreferEnvironmentActionHeuristic : public Heuristic<ValueT, LocationT, ActionT>
+{
+public:
+	/** Initialize the heuristic.
+	 * @param environment_actions The environment actions that may occur
+	 */
+	PreferEnvironmentActionHeuristic(const std::set<ActionT> &environment_actions)
+	: environment_actions(environment_actions)
+	{
+	}
+
+	/** Compute the cost of a node.
+	 * @param node The node to compute the cost for
+	 * @return 0 if the node contains an environment action as incoming action, 1 otherwise.
+	 */
+	ValueT
+	compute_cost(SearchTreeNode<LocationT, ActionT> *node) override
+	{
+		if (std::find_if(std::begin(node->incoming_actions),
+		                 std::end(node->incoming_actions),
+		                 [this](const auto &action) {
+			                 return environment_actions.find(action.second)
+			                        != std::end(environment_actions);
+		                 })
+		    != std::end(node->incoming_actions)) {
+			return 0;
+		} else {
+			return 1;
+		}
+	}
+
+private:
+	std::set<ActionT> environment_actions;
+};
+
 } // namespace synchronous_product
 
 #endif /* ifndef SRC_SYNCHRONOUS_PRODUCT_INCLUDE_SYNCHRONOUS_PRODUCT_HEURISTICS_H */

--- a/src/synchronous_product/include/synchronous_product/heuristics.h
+++ b/src/synchronous_product/include/synchronous_product/heuristics.h
@@ -166,6 +166,22 @@ private:
 	std::set<ActionT> environment_actions;
 };
 
+/** @brief Prefer nodes with a low number of canonical words. */
+template <typename ValueT, typename LocationT, typename ActionT>
+class NumCanonicalWordsHeuristic : public Heuristic<ValueT, LocationT, ActionT>
+{
+public:
+	/** Compute the cost of a node.
+	 * @param node The node to compute the cost for
+	 * @return The number of canonical worrds in the node
+	 */
+	ValueT
+	compute_cost(SearchTreeNode<LocationT, ActionT> *node) override
+	{
+		return node->words.size();
+	}
+};
+
 } // namespace synchronous_product
 
 #endif /* ifndef SRC_SYNCHRONOUS_PRODUCT_INCLUDE_SYNCHRONOUS_PRODUCT_HEURISTICS_H */

--- a/src/synchronous_product/include/synchronous_product/heuristics.h
+++ b/src/synchronous_product/include/synchronous_product/heuristics.h
@@ -182,6 +182,41 @@ public:
 	}
 };
 
+/** @brief Compose multiple heuristics.
+ * This heuristic computes a weighted sum over a set of heuristics.
+ */
+template <typename ValueT, typename LocationT, typename ActionT>
+class CompositeHeuristic : public Heuristic<ValueT, LocationT, ActionT>
+{
+public:
+	/** Initialize the heuristic.
+	 * @param heuristics A set of pairs (weight, heuristic) to use for the weighted sum
+	 */
+	CompositeHeuristic(
+	  std::vector<std::pair<ValueT, std::unique_ptr<Heuristic<ValueT, LocationT, ActionT>>>>
+	    heuristics)
+	: heuristics(std::move(heuristics))
+	{
+	}
+
+	/** Compute the cost of a node.
+	 * @param node The node to compute the cost for
+	 * @return The weighted sum over all the heuristics
+	 */
+	ValueT
+	compute_cost(SearchTreeNode<LocationT, ActionT> *node) override
+	{
+		ValueT res = 0;
+		for (auto &&[weight, heuristic] : heuristics) {
+			res += weight * heuristic->compute_cost(node);
+		}
+		return res;
+	}
+
+private:
+	std::vector<std::pair<ValueT, std::unique_ptr<Heuristic<ValueT, LocationT, ActionT>>>> heuristics;
+};
+
 } // namespace synchronous_product
 
 #endif /* ifndef SRC_SYNCHRONOUS_PRODUCT_INCLUDE_SYNCHRONOUS_PRODUCT_HEURISTICS_H */

--- a/test/test_heuristics.cpp
+++ b/test/test_heuristics.cpp
@@ -26,6 +26,8 @@
 
 namespace {
 
+using Node = synchronous_product::SearchTreeNode<std::string, std::string>;
+
 TEST_CASE("Test BFS heuristic", "[search][heuristics]")
 {
 	synchronous_product::BfsHeuristic<long, std::string, std::string> bfs{};
@@ -52,26 +54,16 @@ TEST_CASE("Test time heuristic", "[search][heuristics]")
 	spdlog::set_level(spdlog::level::debug);
 	synchronous_product::TimeHeuristic<long, std::string, std::string> h;
 
-	using Node = synchronous_product::SearchTreeNode<std::string, std::string>;
-	auto create_test_node =
-	  [](Node *                                                            parent  = nullptr,
-	     const std::set<std::pair<automata::ta::RegionIndex, std::string>> actions = {}) {
-		  auto node = std::make_unique<Node>(
-		    std::set<synchronous_product::CanonicalABWord<std::string, std::string>>{},
-		    parent,
-		    actions);
-		  return node;
-	  };
-	auto root = create_test_node();
-	CHECK(h.compute_cost(root.get()) == 0);
-	auto c1 = create_test_node(root.get(), {{1, "a1"}});
-	CHECK(h.compute_cost(c1.get()) == 1);
-	auto c2 = create_test_node(root.get(), {{3, "a1"}, {4, "b"}});
-	CHECK(h.compute_cost(c2.get()) == 3);
-	auto cc1 = create_test_node(c1.get(), {{2, "a"}, {4, "a"}});
-	CHECK(h.compute_cost(cc1.get()) == 3);
-	auto cc2 = create_test_node(c2.get(), {{2, "a"}, {4, "a"}});
-	CHECK(h.compute_cost(cc2.get()) == 5);
+	Node root{{}, nullptr, {}};
+	CHECK(h.compute_cost(&root) == 0);
+	Node c1{{}, &root, {{1, "a1"}}};
+	CHECK(h.compute_cost(&c1) == 1);
+	Node c2{{}, &root, {{3, "a1"}, {4, "b"}}};
+	CHECK(h.compute_cost(&c2) == 3);
+	Node cc1{{}, &c1, {{2, "a"}, {4, "a"}}};
+	CHECK(h.compute_cost(&cc1) == 3);
+	Node cc2{{}, &c2, {{2, "a"}, {4, "a"}}};
+	CHECK(h.compute_cost(&cc2) == 5);
 }
 
 } // namespace

--- a/test/test_heuristics.cpp
+++ b/test/test_heuristics.cpp
@@ -66,4 +66,17 @@ TEST_CASE("Test time heuristic", "[search][heuristics]")
 	CHECK(h.compute_cost(&cc2) == 5);
 }
 
+TEST_CASE("Test PreferEnvironmentActionHeuristic", "[search][heuristics]")
+{
+	synchronous_product::PreferEnvironmentActionHeuristic<long, std::string, std::string> h{
+	  std::set<std::string>{"environment_action"}};
+	Node root{{}, nullptr, {}};
+	Node n1{{}, &root, {{0, "environment_action"}}};
+	CHECK(h.compute_cost(&n1) == 0);
+	Node n2{{}, &root, {{0, "controller_action"}}};
+	CHECK(h.compute_cost(&n2) == 1);
+	Node n3{{}, &root, {{0, "environment_action"}, {1, "controller_action"}}};
+	CHECK(h.compute_cost(&n3) == 0);
+}
+
 } // namespace

--- a/test/test_heuristics.cpp
+++ b/test/test_heuristics.cpp
@@ -17,6 +17,7 @@
  *  Read the full text in the LICENSE.md file.
  */
 
+#include "automata/ta.h"
 #include "automata/ta_regions.h"
 #include "synchronous_product/canonical_word.h"
 #include "synchronous_product/heuristics.h"
@@ -77,6 +78,29 @@ TEST_CASE("Test PreferEnvironmentActionHeuristic", "[search][heuristics]")
 	CHECK(h.compute_cost(&n2) == 1);
 	Node n3{{}, &root, {{0, "environment_action"}, {1, "controller_action"}}};
 	CHECK(h.compute_cost(&n3) == 0);
+}
+
+TEST_CASE("Test NumCanonicalWordsHeuristic", "[search][heuristics]")
+{
+	using CanonicalABWord = synchronous_product::CanonicalABWord<std::string, std::string>;
+	using TARegionState   = synchronous_product::TARegionState<std::string>;
+	using ATARegionState  = synchronous_product::ATARegionState<std::string>;
+	using Location        = automata::ta::Location<std::string>;
+	synchronous_product::NumCanonicalWordsHeuristic<long, std::string, std::string> h{};
+	Node root{{}, nullptr, {}};
+	Node n1{{CanonicalABWord{{TARegionState{Location{"l"}, "c", 0}}}}, &root, {{1, "a"}}};
+	CHECK(h.compute_cost(&n1) == 1);
+	Node n2{{CanonicalABWord{{TARegionState{Location{"l"}, "c1", 0}},
+	                         {TARegionState{Location{"l"}, "c2", 1}}}},
+	        &root,
+	        {{1, "a"}}};
+	CHECK(h.compute_cost(&n2) == 1);
+	const logic::MTLFormula f{logic::AtomicProposition<std::string>{"a"}};
+	Node                    n3{{CanonicalABWord{{TARegionState{Location{"l1"}, "c", 0}}},
+           CanonicalABWord{{ATARegionState{f, 0}, TARegionState{Location{"l1"}, "c", 0}}}},
+          &root,
+          {{1, "a"}}};
+	CHECK(h.compute_cost(&n3) == 2);
 }
 
 } // namespace


### PR DESCRIPTION
Add three heuristics:
* The `PreferEnvironmentActionHeuristic` prefers environment actions over controller actions by assigning a cost of 0 if the node has an environment action as incoming action and 1 otherwise
* The `NumCanonicalWordsHeuristic` sets as cost the number of canonical words in a node
* The `CompositeHeuristic` can be used to combine heuristics