### PR TITLE
Add more detailed node description to allow analyzing the search tree

### DIFF
--- a/src/synchronous_product/include/synchronous_product/search.h
+++ b/src/synchronous_product/include/synchronous_product/search.h
@@ -204,9 +204,9 @@ public:
 		}
 		SPDLOG_TRACE("Processing {}", *node);
 		if (is_bad_node(node)) {
-			node->description = "Node is bad";
-			node->state       = NodeState::BAD;
-			node->is_expanded = true;
+			node->label_reason = LabelReason::BAD_NODE;
+			node->state        = NodeState::BAD;
+			node->is_expanded  = true;
 			if (incremental_labeling_) {
 				node->set_label(NodeLabel::BOTTOM, terminate_early_);
 				node->label_propagate(controller_actions_, environment_actions_, terminate_early_);
@@ -214,9 +214,9 @@ public:
 			return;
 		}
 		if (!has_satisfiable_ata_configuration(*node)) {
-			node->description = "No ATA successor";
-			node->state       = NodeState::GOOD;
-			node->is_expanded = true;
+			node->label_reason = LabelReason::NO_ATA_SUCCESSOR;
+			node->state        = NodeState::GOOD;
+			node->is_expanded  = true;
 			if (incremental_labeling_) {
 				node->set_label(NodeLabel::TOP, terminate_early_);
 				node->label_propagate(controller_actions_, environment_actions_, terminate_early_);
@@ -224,9 +224,9 @@ public:
 			return;
 		}
 		if (dominates_ancestor(node)) {
-			node->description = "monotonically dominated";
-			node->state       = NodeState::GOOD;
-			node->is_expanded = true;
+			node->label_reason = LabelReason::MONOTONIC_DOMINATION;
+			node->state        = NodeState::GOOD;
+			node->is_expanded  = true;
 			if (incremental_labeling_) {
 				node->set_label(NodeLabel::TOP, terminate_early_);
 				node->label_propagate(controller_actions_, environment_actions_, terminate_early_);
@@ -296,7 +296,7 @@ public:
 		if (node->children.empty()) {
 			node->state = NodeState::DEAD;
 			if (incremental_labeling_) {
-				node->description = "dead";
+				node->label_reason = LabelReason::DEAD_NODE;
 				node->set_label(NodeLabel::TOP, terminate_early_);
 				node->label_propagate(controller_actions_, environment_actions_, terminate_early_);
 			}

--- a/src/synchronous_product/include/synchronous_product/search.h
+++ b/src/synchronous_product/include/synchronous_product/search.h
@@ -204,6 +204,7 @@ public:
 		}
 		SPDLOG_TRACE("Processing {}", *node);
 		if (is_bad_node(node)) {
+			node->description = "Node is bad";
 			node->state       = NodeState::BAD;
 			node->is_expanded = true;
 			if (incremental_labeling_) {
@@ -212,7 +213,18 @@ public:
 			}
 			return;
 		}
-		if (!has_satisfiable_ata_configuration(*node) || dominates_ancestor(node)) {
+		if (!has_satisfiable_ata_configuration(*node)) {
+			node->description = "No ATA successor";
+			node->state       = NodeState::GOOD;
+			node->is_expanded = true;
+			if (incremental_labeling_) {
+				node->set_label(NodeLabel::TOP, terminate_early_);
+				node->label_propagate(controller_actions_, environment_actions_, terminate_early_);
+			}
+			return;
+		}
+		if (dominates_ancestor(node)) {
+			node->description = "monotonically dominated";
 			node->state       = NodeState::GOOD;
 			node->is_expanded = true;
 			if (incremental_labeling_) {
@@ -284,6 +296,7 @@ public:
 		if (node->children.empty()) {
 			node->state = NodeState::DEAD;
 			if (incremental_labeling_) {
+				node->description = "dead";
 				node->set_label(NodeLabel::TOP, terminate_early_);
 				node->label_propagate(controller_actions_, environment_actions_, terminate_early_);
 			}

--- a/src/synchronous_product/include/synchronous_product/search_tree.h
+++ b/src/synchronous_product/include/synchronous_product/search_tree.h
@@ -50,6 +50,18 @@ enum class NodeLabel {
 	CANCELED,
 };
 
+/** The reason for the current label, used for more detailed output */
+enum class LabelReason {
+	UNKNOWN,
+	BAD_NODE,
+	DEAD_NODE,
+	NO_ATA_SUCCESSOR,
+	MONOTONIC_DOMINATION,
+	NO_BAD_ENV_ACTION,
+	GOOD_CONTROLLER_ACTION_FIRST,
+	BAD_ENV_ACTION_FIRST
+};
+
 /** A node in the search tree
  * @see TreeSearch */
 template <typename Location, typename ActionType>
@@ -168,12 +180,12 @@ struct SearchTreeNode
 		             first_bad_environment_step);
 		// cases in which incremental labelling can be applied and recursive calls should be issued
 		if (first_non_good_environment_step == max && first_bad_environment_step == max) {
-			description = "No non-good or bad environment action";
+			label_reason = LabelReason::NO_BAD_ENV_ACTION;
 			set_label(NodeLabel::TOP, cancel_children);
 			SPDLOG_TRACE("{}: No non-good or bad environment action", NodeLabel::TOP);
 		} else if (first_good_controller_step < first_non_good_environment_step
 		           && first_good_controller_step < first_bad_environment_step) {
-			description = "Good controller action first";
+			label_reason = LabelReason::GOOD_CONTROLLER_ACTION_FIRST;
 			set_label(NodeLabel::TOP, cancel_children);
 			SPDLOG_TRACE("{}: Good controller action at {}, before first non-good env action at {}",
 			             NodeLabel::TOP,
@@ -182,7 +194,7 @@ struct SearchTreeNode
 		} else if (first_bad_environment_step < max
 		           && first_bad_environment_step <= first_good_controller_step
 		           && first_bad_environment_step <= first_non_bad_controller_step) {
-			description = "Bad env action first";
+			label_reason = LabelReason::BAD_ENV_ACTION_FIRST;
 			set_label(NodeLabel::BOTTOM, cancel_children);
 			SPDLOG_TRACE("{}: Bad env action at {}, before first non-bad controller action at {}",
 			             NodeLabel::BOTTOM,
@@ -248,7 +260,8 @@ struct SearchTreeNode
 	std::vector<std::unique_ptr<SearchTreeNode>> children = {};
 	/** The set of actions on the incoming edge, i.e., how we can reach this node from its parent */
 	std::set<std::pair<RegionIndex, ActionType>> incoming_actions;
-	std::string                                  description{""};
+	/** A more detailed description for the node that explains the current label. */
+	LabelReason label_reason = LabelReason::UNKNOWN;
 };
 
 /** Print a node state. */

--- a/src/synchronous_product/include/synchronous_product/search_tree.h
+++ b/src/synchronous_product/include/synchronous_product/search_tree.h
@@ -168,10 +168,12 @@ struct SearchTreeNode
 		             first_bad_environment_step);
 		// cases in which incremental labelling can be applied and recursive calls should be issued
 		if (first_non_good_environment_step == max && first_bad_environment_step == max) {
+			description = "No non-good or bad environment action";
 			set_label(NodeLabel::TOP, cancel_children);
 			SPDLOG_TRACE("{}: No non-good or bad environment action", NodeLabel::TOP);
 		} else if (first_good_controller_step < first_non_good_environment_step
 		           && first_good_controller_step < first_bad_environment_step) {
+			description = "Good controller action first";
 			set_label(NodeLabel::TOP, cancel_children);
 			SPDLOG_TRACE("{}: Good controller action at {}, before first non-good env action at {}",
 			             NodeLabel::TOP,
@@ -180,6 +182,7 @@ struct SearchTreeNode
 		} else if (first_bad_environment_step < max
 		           && first_bad_environment_step <= first_good_controller_step
 		           && first_bad_environment_step <= first_non_bad_controller_step) {
+			description = "Bad env action first";
 			set_label(NodeLabel::BOTTOM, cancel_children);
 			SPDLOG_TRACE("{}: Bad env action at {}, before first non-bad controller action at {}",
 			             NodeLabel::BOTTOM,
@@ -245,6 +248,7 @@ struct SearchTreeNode
 	std::vector<std::unique_ptr<SearchTreeNode>> children = {};
 	/** The set of actions on the incoming edge, i.e., how we can reach this node from its parent */
 	std::set<std::pair<RegionIndex, ActionType>> incoming_actions;
+	std::string                                  description{""};
 };
 
 /** Print a node state. */

--- a/src/visualization/include/visualization/tree_to_graphviz.h
+++ b/src/visualization/include/visualization/tree_to_graphviz.h
@@ -64,7 +64,8 @@ add_search_node_to_graph(const synchronous_product::SearchTreeNode<LocationT, Ac
 
 	// Split the incoming actions into node sections.
 	// Put the incoming actions into their own group (with {}) to separate the from the words.
-	utilities::graphviz::Node node{graph->add_node(fmt::format("{{{}}}|{}",
+	utilities::graphviz::Node node{graph->add_node(fmt::format("{{{}}}|{{{}}}|{}",
+	                                                           search_node->description,
 	                                                           fmt::join(incoming_action_labels, "|"),
 	                                                           fmt::join(words_labels, "|")))};
 	// Set the node color according to its label.

--- a/src/visualization/include/visualization/tree_to_graphviz.h
+++ b/src/visualization/include/visualization/tree_to_graphviz.h
@@ -28,6 +28,8 @@
 
 namespace visualization {
 
+using synchronous_product::LabelReason;
+
 /** @brief Add a search tree node to a dot graph visualization of the search tree.
  * Add node as dot node to thegraph. Additionally, add all its children along
  * with edges from the given node to its children.
@@ -62,10 +64,23 @@ add_search_node_to_graph(const synchronous_product::SearchTreeNode<LocationT, Ac
 		  fmt::format("({}, {})", incoming_action.first, incoming_action.second));
 	}
 
+	std::string label_reason;
+	switch (search_node->label_reason) {
+	case LabelReason::UNKNOWN: label_reason = "unknown"; break;
+	case LabelReason::BAD_NODE: label_reason = "bad node"; break;
+	case LabelReason::DEAD_NODE: label_reason = "dead node"; break;
+	case LabelReason::NO_ATA_SUCCESSOR: label_reason = "no ATA successor"; break;
+	case LabelReason::MONOTONIC_DOMINATION: label_reason = "monotonic domination"; break;
+	case LabelReason::NO_BAD_ENV_ACTION: label_reason = "no bad env action"; break;
+	case LabelReason::GOOD_CONTROLLER_ACTION_FIRST:
+		label_reason = "good controller action first";
+		break;
+	case LabelReason::BAD_ENV_ACTION_FIRST: label_reason = "bad env action first"; break;
+	}
 	// Split the incoming actions into node sections.
 	// Put the incoming actions into their own group (with {}) to separate the from the words.
 	utilities::graphviz::Node node{graph->add_node(fmt::format("{{{}}}|{{{}}}|{}",
-	                                                           search_node->description,
+	                                                           label_reason,
 	                                                           fmt::join(incoming_action_labels, "|"),
 	                                                           fmt::join(words_labels, "|")))};
 	// Set the node color according to its label.


### PR DESCRIPTION
Add a label reason to each node that shortly describes why a node has a certain label and print the label in the visualization. This greatly helps understanding what happens during search.