### PR TITLE
Fix MTL formula comparison of conjunctions with different number of sub-formulas

### DIFF
--- a/src/mtl/include/mtl/MTLFormula.hpp
+++ b/src/mtl/include/mtl/MTLFormula.hpp
@@ -243,10 +243,6 @@ MTLFormula<APType>::operator<(const MTLFormula &rhs) const
 		return this->get_atomicProposition() < rhs.get_atomicProposition();
 	}
 
-	// compare subformulas
-	// Note: since the operators are the same, the size of operands needs to be the same
-	assert(this->get_operands().size() == rhs.get_operands().size());
-
 	// Compare intervals before operands.
 	if (operator_ == LOP::LUNTIL || operator_ == LOP::LDUNTIL) {
 		if (duration_ < rhs.duration_) {

--- a/test/test_mtlFormula.cpp
+++ b/test/test_mtlFormula.cpp
@@ -6,8 +6,6 @@
  *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
 
-
-
 #include "mtl/MTLFormula.h"
 #include "utilities/Interval.h"
 #include "utilities/types.h"
@@ -312,6 +310,25 @@ TEST_CASE("Get maximal region index of an MTL formula", "[libmtl]")
 	CHECK(globally(a, TimeInterval{11, BoundType::STRICT, 10, BoundType::STRICT})
 	        .get_maximal_region_index()
 	      == 23);
+}
+
+TEST_CASE("Compare MTL formulas", "[libmtl]")
+{
+	using MTLFormula = logic::MTLFormula<std::string>;
+	using AP         = logic::AtomicProposition<std::string>;
+	using logic::TimeInterval;
+	using utilities::arithmetic::BoundType;
+	const auto a = MTLFormula{AP{"a"}};
+	const auto b = MTLFormula{AP{"b"}};
+	const auto c = MTLFormula{AP{"c"}};
+	CHECK(a != b);
+	CHECK((a && b) != (a && b && c));
+	CHECK((a && b) != (a || b));
+	CHECK((a && b) != a.until(b));
+	CHECK(a.until(b) != a.dual_until(b));
+	CHECK(a.until(b, TimeInterval{0, 1}) != a.until(b));
+	CHECK(a.until(b, TimeInterval{0, 1})
+	      != a.until(b, TimeInterval{0, BoundType::STRICT, 1, BoundType::WEAK}));
 }
 
 } // namespace

--- a/test/test_mtlFormula.cpp
+++ b/test/test_mtlFormula.cpp
@@ -329,6 +329,7 @@ TEST_CASE("Compare MTL formulas", "[libmtl]")
 	CHECK(a.until(b, TimeInterval{0, 1}) != a.until(b));
 	CHECK(a.until(b, TimeInterval{0, 1})
 	      != a.until(b, TimeInterval{0, BoundType::STRICT, 1, BoundType::WEAK}));
+	CHECK(MTLFormula::create_conjunction({a, b}) != MTLFormula::create_conjunction({a, b, c}));
 }
 
 } // namespace


### PR DESCRIPTION
Do not enforce same-sized operands when comparing MTL formulas.

The assumption that both operands must have the same size if they are of the same type is wrong because one sub-formula may be a conjunction with two operands, while the other sub-formula is a conjunction with three operands. As we compare the sub-formulas with a lexicographical comparison, the assumption is also unnecessary.

Fixes #188.