### PR TITLE
Fix time heuristic

### DIFF
--- a/src/search/include/search/heuristics.h
+++ b/src/search/include/search/heuristics.h
@@ -105,36 +105,14 @@ class TimeHeuristic : public Heuristic<ValueT, LocationT, ActionT>
 {
 public:
 	/** @brief Compute the cost of the given node.
-	 * The cost will strictly monotonically increase for each node, thereby emulating breadth-first
-	 * search.
+	 * The cost is the the minimal number of region increments it takes to reach the node.
 	 * @param node The node to compute the cost for
 	 * @return The cost of the node
 	 */
 	ValueT
 	compute_cost(SearchTreeNode<LocationT, ActionT> *node) override
 	{
-		if (node->parents.empty()) {
-			return 0;
-		}
-		ValueT cost = std::numeric_limits<ValueT>::max();
-		for (const auto &parent : node->parents) {
-			if (parent == node) {
-				// Self-loop, this cannot possibly be the shortest path.
-				continue;
-			}
-			// TODO fix cost computation for parent
-			// ValueT parent_cost = compute_cost(parent);
-			ValueT parent_cost = 0;
-			ValueT node_cost   = std::numeric_limits<ValueT>::max();
-			for (const auto &[action, child] : parent->get_children()) {
-				if (child.get() == node) {
-					node_cost = std::min(node_cost, static_cast<ValueT>(action.first));
-				}
-			}
-			cost = std::min(cost, parent_cost + node_cost);
-		}
-		assert(cost >= 0);
-		return cost;
+		return node->min_total_region_increments;
 	}
 };
 

--- a/src/search/include/search/search.h
+++ b/src/search/include/search/search.h
@@ -385,16 +385,17 @@ private:
 		// the same reg_a class.
 		{
 			std::lock_guard lock{nodes_mutex_};
-			std::for_each(std::begin(child_classes), std::end(child_classes), [&](auto &&map_entry) {
-				auto [child_it, is_new] =
-				  nodes_.insert({map_entry.second, std::make_shared<Node>(map_entry.second)});
-				for (const auto &action : outgoing_actions[map_entry.first]) {
-					node->add_child(action, child_it->second);
+			std::for_each(std::begin(child_classes), std::end(child_classes), [&](const auto &map_entry) {
+				const auto &[reg_a, words] = map_entry;
+				auto [child_it, is_new]    = nodes_.insert({words, std::make_shared<Node>(words)});
+				const std::shared_ptr<Node> &child_ptr = child_it->second;
+				for (const auto &action : outgoing_actions[reg_a]) {
+					node->add_child(action, child_ptr);
 					if (is_new) {
-						SPDLOG_TRACE("New child: {}", map_entry.second);
-						new_children.insert(child_it->second.get());
+						SPDLOG_TRACE("New child: {}", words);
+						new_children.insert(child_ptr.get());
 					} else {
-						existing_children.insert(child_it->second.get());
+						existing_children.insert(child_ptr.get());
 					}
 				}
 			});

--- a/src/search/include/search/search.h
+++ b/src/search/include/search/search.h
@@ -114,6 +114,7 @@ public:
 		  std::all_of(environment_actions_.begin(), environment_actions_.end(), [this](const auto &a) {
 			  return controller_actions_.find(a) == controller_actions_.end();
 		  }));
+		tree_root_->min_total_region_increments = 0;
 		add_node_to_queue(tree_root_.get());
 	}
 

--- a/src/search/include/search/search_tree.h
+++ b/src/search/include/search/search_tree.h
@@ -268,6 +268,8 @@ public:
 			throw std::invalid_argument(
 			  "Cannot add child node, node already has child with the same action");
 		}
+		node->min_total_region_increments =
+		  std::min(node->min_total_region_increments, min_total_region_increments + action.first);
 		node->parents.insert(this);
 	}
 
@@ -286,6 +288,8 @@ public:
 	std::atomic_bool is_expanding{false};
 	/** A more detailed description for the node that explains the current label. */
 	LabelReason label_reason = LabelReason::UNKNOWN;
+	/** The current regionalized minimal total time to reach this node */
+	RegionIndex min_total_region_increments = std::numeric_limits<RegionIndex>::max();
 
 private:
 	/** A list of the children of the node, which are reachable by a single transition */

--- a/test/test_heuristics.cpp
+++ b/test/test_heuristics.cpp
@@ -61,7 +61,8 @@ TEST_CASE("Test time heuristic", "[search][heuristics]")
 
 	const auto dummy_words =
 	  std::set<CanonicalABWord>{CanonicalABWord({{TARegionState{Location{"l0"}, "x", 0}}})};
-	auto root = std::make_shared<Node>(std::set<CanonicalABWord>{});
+	auto root                         = std::make_shared<Node>(std::set<CanonicalABWord>{});
+	root->min_total_region_increments = 0;
 	CHECK(h.compute_cost(root.get()) == 0);
 	auto c1 = std::make_shared<Node>(dummy_words);
 	root->add_child({1, "a1"}, c1);
@@ -70,15 +71,14 @@ TEST_CASE("Test time heuristic", "[search][heuristics]")
 	root->add_child({3, "a1"}, c2);
 	root->add_child({4, "b"}, c2);
 	CHECK(h.compute_cost(c2.get()) == 3);
-	// TODO fix heuristic
-	// auto cc1 = std::make_shared<Node>(dummy_words);
-	// c1->add_child({2, "a"}, cc1);
-	// c1->add_child({4, "a"}, cc1);
-	// CHECK(h.compute_cost(cc1.get()) == 3);
-	// auto cc2 = std::make_shared<Node>(dummy_words);
-	// c2->add_child({2, "a"}, cc2);
-	// c2->add_child({4, "a"}, cc2);
-	// CHECK(h.compute_cost(cc2.get()) == 5);
+	auto cc1 = std::make_shared<Node>(dummy_words);
+	c1->add_child({2, "a"}, cc1);
+	c1->add_child({4, "a"}, cc1);
+	CHECK(h.compute_cost(cc1.get()) == 3);
+	auto cc2 = std::make_shared<Node>(dummy_words);
+	c2->add_child({2, "a"}, cc2);
+	c2->add_child({4, "a"}, cc2);
+	CHECK(h.compute_cost(cc2.get()) == 5);
 }
 
 TEST_CASE("Test PreferEnvironmentActionHeuristic", "[search][heuristics]")
@@ -127,7 +127,8 @@ TEST_CASE("Test NumCanonicalWordsHeuristic", "[search][heuristics]")
 
 TEST_CASE("Test CompositeHeuristic", "[search][heuristics]")
 {
-	auto       root = std::make_shared<Node>(std::set<CanonicalABWord>{});
+	auto root                         = std::make_shared<Node>(std::set<CanonicalABWord>{});
+	root->min_total_region_increments = 0;
 	const auto dummy_words =
 	  std::set<CanonicalABWord>{CanonicalABWord({{TARegionState{Location{"l0"}, "x", 0}}})};
 	auto n1 = std::make_shared<Node>(dummy_words);

--- a/test/test_search.cpp
+++ b/test/test_search.cpp
@@ -155,12 +155,15 @@ TEST_CASE("Search in an ABConfiguration tree", "[search]")
 		        CanonicalABWord({{TARegionState{Location{"l0"}, "x", 0}}, {ATARegionState{spec, 3}}}),
 		        CanonicalABWord({{TARegionState{Location{"l0"}, "x", 0}, ATARegionState{spec, 4}}}),
 		        CanonicalABWord({{TARegionState{Location{"l0"}, "x", 0}}, {ATARegionState{spec, 5}}})});
+		CHECK(children.at({3, "a"})->min_total_region_increments == 3);
 		CHECK(children.at({0, "b"})->words
 		      == std::set{
 		        CanonicalABWord({{TARegionState{Location{"l1"}, "x", 0}, ATARegionState{spec, 0}}})});
+		CHECK(children.at({0, "b"})->min_total_region_increments == 0);
 		CHECK(children.at({1, "b"})->words
 		      == std::set{
 		        CanonicalABWord({{TARegionState{Location{"l1"}, "x", 1}, ATARegionState{spec, 1}}})});
+		CHECK(children.at({1, "b"})->min_total_region_increments == 1);
 	}
 
 	SECTION("The next steps compute the right children")
@@ -196,15 +199,21 @@ TEST_CASE("Search in an ABConfiguration tree", "[search]")
 			CHECK(children.at({3, "a"})->words
 			      == std::set{CanonicalABWord(
 			        {{TARegionState{Location{"l0"}, "x", 0}}, {ATARegionState{spec, 5}}})});
+			CHECK(children.at({3, "a"})->min_total_region_increments == 6);
 			// They point to the same node.
 			CHECK(children.at({3, "a"}) == children.at({4, "a"}));
 			CHECK(children.at({3, "a"}) == children.at({5, "a"}));
+			CHECK(children.at({4, "a"})->min_total_region_increments == 6);
+			CHECK(children.at({5, "a"})->min_total_region_increments == 6);
+
 			CHECK(children.at({0, "b"})->words
 			      == std::set{CanonicalABWord({{TARegionState{Location{"l1"}, "x", 0}}}),
 			                  CanonicalABWord({{TARegionState{Location{"l1"}, "x", 0},
 			                                    ATARegionState{logic::MTLFormula{AP{"sink"}}, 0}}})});
+			CHECK(children.at({0, "b"})->min_total_region_increments == 3);
 			CHECK(children.at({1, "b"})->words
 			      == std::set{CanonicalABWord({{TARegionState{Location{"l1"}, "x", 1}}})});
+			CHECK(children.at({1, "b"})->min_total_region_increments == 4);
 		}
 
 		// Process second child of the root.


### PR DESCRIPTION
With the switch to search graphs (#97), the time heuristic was no longer working, as we could not easily traverse a path to the root.

Instead of traversing the path for every node, store the minimal number of region increments that it takes to reach a node when adding the node to the graph. This can then be directly used as value for the heuristic.