### PR TITLE
Extend railroad test to a benchmark

### DIFF
--- a/src/search/include/search/search.h
+++ b/src/search/include/search/search.h
@@ -272,8 +272,8 @@ public:
 
 		// Create child nodes, where each child contains all successors words of
 		// the same reg_a class.
-		std::transform(std::make_move_iterator(std::begin(child_classes)),
-		               std::make_move_iterator(std::end(child_classes)),
+		std::transform(std::begin(child_classes),
+		               std::end(child_classes),
 		               std::back_inserter(node->children),
 		               [node, &outgoing_actions](auto &&map_entry) {
 			               auto child =

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -22,7 +22,7 @@ if (COVERAGE)
 endif()
 
 add_library(railroad SHARED railroad.cpp)
-target_link_libraries(railroad PUBLIC ta search)
+target_link_libraries(railroad PUBLIC ta search mtl visualization)
 
 add_library(fischer SHARED fischer.cpp)
 target_link_libraries(fischer PUBLIC ta search)

--- a/test/railroad.cpp
+++ b/test/railroad.cpp
@@ -20,8 +20,6 @@
 
 #include "railroad.h"
 
-#include "automata/automata.h"
-#include "automata/ta.h"
 #include "automata/ta_product.h"
 
 using automata::Time;
@@ -72,15 +70,17 @@ create_crossing_problem(std::vector<Time> distances)
 		                 {{clock, AtomicClockConstraintT<std::equal_to<Time>>(2)}},
 		                 {clock})}});
 		const std::string i_s = std::to_string(i);
-		const auto        far = i == 1 ? Location{"FAR"} : Location{"BEHIND_" + std::to_string(i - 1)};
-		const Location    near{"NEAR_" + i_s};
-		const Location    in{"IN_" + i_s};
-		const Location    behind{"BEHIND_" + i_s};
-		train_locations.insert({far, near, in, behind});
+		const auto     far = i == 1 ? Location{"FAR"} : Location{"FAR_BEHIND_" + std::to_string(i - 1)};
+		const Location near{"NEAR_" + i_s};
+		const Location in{"IN_" + i_s};
+		const Location behind{"BEHIND_" + i_s};
+		const Location far_behind{"FAR_BEHIND_" + i_s};
+		train_locations.insert({far, near, in, behind, far_behind});
 		const std::string get_near{"get_near_" + i_s};
 		const std::string enter{"enter_" + i_s};
 		const std::string leave{"leave_" + i_s};
-		train_actions.insert({get_near, enter, leave});
+		const std::string travel{"travel_" + i_s};
+		train_actions.insert({get_near, enter, leave, travel});
 		train_transitions.push_back(
 		  Transition{far,
 		             get_near,
@@ -91,11 +91,13 @@ create_crossing_problem(std::vector<Time> distances)
 		  Transition{near, enter, in, {{"t", AtomicClockConstraintT<std::greater<Time>>(2)}}, {"t"}});
 		train_transitions.push_back(Transition{
 		  in, leave, behind, {{"t", AtomicClockConstraintT<std::equal_to<Time>>(1)}}, {"t"}});
+		train_transitions.push_back(Transition{
+		  behind, travel, far_behind, {{"t", AtomicClockConstraintT<std::greater<Time>>(2)}}, {"t"}});
 	}
 	automata.push_back(TA{train_locations,
 	                      train_actions,
 	                      Location{"FAR"},
-	                      {Location{"BEHIND_" + std::to_string(distances.size())}},
+	                      {Location{"FAR_BEHIND_" + std::to_string(distances.size())}},
 	                      {"t"},
 	                      train_transitions});
 	environment_actions.insert(std::begin(train_actions), std::end(train_actions));

--- a/test/railroad.cpp
+++ b/test/railroad.cpp
@@ -21,14 +21,20 @@
 #include "railroad.h"
 
 #include "automata/ta_product.h"
+#include "mtl/MTLFormula.h"
+#include "utilities/Interval.h"
+#include "visualization/ta_to_graphviz.h"
 
 using automata::Time;
 using Location   = automata::ta::Location<std::string>;
 using TA         = automata::ta::TimedAutomaton<std::string, std::string>;
 using Transition = automata::ta::Transition<std::string, std::string>;
 using automata::AtomicClockConstraintT;
+using F  = logic::MTLFormula<std::string>;
+using AP = logic::AtomicProposition<std::string>;
 
 std::tuple<automata::ta::TimedAutomaton<std::vector<std::string>, std::string>,
+           logic::MTLFormula<std::string>,
            std::set<std::string>,
            std::set<std::string>>
 create_crossing_problem(std::vector<Time> distances)
@@ -39,6 +45,7 @@ create_crossing_problem(std::vector<Time> distances)
 	std::set<std::string>   train_actions;
 	std::set<Location>      train_locations;
 	std::vector<Transition> train_transitions;
+	std::vector<F>          spec_disjuncts;
 	for (std::size_t i = 1; i <= distances.size(); ++i) {
 		const std::string clock        = "c_" + std::to_string(i);
 		const std::string start_close  = "start_close_" + std::to_string(i);
@@ -46,29 +53,30 @@ create_crossing_problem(std::vector<Time> distances)
 		const std::string start_open   = "start_open_" + std::to_string(i);
 		const std::string finish_open  = "finish_open_" + std::to_string(i);
 		controller_actions.insert({start_close, start_open, finish_close, finish_open});
-		// environment_actions.insert({});
 		automata.push_back(
 		  TA{{Location{"OPEN"}, Location{"CLOSING"}, Location{"CLOSED"}, Location{"OPENING"}},
 		     {start_close, finish_close, start_open, finish_open},
 		     Location{"OPEN"},
 		     {Location{"OPEN"}, Location{"CLOSING"}, Location{"CLOSED"}, Location{"OPENING"}},
 		     {clock},
-		     {Transition(Location{"OPEN"}, start_close, Location{"CLOSING"}, {}, {clock}),
-		      Transition(Location{"CLOSING"},
-		                 finish_close,
-		                 Location{"CLOSED"},
-		                 {{clock, AtomicClockConstraintT<std::equal_to<Time>>(1)}},
-		                 {clock}),
-		      Transition(Location{"CLOSED"},
-		                 start_open,
-		                 Location{"OPENING"},
-		                 {{clock, AtomicClockConstraintT<std::greater_equal<Time>>(1)}},
-		                 {clock}),
-		      Transition(Location{"OPENING"},
-		                 finish_open,
-		                 Location{"OPEN"},
-		                 {{clock, AtomicClockConstraintT<std::equal_to<Time>>(2)}},
-		                 {clock})}});
+		     {
+		       Transition(Location{"OPEN"}, start_close, Location{"CLOSING"}, {}, {clock}),
+		       Transition(Location{"CLOSING"},
+		                  finish_close,
+		                  Location{"CLOSED"},
+		                  {{clock, AtomicClockConstraintT<std::equal_to<Time>>(1)}},
+		                  {clock}),
+		       Transition(Location{"CLOSED"},
+		                  start_open,
+		                  Location{"OPENING"},
+		                  {{clock, AtomicClockConstraintT<std::greater_equal<Time>>(1)}},
+		                  {clock}),
+		       Transition(Location{"OPENING"},
+		                  finish_open,
+		                  Location{"OPEN"},
+		                  {{clock, AtomicClockConstraintT<std::equal_to<Time>>(1)}},
+		                  {clock}),
+		     }});
 		const std::string i_s = std::to_string(i);
 		const auto     far = i == 1 ? Location{"FAR"} : Location{"FAR_BEHIND_" + std::to_string(i - 1)};
 		const Location near{"NEAR_" + i_s};
@@ -85,14 +93,28 @@ create_crossing_problem(std::vector<Time> distances)
 		  Transition{far,
 		             get_near,
 		             near,
-		             {{"t", AtomicClockConstraintT<std::greater<Time>>(distances[i - 1])}},
+		             {{"t", AtomicClockConstraintT<std::equal_to<Time>>(distances[i - 1])}},
 		             {"t"}});
 		train_transitions.push_back(
-		  Transition{near, enter, in, {{"t", AtomicClockConstraintT<std::greater<Time>>(2)}}, {"t"}});
+		  Transition{near,
+		             enter,
+		             in,
+		             {{"t", AtomicClockConstraintT<std::greater_equal<Time>>(0)},
+		              {"t", AtomicClockConstraintT<std::less_equal<Time>>(1)}},
+		             {"t"}});
 		train_transitions.push_back(Transition{
 		  in, leave, behind, {{"t", AtomicClockConstraintT<std::equal_to<Time>>(1)}}, {"t"}});
 		train_transitions.push_back(Transition{
-		  behind, travel, far_behind, {{"t", AtomicClockConstraintT<std::greater<Time>>(2)}}, {"t"}});
+		  behind, travel, far_behind, {{"t", AtomicClockConstraintT<std::equal_to<Time>>(2)}}, {"t"}});
+		const auto finish_close_f = F{AP{finish_close}};
+		const auto start_open_f   = F{AP{start_open}};
+		const auto finish_open_f  = F{AP{finish_open}};
+		const auto enter_f        = F{AP{enter}};
+		const auto leave_f        = F{AP{leave}};
+		const auto travel_f       = F{AP{travel}};
+		spec_disjuncts.push_back(enter_f.dual_until(!finish_close_f)
+		                         || start_open_f.dual_until(!leave_f)
+		                         || travel_f.dual_until(!finish_open_f));
 	}
 	automata.push_back(TA{train_locations,
 	                      train_actions,
@@ -101,7 +123,19 @@ create_crossing_problem(std::vector<Time> distances)
 	                      {"t"},
 	                      train_transitions});
 	environment_actions.insert(std::begin(train_actions), std::end(train_actions));
+	auto spec = spec_disjuncts[0];
+	std::for_each(std::next(std::begin(spec_disjuncts)),
+	              std::end(spec_disjuncts),
+	              [&spec](auto &&spec_disjunct) { spec = spec || spec_disjunct; });
+	for (std::size_t i = 1; i < automata.size(); i++) {
+		visualization::ta_to_graphviz(automata[i - 1])
+		  .render_to_file(fmt::format("railroad{}_crossing_{}.pdf", distances.size(), i));
+	}
+	visualization::ta_to_graphviz(automata.back())
+	  .render_to_file(fmt::format("railroad{}_train.pdf", distances.size()));
+
 	return std::make_tuple(automata::ta::get_product(automata),
+	                       spec,
 	                       controller_actions,
 	                       environment_actions);
 }

--- a/test/railroad.h
+++ b/test/railroad.h
@@ -22,6 +22,7 @@
 
 #include "automata/automata.h"
 #include "automata/ta.h"
+#include "mtl/MTLFormula.h"
 
 #include <set>
 #include <string>
@@ -29,6 +30,7 @@
 #include <vector>
 
 std::tuple<automata::ta::TimedAutomaton<std::vector<std::string>, std::string>,
+           logic::MTLFormula<std::string>,
            std::set<std::string>,
            std::set<std::string>>
 create_crossing_problem(std::vector<automata::Time> distances);

--- a/test/test_ata.cpp
+++ b/test/test_ata.cpp
@@ -423,7 +423,7 @@ TEST_CASE("ATA with sink location", "[ta]")
 	CHECK(!ata.accepts_word({{"b", 0}, {"b", 1}, {"a", 2}}));
 }
 
-TEST_CASE("ATA must not contain the sink location in any transition", "[]")
+TEST_CASE("ATA must not contain the sink location in any transition", "[ta]")
 {
 	std::set<Transition<std::string, std::string>> transitions;
 	SECTION("sink in initial location")

--- a/test/test_create_controller.cpp
+++ b/test/test_create_controller.cpp
@@ -73,8 +73,7 @@ TEST_CASE("Create a simple controller", "[controller]")
 	CAPTURE(ta);
 	CAPTURE(spec);
 	CAPTURE(ata);
-	search::TreeSearch<std::string, std::string> search(
-	  &ta, &ata, {"c"}, {"e"}, 1, true, false);
+	search::TreeSearch<std::string, std::string> search(&ta, &ata, {"c"}, {"e"}, 1, true, false);
 	search.build_tree();
 #ifdef HAVE_VISUALIZATION
 	visualization::search_tree_to_graphviz(*search.get_root()).render_to_file("simple_tree.svg");
@@ -150,8 +149,7 @@ TEST_CASE("Controller can decide to do nothing", "[controller]")
 	auto ata = mtl_ata_translation::translate(logic::finally(logic::MTLFormula{ap_e}), {ap_c, ap_e});
 	CAPTURE(ta);
 	CAPTURE(ata);
-	search::TreeSearch<std::string, std::string> search(
-	  &ta, &ata, {"c"}, {"e"}, 0, true, false);
+	search::TreeSearch<std::string, std::string> search(&ta, &ata, {"c"}, {"e"}, 0, true, false);
 	search.build_tree(false);
 	INFO("Tree:\n" << search::node_to_string(*search.get_root(), true));
 	CHECK(search.get_root()->label == NodeLabel::TOP);

--- a/test/test_railroad.cpp
+++ b/test/test_railroad.cpp
@@ -66,20 +66,20 @@ TEST_CASE("A single railroad crossing", "[.railroad]")
 	const auto travel       = F{AP{"travel_1"}};
 	const auto spec         = enter.dual_until(!finish_close) || start_open.dual_until(!leave)
 	                  || travel.dual_until(!finish_open);
+	INFO("Spec: " << spec);
 	auto ata = mtl_ata_translation::translate(spec, actions);
 	INFO("TA: " << product);
 	INFO("ATA: " << ata);
-	const auto K = std::max(automata::ta::get_maximal_region_index(product),
-	                        static_cast<unsigned int>(spec.get_maximal_region_index()));
-	TreeSearch search{
-	  &product,
-	  &ata,
-	  controller_actions,
-	  environment_actions,
-	  K,
-	  true,
-	  true,
-	  std::make_unique<search::TimeHeuristic<long, std::vector<std::string>, std::string>>()};
+	const unsigned int K = std::max(product.get_largest_constant(), spec.get_largest_constant());
+	TreeSearch         search{
+    &product,
+    &ata,
+    controller_actions,
+    environment_actions,
+    K,
+    true,
+    true,
+    std::make_unique<search::TimeHeuristic<long, std::vector<std::string>, std::string>>()};
 
 	search.build_tree(true);
 	// INFO("Tree:\n" << search::node_to_string(*search.get_root(), true));

--- a/test/test_railroad.cpp
+++ b/test/test_railroad.cpp
@@ -62,15 +62,15 @@ TEST_CASE("Railroad crossing benchmark", "[.benchmark][railroad]")
 {
 	spdlog::set_level(spdlog::level::debug);
 	spdlog::set_pattern("%t %v");
-	// auto distances = GENERATE(values({std::vector<Time>{2}, std::vector<Time>{2, 2}}));
-	const std::vector<Time> distances           = {2};
-	const auto              num_crossings       = distances.size();
-	const auto              problem             = create_crossing_problem(distances);
-	auto                    plant               = std::get<0>(problem);
-	auto                    spec                = std::get<1>(problem);
-	auto                    controller_actions  = std::get<2>(problem);
-	auto                    environment_actions = std::get<3>(problem);
-	std::set<AP>            actions;
+	auto distances =
+	  GENERATE(values({std::vector<Time>{2}, std::vector<Time>{2, 2}, std::vector<Time>{2, 4}}));
+	const auto   num_crossings       = distances.size();
+	const auto   problem             = create_crossing_problem(distances);
+	auto         plant               = std::get<0>(problem);
+	auto         spec                = std::get<1>(problem);
+	auto         controller_actions  = std::get<2>(problem);
+	auto         environment_actions = std::get<3>(problem);
+	std::set<AP> actions;
 	std::set_union(begin(controller_actions),
 	               end(controller_actions),
 	               begin(environment_actions),
@@ -89,9 +89,11 @@ TEST_CASE("Railroad crossing benchmark", "[.benchmark][railroad]")
 	// auto weight_canonical_words = GENERATE(4, 6, 10, 15);
 	auto weight_plant           = 12;
 	auto weight_canonical_words = 10;
-	BENCHMARK(fmt::format("Run search with weight_plant={}, weight_canonical_words={}",
-	                      weight_plant,
-	                      weight_canonical_words))
+	BENCHMARK(
+	  fmt::format("Run search with weight_plant={}, weight_canonical_words={}, distances=({})",
+	              weight_plant,
+	              weight_canonical_words,
+	              fmt::join(distances, ", ")))
 	{
 		std::vector<std::pair<long, std::unique_ptr<H>>> heuristics;
 		heuristics.emplace_back(

--- a/test/test_railroad.cpp
+++ b/test/test_railroad.cpp
@@ -17,7 +17,7 @@
  *  Read the full text in the LICENSE.md file.
  */
 
-#define SPDLOG_ACTIVE_LEVEL SPDLOG_LEVEL_DEBUG
+#define SPDLOG_ACTIVE_LEVEL SPDLOG_LEVEL_ERROR
 
 #include "automata/automata.h"
 #include "automata/ta.h"
@@ -26,15 +26,26 @@
 #include "mtl/MTLFormula.h"
 #include "mtl_ata_translation/translator.h"
 #include "railroad.h"
+#include "search/canonical_word.h"
 #include "search/create_controller.h"
 #include "search/heuristics.h"
 #include "search/search.h"
 #include "search/search_tree.h"
+#include "search/synchronous_product.h"
 #include "visualization/ta_to_graphviz.h"
 #include "visualization/tree_to_graphviz.h"
 
+#include <fmt/format.h>
+#include <fmt/ostream.h>
+#include <spdlog/common.h>
+#include <spdlog/spdlog.h>
+
 #include <catch2/benchmark/catch_benchmark.hpp>
 #include <catch2/catch_test_macros.hpp>
+#include <catch2/generators/catch_generators.hpp>
+#include <iterator>
+
+#undef TRUE
 
 namespace {
 
@@ -47,166 +58,67 @@ using AP = logic::AtomicProposition<std::string>;
 using search::NodeLabel;
 using TreeSearch = search::TreeSearch<std::vector<std::string>, std::string>;
 
-TEST_CASE("A single railroad crossing", "[.railroad]")
+TEST_CASE("Railroad crossing benchmark", "[.benchmark][railroad]")
 {
-	spdlog::set_level(spdlog::level::trace);
+	spdlog::set_level(spdlog::level::debug);
 	spdlog::set_pattern("%t %v");
-	const auto &[product, controller_actions, environment_actions] = create_crossing_problem({2});
-	std::set<AP> actions;
+	// auto distances = GENERATE(values({std::vector<Time>{2}, std::vector<Time>{2, 2}}));
+	const std::vector<Time> distances           = {2};
+	const auto              num_crossings       = distances.size();
+	const auto              problem             = create_crossing_problem(distances);
+	auto                    plant               = std::get<0>(problem);
+	auto                    spec                = std::get<1>(problem);
+	auto                    controller_actions  = std::get<2>(problem);
+	auto                    environment_actions = std::get<3>(problem);
+	std::set<AP>            actions;
 	std::set_union(begin(controller_actions),
 	               end(controller_actions),
 	               begin(environment_actions),
 	               end(environment_actions),
 	               inserter(actions, end(actions)));
-	const auto finish_close = F{AP{"finish_close_1"}};
-	const auto start_open   = F{AP{"start_open_1"}};
-	const auto finish_open  = F{AP{"finish_open_1"}};
-	const auto enter        = F{AP{"enter_1"}};
-	const auto leave        = F{AP{"leave_1"}};
-	const auto travel       = F{AP{"travel_1"}};
-	const auto spec         = enter.dual_until(!finish_close) || start_open.dual_until(!leave)
-	                  || travel.dual_until(!finish_open);
-	INFO("Spec: " << spec);
+	CAPTURE(spec);
 	auto ata = mtl_ata_translation::translate(spec, actions);
-	INFO("TA: " << product);
-	INFO("ATA: " << ata);
-	const unsigned int K = std::max(product.get_largest_constant(), spec.get_largest_constant());
-	TreeSearch         search{
-    &product,
-    &ata,
-    controller_actions,
-    environment_actions,
-    K,
-    true,
-    true,
-    std::make_unique<search::TimeHeuristic<long, std::vector<std::string>, std::string>>()};
+	CAPTURE(plant);
+	CAPTURE(ata);
+	const unsigned int K = std::max(plant.get_largest_constant(), spec.get_largest_constant());
 
-	search.build_tree(true);
-	// INFO("Tree:\n" << search::node_to_string(*search.get_root(), true));
-#ifdef HAVE_VISUALIZATION
-	visualization::search_tree_to_graphviz(*search.get_root(), true).render_to_file("railroad1.svg");
-	visualization::ta_to_graphviz(controller_synthesis::create_controller(search.get_root(), 2))
-	  .render_to_file("railroad_controller.pdf");
-#endif
-	CHECK(search.get_root()->label == NodeLabel::TOP);
-}
-
-TEST_CASE("Two railroad crossings", "[.medium][railroad]")
-{
-	spdlog::set_level(spdlog::level::trace);
-	spdlog::set_pattern("%t %v");
-	const auto   problem             = create_crossing_problem({2, 4});
-	auto         plant               = std::get<0>(problem);
-	auto         controller_actions  = std::get<1>(problem);
-	auto         environment_actions = std::get<2>(problem);
-	std::set<AP> actions;
-	std::set_union(begin(controller_actions),
-	               end(controller_actions),
-	               begin(environment_actions),
-	               end(environment_actions),
-	               inserter(actions, end(actions)));
-	const auto finish_close_1 = F{AP{"finish_close_1"}};
-	const auto start_open_1   = F{AP{"start_open_1"}};
-	const auto enter_1        = F{AP{"enter_1"}};
-	const auto finish_close_2 = F{AP{"finish_close_2"}};
-	const auto start_open_2   = F{AP{"start_open_2"}};
-	const auto enter_2        = F{AP{"enter_2"}};
-	auto       ata =
-	  mtl_ata_translation::translate(((!finish_close_1).until(enter_1) && finally(enter_1))
-	                                   || ((!finish_close_2).until(enter_2) && finally(enter_2)),
-	                                 actions);
-	INFO("TA: " << plant);
-	INFO("ATA: " << ata);
-	BENCHMARK("Run the search")
+	using H = search::Heuristic<long, std::vector<std::string>, std::string>;
+	//	auto weight_plant = GENERATE(-5, -1, 0, 1, 10);
+	//	auto weight_canonical_words = GENERATE(-5, 0, 5);
+	// auto weight_plant           = GENERATE(8, 10, 12, 15);
+	// auto weight_canonical_words = GENERATE(4, 6, 10, 15);
+	auto weight_plant           = 12;
+	auto weight_canonical_words = 10;
+	BENCHMARK(fmt::format("Run search with weight_plant={}, weight_canonical_words={}",
+	                      weight_plant,
+	                      weight_canonical_words))
 	{
-		TreeSearch search{
-		  &plant,
-		  &ata,
-		  controller_actions,
-		  environment_actions,
-		  4,
-		  true,
-		  true,
-		  std::make_unique<search::TimeHeuristic<long, std::vector<std::string>, std::string>>()};
+		std::vector<std::pair<long, std::unique_ptr<H>>> heuristics;
+		heuristics.emplace_back(
+		  weight_canonical_words,
+		  std::make_unique<
+		    search::NumCanonicalWordsHeuristic<long, std::vector<std::string>, std::string>>());
+		heuristics.emplace_back(
+		  weight_plant,
+		  std::make_unique<
+		    search::PreferEnvironmentActionHeuristic<long, std::vector<std::string>, std::string>>(
+		    environment_actions));
+		heuristics.emplace_back(
+		  1, std::make_unique<search::TimeHeuristic<long, std::vector<std::string>, std::string>>());
+		std::unique_ptr<H> heuristic{new search::CompositeHeuristic(std::move(heuristics))};
+		TreeSearch         search{
+      &plant, &ata, controller_actions, environment_actions, K, true, true, std::move(heuristic)};
+
 		search.build_tree(true);
-		// INFO("Tree:\n" << search::node_to_string(*search.get_root(), true));
-#ifdef HAVE_VISUALIZATION
-		// visualization::search_tree_to_graphviz(*search.get_root(), true)
-		//  .render_to_file("railroad2.svg");
-#endif
-		std::size_t size         = 0;
-		std::size_t non_canceled = 0;
-		for (auto it = search::begin(search.get_root()); it != search::end(search.get_root()); it++) {
-			size++;
-			if (it->label != search::NodeLabel::CANCELED) {
-				non_canceled++;
-			}
-		}
-		INFO("Tree size: " << size);
-		INFO("Non-canceled: " << non_canceled);
 		CHECK(search.get_root()->label == NodeLabel::TOP);
-	};
-}
-
-TEST_CASE("Three railroad crossings", "[.large][railroad]")
-{
-	spdlog::set_level(spdlog::level::trace);
-	spdlog::set_pattern("%t %v");
-	const auto   problem             = create_crossing_problem({2, 2, 2});
-	auto         plant               = std::get<0>(problem);
-	auto         controller_actions  = std::get<1>(problem);
-	auto         environment_actions = std::get<2>(problem);
-	std::set<AP> actions;
-	std::set_union(begin(controller_actions),
-	               end(controller_actions),
-	               begin(environment_actions),
-	               end(environment_actions),
-	               inserter(actions, end(actions)));
-	const auto finish_close_1 = F{AP{"finish_close_1"}};
-	const auto start_open_1   = F{AP{"start_open_1"}};
-	const auto enter_1        = F{AP{"enter_1"}};
-	const auto finish_close_2 = F{AP{"finish_close_2"}};
-	const auto start_open_2   = F{AP{"start_open_2"}};
-	const auto enter_2        = F{AP{"enter_2"}};
-	const auto finish_close_3 = F{AP{"finish_close_3"}};
-	const auto start_open_3   = F{AP{"start_open_3"}};
-	const auto enter_3        = F{AP{"enter_3"}};
-	auto       ata =
-	  mtl_ata_translation::translate(((!finish_close_1).until(enter_1) && finally(enter_1))
-	                                   || ((!finish_close_2).until(enter_2) && finally(enter_2))
-	                                   || ((!finish_close_3).until(enter_3) && finally(enter_3)),
-	                                 actions);
-	// INFO("TA: " << product);
-	// INFO("ATA: " << ata);
-	BENCHMARK("Run the search")
-	{
-		TreeSearch search{
-		  &plant,
-		  &ata,
-		  controller_actions,
-		  environment_actions,
-		  2,
-		  true,
-		  true,
-		  std::make_unique<search::TimeHeuristic<long, std::vector<std::string>, std::string>>()};
-		search.build_tree(true);
 #ifdef HAVE_VISUALIZATION
 		visualization::search_tree_to_graphviz(*search.get_root(), true)
-		  .render_to_file("railroad3.svg");
+		  .render_to_file(fmt::format("railroad{}.svg", num_crossings));
+		visualization::ta_to_graphviz(controller_synthesis::create_controller(search.get_root(), 2),
+		                              false)
+		  .render_to_file(fmt::format("railroad{}_controller.pdf", num_crossings));
 #endif
-		std::size_t size         = 0;
-		std::size_t non_canceled = 0;
-		for (auto it = search::begin(search.get_root()); it != search::end(search.get_root()); it++) {
-			size++;
-			if (it->label != search::NodeLabel::CANCELED) {
-				non_canceled++;
-			}
-		}
-		INFO("Tree size: " << size);
-		INFO("Non-canceled: " << non_canceled);
-		CHECK(search.get_root()->label == NodeLabel::TOP);
 	};
-	// INFO("Tree:\n" << search::node_to_string(*search.get_root(), true));
 }
 
 } // namespace


### PR DESCRIPTION
Generate the spec in the problem generator and run a set of benchmarks on the railroad problem.

Also fix the spec by properly using dual untils. This should actually accomplish the desired behavior (the previous spec did not).