### PR TITLE
controller: skip further nodes if we have found a good controller action

### DIFF
--- a/src/app/app.cpp
+++ b/src/app/app.cpp
@@ -193,7 +193,10 @@ Launcher::run()
 		visualization::search_tree_to_graphviz(*search.get_root(), true).render_to_file(tree_dot_graph);
 	}
 	SPDLOG_INFO("Creating controller");
-	auto controller = controller_synthesis::create_controller(search.get_root(), K);
+	auto controller = controller_synthesis::create_controller(search.get_root(),
+	                                                          controller_actions,
+	                                                          environment_actions,
+	                                                          K);
 	if (!controller_dot_path.empty()) {
 		SPDLOG_INFO("Writing controller to '{}'", controller_dot_path.c_str());
 		visualization::ta_to_graphviz(controller, !hide_controller_labels)

--- a/test/test_create_controller.cpp
+++ b/test/test_create_controller.cpp
@@ -82,7 +82,8 @@ TEST_CASE("Create a simple controller", "[.][controller]")
 	visualization::search_tree_to_graphviz(*search.get_root()).render_to_file("simple_tree.svg");
 	visualization::ta_to_graphviz(ta).render_to_file("simple_plant.svg");
 #endif
-	const auto controller = controller_synthesis::create_controller(search.get_root(), 2);
+	const auto controller =
+	  controller_synthesis::create_controller(search.get_root(), {"c"}, {"e"}, 2);
 	CAPTURE(controller);
 	visualization::ta_to_graphviz(controller, false).render_to_file("simple_controller.svg");
 	CHECK(search.get_root()->label == search::NodeLabel::TOP);
@@ -125,7 +126,10 @@ TEST_CASE("Controller time bounds", "[.railroad][controller]")
 
 	search.build_tree();
 	CHECK(search.get_root()->label == NodeLabel::TOP);
-	auto controller = create_controller(search.get_root(), 4);
+	auto controller = create_controller(search.get_root(),
+	                                    {"start_open", "start_close"},
+	                                    {"finish_open", "finish_close"},
+	                                    4);
 
 #ifdef HAVE_VISUALIZATION
 	visualization::ta_to_graphviz(controller).render_to_file("railroad_bounds_controller.svg");
@@ -156,7 +160,7 @@ TEST_CASE("Controller can decide to do nothing", "[controller]")
 	search.build_tree(false);
 	INFO("Tree:\n" << search::node_to_string(*search.get_root(), true));
 	CHECK(search.get_root()->label == NodeLabel::TOP);
-	auto controller = create_controller(search.get_root(), 1);
+	auto controller = create_controller(search.get_root(), {"c"}, {"e"}, 1);
 	CAPTURE(controller);
 	CHECK(controller.get_transitions().empty());
 }

--- a/test/test_fischer.cpp
+++ b/test/test_fischer.cpp
@@ -86,7 +86,8 @@ TEST_CASE("Two processes", "[.large][fisher]")
 #ifdef HAVE_VISUALIZATION
 	visualization::search_tree_to_graphviz(*search.get_root(), true).render_to_file("fischer2.svg");
 	visualization::ta_to_graphviz(product).render_to_file("fischer2_ta.svg");
-	visualization::ta_to_graphviz(controller_synthesis::create_controller(search.get_root(), K))
+	visualization::ta_to_graphviz(controller_synthesis::create_controller(
+	                                search.get_root(), controller_actions, environment_actions, K))
 	  .render_to_file("fischer2_controller.svg");
 #endif
 	CHECK(search.get_root()->label == NodeLabel::TOP);

--- a/test/test_railroad.cpp
+++ b/test/test_railroad.cpp
@@ -104,7 +104,8 @@ TEST_CASE("Railroad", "[railroad]")
 #ifdef HAVE_VISUALIZATION
 	visualization::search_tree_to_graphviz(*search.get_root(), true)
 	  .render_to_file(fmt::format("railroad{}.svg", num_crossings));
-	visualization::ta_to_graphviz(controller_synthesis::create_controller(search.get_root(), 2),
+	visualization::ta_to_graphviz(controller_synthesis::create_controller(
+	                                search.get_root(), controller_actions, environment_actions, 2),
 	                              false)
 	  .render_to_file(fmt::format("railroad{}_controller.pdf", num_crossings));
 #endif
@@ -162,7 +163,8 @@ TEST_CASE("Railroad crossing benchmark", "[.benchmark][railroad]")
 #ifdef HAVE_VISUALIZATION
 		visualization::search_tree_to_graphviz(*search.get_root(), true)
 		  .render_to_file(fmt::format("railroad{}.svg", num_crossings));
-		visualization::ta_to_graphviz(controller_synthesis::create_controller(search.get_root(), 2),
+		visualization::ta_to_graphviz(controller_synthesis::create_controller(
+		                                search.get_root(), controller_actions, environment_actions, 2),
 		                              false)
 		  .render_to_file(fmt::format("railroad{}_controller.pdf", num_crossings));
 #endif


### PR DESCRIPTION
When creating the controller, we can safely skip all further successors
once we have found a controller action. This is because at that point,
the controller can always follow a good path, independent of the other
sub-trees.

This keeps the resulting controller much smaller, although it now
contains less options.